### PR TITLE
feat: relay listen/sign loop over NIP-46

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ It keeps your `nsec` on a machine you control and signs on behalf of web and
 native clients over a relay — the secret key never reaches the client.
 
 > **Status: early / work in progress.** This is Showcase 1 of the zig-nostr
-> roadmap. The current build derives your key and prints a `bunker://`
-> connection token; the relay listen/sign loop, encrypted key storage
-> (NIP-49), and the approval UX are landing next.
+> roadmap. The current build connects to your relays and answers NIP-46
+> requests — `get_public_key`, `sign_event`, `ping`, and NIP-44
+> encrypt/decrypt — auto-approving each one behind the connection secret.
+> Encrypted key storage (NIP-49) and a real approval UX are landing next.
 
 ## Build
 
@@ -22,18 +23,24 @@ zig build
 
 ## Usage
 
+Configure the signer with environment variables, then run it:
+
 ```sh
 SIGNER_SECRET_KEY=<64-char hex secret key> \
-  zig build run -- --relay wss://relay.example.com [--relay wss://...] [--secret <connection-secret>]
+SIGNER_RELAYS="wss://relay.example.com,wss://relay.two" \
+SIGNER_CONNECT_SECRET=<optional connection secret> \
+  zig build run
 ```
 
 It prints the signer's public key and the `bunker://` token a client uses to
-connect.
+connect, then dials each relay and serves NIP-46 requests until stopped
+(reconnecting automatically if a relay drops). Paste the token into a
+NIP-46-capable client to sign with a key that never leaves this process.
 
 ## Roadmap
 
 - [x] `bunker://` connection token from a key + relays
-- [ ] Relay listen/sign loop (answer NIP-46 requests over a relay)
+- [x] Relay listen/sign loop (answer NIP-46 requests over a relay)
 - [ ] Encrypted key storage at rest (NIP-49 `ncryptsec`)
 - [ ] Per-request approval policy
 - [ ] Native macOS app + downloadable build

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "git+https://github.com/zig-nostr/nostr#b6f25744e47ed8d8b3e03256acb77eb01c0a54c2",
-            .hash = "nostr-0.2.1-CMyPzdK7BQD7xA9czN1OuADxSY5k6cKnR9n5fZ9LAMM2",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.3.0.tar.gz",
+            .hash = "nostr-0.3.0-CMyPzZ69BQCEFcseEAnzNcjx87ql2zLrG_KGGzIj5juN",
         },
     },
     .paths = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,12 +1,15 @@
 //! zig-nostr signer — a headless NIP-46 remote signer ("bunker").
 //!
 //! Keeps the user's secret key on a machine they control and signs for remote
-//! clients over a relay. This early build derives the key and prints the
-//! `bunker://` connection token; the relay listen/sign loop, encrypted key
-//! storage (NIP-49), and the approval UX are the next slices — see README.
+//! clients over a relay. On startup it derives the keypair, prints the
+//! `bunker://` connection token, then connects to each configured relay and
+//! serves NIP-46 requests (see `serve.zig`) until stopped. Encrypted key
+//! storage (NIP-49) and a per-request approval UX are the next slices; this
+//! build auto-approves every request behind the connection secret.
 
 const std = @import("std");
 const nostr = @import("nostr");
+const serve = @import("serve.zig");
 
 const keys = nostr.keys;
 const nip46 = nostr.nip46;
@@ -18,9 +21,10 @@ const usage =
     \\Configure via environment variables:
     \\  SIGNER_SECRET_KEY      64-char hex secret key (required)
     \\  SIGNER_RELAYS          comma-separated wss:// relay URLs (required)
-    \\  SIGNER_CONNECT_SECRET  optional connection secret
+    \\  SIGNER_CONNECT_SECRET  optional connection secret clients must echo
     \\
-    \\Prints the signer's public key and the bunker:// token clients connect with.
+    \\Prints the signer's public key and the bunker:// token clients connect
+    \\with, then serves NIP-46 requests over the relays until stopped.
     \\
 ;
 
@@ -58,14 +62,75 @@ pub fn main() !void {
     defer gpa.free(pk_hex);
 
     std.debug.print(
-        \\zig-nostr signer (headless, work in progress)
+        \\zig-nostr signer (headless)
         \\  pubkey : {s}
         \\  bunker : {s}
         \\
-        \\The relay listen/sign loop is not wired up yet — this prints the
-        \\connection token so clients can be wired while it lands.
+        \\Share the bunker:// token with a client to connect. Requests are
+        \\auto-approved{s}. Press Ctrl-C to stop.
         \\
-    , .{ pk_hex, token });
+    , .{ pk_hex, token, if (conn_secret == null) " (no connection secret set)" else "" });
+
+    // Serve each relay on its own thread. Each thread owns its secp256k1
+    // context and bunker, so nothing mutable is shared between them; the only
+    // shared state is the read-only key material and the allocator.
+    var threads: std.ArrayList(std.Thread) = .empty;
+    defer threads.deinit(gpa);
+    for (relays.items) |url| {
+        const t = std.Thread.spawn(.{}, serveRelayForever, .{ gpa, url, secret_key, conn_secret }) catch |err| {
+            std.debug.print("signer: [{s}] could not start: {s}\n", .{ url, @errorName(err) });
+            continue;
+        };
+        try threads.append(gpa, t);
+    }
+    if (threads.items.len == 0) fail("could not start any relay connections");
+    for (threads.items) |t| t.join();
+}
+
+/// Connects to `url` and serves requests forever, reconnecting after a short
+/// delay whenever the connection drops. Runs on its own thread with its own
+/// signing context, derived from the shared read-only `secret_key`.
+fn serveRelayForever(
+    gpa: std.mem.Allocator,
+    url: []const u8,
+    secret_key: [32]u8,
+    conn_secret: ?[]const u8,
+) void {
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var signer = keys.Signer.init();
+    defer signer.deinit();
+    const kp = signer.keyPairFromSecretKey(secret_key) catch {
+        std.debug.print("signer: [{s}] invalid secret key\n", .{url});
+        return;
+    };
+
+    var bunker = nip46.Bunker.initSingleKey(signer, kp, nip46.approveAll());
+    bunker.secret = conn_secret;
+
+    while (true) {
+        serveOnce(gpa, io, url, bunker, kp) catch |err| {
+            std.debug.print("signer: [{s}] {s}\n", .{ url, @errorName(err) });
+        };
+        std.debug.print("signer: [{s}] disconnected; reconnecting in 3s\n", .{url});
+        io.sleep(std.Io.Duration.fromSeconds(3), .awake) catch {};
+    }
+}
+
+/// Dials `url`, then serves requests until the connection closes.
+fn serveOnce(
+    gpa: std.mem.Allocator,
+    io: std.Io,
+    url: []const u8,
+    bunker: nip46.Bunker,
+    remote: keys.KeyPair,
+) !void {
+    var relay = try nostr.relay.dial(gpa, io, url);
+    defer relay.deinit();
+    std.debug.print("signer: [{s}] connected; listening for NIP-46 requests\n", .{url});
+    try serve.serve(gpa, io, relay, bunker, remote);
 }
 
 fn getEnv(name: [*:0]const u8) ?[]const u8 {
@@ -76,6 +141,11 @@ fn getEnv(name: [*:0]const u8) ?[]const u8 {
 fn fail(message: []const u8) noreturn {
     std.debug.print("error: {s}\n\n{s}", .{ message, usage });
     std.process.exit(1);
+}
+
+test {
+    // Ensure the serve loop's hermetic tests run under `zig build test`.
+    _ = @import("serve.zig");
 }
 
 test "derives the pubkey and builds a bunker token" {

--- a/src/serve.zig
+++ b/src/serve.zig
@@ -1,0 +1,346 @@
+//! The signer's request-serving loop.
+//!
+//! Given an established relay connection and a NIP-46 `Bunker`, `serve`
+//! subscribes for the kind:24133 requests addressed to the signer, decrypts and
+//! dispatches each one through the bunker, and publishes the sealed reply back
+//! to the requesting client — the user's key never leaves this process.
+//!
+//! `serve` is generic over the connection type. In production it drives a live
+//! `nostr.relay.Relay`; in tests it drives an in-memory `nostr.relay.Connection`
+//! over a scripted fake stream, so the whole request→response cycle is proven
+//! hermetically in CI, exactly as the nostr library proves its relay transport.
+//! Relay dialing, fan-out across relays, and reconnection live in `main.zig`;
+//! this module is the pure protocol loop over one connection.
+
+const std = @import("std");
+const nostr = @import("nostr");
+
+const keys = nostr.keys;
+const nip46 = nostr.nip46;
+const hex = nostr.hex;
+const Event = nostr.event.Event;
+const Filter = nostr.filter.Filter;
+const TagFilter = nostr.filter.TagFilter;
+
+/// The subscription id the signer opens on each relay.
+pub const subscription_id = "nostr-signer";
+
+/// Serves NIP-46 requests over `conn` until the connection closes (a clean
+/// relay close or EOF), then returns. `conn` is any established connection
+/// exposing `subscribe`, `receive`, and `publish` — the live `nostr.relay.Relay`
+/// in production, an in-memory `Connection` in tests. `bunker` answers the
+/// decrypted requests; `remote` is the signer's communication keypair (the
+/// pubkey clients address, and the sender of every reply).
+///
+/// I/O errors from the relay propagate to the caller (which reconnects);
+/// per-request failures (an undecryptable event, a malformed request) are
+/// logged and skipped so one bad event can't take the signer down.
+pub fn serve(
+    gpa: std.mem.Allocator,
+    io: std.Io,
+    conn: anytype,
+    bunker: nip46.Bunker,
+    remote: keys.KeyPair,
+) !void {
+    const my_pubkey_hex = try hex.encode(gpa, &remote.public_key);
+    defer gpa.free(my_pubkey_hex);
+
+    // Only requests from now on: ignore any matching history the relay replays
+    // before EOSE, so a restart doesn't re-answer stale requests.
+    const since = std.Io.Timestamp.now(io, .real).toSeconds();
+    const kinds = [_]u16{nip46.kind};
+    const p_values = [_][]const u8{my_pubkey_hex};
+    const tag_filters = [_]TagFilter{.{ .letter = 'p', .values = &p_values }};
+    const filters = [_]Filter{.{ .kinds = &kinds, .tags = &tag_filters, .since = since }};
+    try conn.subscribe(subscription_id, &filters);
+
+    while (true) {
+        var msg = (try conn.receive()) orelse break;
+        defer msg.deinit();
+        switch (msg.value) {
+            .event => |e| handleRequest(gpa, io, conn, bunker, remote, e.event) catch |err| {
+                std.debug.print("signer: dropped a request: {s}\n", .{@errorName(err)});
+            },
+            .eose => {},
+            .closed => |c| {
+                std.debug.print("signer: relay closed the subscription: {s}\n", .{c.message});
+                return;
+            },
+            .notice => |n| std.debug.print("signer: relay notice: {s}\n", .{n.message}),
+            // OK acks our own reply publications; nothing to do.
+            .ok => {},
+        }
+    }
+}
+
+/// Decrypts one kind:24133 request event addressed to us, runs it through the
+/// bunker, and publishes the sealed reply back to the event's author.
+fn handleRequest(
+    gpa: std.mem.Allocator,
+    io: std.Io,
+    conn: anytype,
+    bunker: nip46.Bunker,
+    remote: keys.KeyPair,
+    request_event: Event,
+) !void {
+    // The client is the event's author; decrypt with our communication key.
+    const plaintext = try nip46.open(gpa, bunker.signer, remote.secret_key, request_event);
+    defer gpa.free(plaintext);
+
+    var parsed = try nip46.parseRequest(gpa, plaintext);
+    defer parsed.deinit();
+
+    const client_hex = try hex.encode(gpa, &request_event.pubkey);
+    defer gpa.free(client_hex);
+    std.debug.print("signer: '{s}' from {s}…\n", .{ parsed.value.method, client_hex[0..16] });
+
+    var response = try bunker.handle(gpa, io, parsed.value);
+    defer response.deinit();
+
+    const response_json = try response.value.toJson(gpa);
+    defer gpa.free(response_json);
+
+    const created_at = std.Io.Timestamp.now(io, .real).toSeconds();
+    var sealed = try nip46.seal(gpa, io, bunker.signer, remote, request_event.pubkey, response_json, created_at);
+    defer sealed.deinit();
+
+    try conn.publish(sealed.event);
+}
+
+// ---------------------------------------------------------------------------
+// Tests — an in-memory fake stream drives a real nostr Connection end to end:
+// a client seals a request, the serve loop answers it, and we decrypt the
+// published reply and assert on it. No socket, no relay.
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+/// A byte stream that hands the serve loop one scripted server frame (then EOF)
+/// and captures everything the loop writes back.
+const FakeStream = struct {
+    to_read: []const u8,
+    read_pos: usize = 0,
+    written: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+
+    // `pub` because the nostr package's generic `Connection` calls these
+    // across the module boundary.
+    pub fn read(self: *FakeStream, buffer: []u8) error{}!usize {
+        const remaining = self.to_read[self.read_pos..];
+        const n = @min(buffer.len, remaining.len);
+        @memcpy(buffer[0..n], remaining[0..n]);
+        self.read_pos += n;
+        return n;
+    }
+
+    pub fn writeAll(self: *FakeStream, bytes: []const u8) !void {
+        try self.written.appendSlice(self.allocator, bytes);
+    }
+};
+
+/// Appends an unmasked server text frame (as a relay would send), for any length.
+fn appendServerText(list: *std.ArrayList(u8), allocator: std.mem.Allocator, text: []const u8) !void {
+    try list.append(allocator, 0x81); // FIN + text
+    if (text.len <= 125) {
+        try list.append(allocator, @intCast(text.len));
+    } else if (text.len <= 0xffff) {
+        try list.append(allocator, 126);
+        var ext: [2]u8 = undefined;
+        std.mem.writeInt(u16, &ext, @intCast(text.len), .big);
+        try list.appendSlice(allocator, &ext);
+    } else {
+        try list.append(allocator, 127);
+        var ext: [8]u8 = undefined;
+        std.mem.writeInt(u64, &ext, text.len, .big);
+        try list.appendSlice(allocator, &ext);
+    }
+    try list.appendSlice(allocator, text);
+}
+
+/// Wraps a NIP-46 request as a relay EVENT frame from `client` to `signer`,
+/// runs the serve loop against it, and returns the decrypted reply the loop
+/// published. Everything is arena-free; the caller owns `.deinit`.
+const Harness = struct {
+    signer_ctx: keys.Signer,
+    signer_kp: keys.KeyPair,
+    client_ctx: keys.Signer,
+    client_kp: keys.KeyPair,
+
+    fn init() !Harness {
+        const signer_ctx = keys.Signer.init();
+        const client_ctx = keys.Signer.init();
+        // BIP-340 test-vector secret (known-good) for the signer; a small
+        // in-range scalar for the client. Both derive valid x-only pubkeys.
+        const signer_sec = try hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+        var client_sec = [_]u8{0} ** 32;
+        client_sec[31] = 3;
+        return .{
+            .signer_ctx = signer_ctx,
+            .signer_kp = try signer_ctx.keyPairFromSecretKey(signer_sec),
+            .client_ctx = client_ctx,
+            .client_kp = try client_ctx.keyPairFromSecretKey(client_sec),
+        };
+    }
+
+    fn deinit(self: *Harness) void {
+        self.signer_ctx.deinit();
+        self.client_ctx.deinit();
+    }
+
+    /// Runs `serve` against a single sealed `request` and returns the reply
+    /// plaintext JSON the signer published (decrypted with the client key).
+    fn roundTrip(self: *Harness, gpa: std.mem.Allocator, io: std.Io, request: nip46.Request) ![]u8 {
+        // Client seals the request to the signer's pubkey.
+        const req_json = try request.toJson(gpa);
+        defer gpa.free(req_json);
+        var sealed_req = try nip46.seal(gpa, io, self.client_ctx, self.client_kp, self.signer_kp.public_key, req_json, 1_700_000_000);
+        defer sealed_req.deinit();
+        const req_event_json = try nostr.event.toJson(gpa, sealed_req.event);
+        defer gpa.free(req_event_json);
+
+        // Frame it as the relay message the subscription would deliver.
+        const relay_msg = try std.fmt.allocPrint(gpa, "[\"EVENT\",\"{s}\",{s}]", .{ subscription_id, req_event_json });
+        defer gpa.free(relay_msg);
+        var script: std.ArrayList(u8) = .empty;
+        defer script.deinit(gpa);
+        try appendServerText(&script, gpa, relay_msg);
+
+        var written: std.ArrayList(u8) = .empty;
+        defer written.deinit(gpa);
+        var stream = FakeStream{ .to_read = script.items, .written = &written, .allocator = gpa };
+        var conn = nostr.relay.Connection(*FakeStream).init(gpa, io, &stream);
+        defer conn.deinit();
+
+        const bunker = nip46.Bunker.initSingleKey(self.signer_ctx, self.signer_kp, nip46.approveAll());
+        try serve(gpa, io, &conn, bunker, self.signer_kp);
+
+        // The loop wrote a REQ then an EVENT; find the published EVENT frame and
+        // decrypt its content with the client key.
+        const reply_event_json = try findPublishedEvent(gpa, written.items);
+        defer gpa.free(reply_event_json);
+        var reply_event = try nostr.event.fromJson(gpa, reply_event_json);
+        defer reply_event.deinit();
+        return nip46.open(gpa, self.client_ctx, self.client_kp.secret_key, reply_event.value);
+    }
+};
+
+/// Scans captured client frames for the `["EVENT",<event>]` publish and returns
+/// the inner event JSON object. `written` is mutated in place (frame unmasking).
+fn findPublishedEvent(gpa: std.mem.Allocator, written: []u8) ![]u8 {
+    var offset: usize = 0;
+    while (try nostr.websocket.decodeFrame(written[offset..])) |frame| {
+        offset += frame.frame_len;
+        const prefix = "[\"EVENT\",";
+        if (std.mem.startsWith(u8, frame.payload, prefix)) {
+            const inner = frame.payload[prefix.len .. frame.payload.len - 1];
+            return gpa.dupe(u8, inner);
+        }
+    }
+    return error.NoPublishedEvent;
+}
+
+test "serve answers get_public_key over the relay round-trip" {
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var h = try Harness.init();
+    defer h.deinit();
+
+    const reply = try h.roundTrip(gpa, io, .{ .id = "req-1", .method = "get_public_key", .params = &.{} });
+    defer gpa.free(reply);
+
+    var parsed = try nip46.parseResponse(gpa, reply);
+    defer parsed.deinit();
+
+    try testing.expectEqualStrings("req-1", parsed.value.id);
+    try testing.expectEqualStrings("", parsed.value.err);
+    const expected_pubkey = try hex.encode(gpa, &h.signer_kp.public_key);
+    defer gpa.free(expected_pubkey);
+    try testing.expectEqualStrings(expected_pubkey, parsed.value.result);
+}
+
+test "serve signs an event and the signature verifies" {
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var h = try Harness.init();
+    defer h.deinit();
+
+    const template = "{\"kind\":1,\"content\":\"gm from a remote signer\",\"tags\":[],\"created_at\":1700000000}";
+    const params = [_][]const u8{template};
+    const reply = try h.roundTrip(gpa, io, .{ .id = "sign-1", .method = "sign_event", .params = &params });
+    defer gpa.free(reply);
+
+    var parsed = try nip46.parseResponse(gpa, reply);
+    defer parsed.deinit();
+    try testing.expectEqualStrings("sign-1", parsed.value.id);
+    try testing.expectEqualStrings("", parsed.value.err);
+
+    // The result is the signed event; it must carry the signer's key and a
+    // signature that verifies against its own recomputed id.
+    var signed = try nostr.event.fromJson(gpa, parsed.value.result);
+    defer signed.deinit();
+    try testing.expectEqual(@as(u16, 1), signed.value.kind);
+    try testing.expectEqualStrings("gm from a remote signer", signed.value.content);
+    try testing.expectEqualSlices(u8, &h.signer_kp.public_key, &signed.value.pubkey);
+    try testing.expect(try nostr.event.verify(gpa, h.signer_ctx, signed.value));
+}
+
+test "serve rejects a request when the policy denies it" {
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var h = try Harness.init();
+    defer h.deinit();
+
+    // A bunker that denies everything must still answer — with an error reply.
+    const template = "{\"kind\":1,\"content\":\"nope\",\"tags\":[],\"created_at\":1700000000}";
+    const params = [_][]const u8{template};
+
+    const req_json = try (nip46.Request{ .id = "deny-1", .method = "sign_event", .params = &params }).toJson(gpa);
+    defer gpa.free(req_json);
+    var sealed_req = try nip46.seal(gpa, io, h.client_ctx, h.client_kp, h.signer_kp.public_key, req_json, 1_700_000_000);
+    defer sealed_req.deinit();
+    const req_event_json = try nostr.event.toJson(gpa, sealed_req.event);
+    defer gpa.free(req_event_json);
+    const relay_msg = try std.fmt.allocPrint(gpa, "[\"EVENT\",\"{s}\",{s}]", .{ subscription_id, req_event_json });
+    defer gpa.free(relay_msg);
+    var script: std.ArrayList(u8) = .empty;
+    defer script.deinit(gpa);
+    try appendServerText(&script, gpa, relay_msg);
+
+    var written: std.ArrayList(u8) = .empty;
+    defer written.deinit(gpa);
+    var stream = FakeStream{ .to_read = script.items, .written = &written, .allocator = gpa };
+    var conn = nostr.relay.Connection(*FakeStream).init(gpa, io, &stream);
+    defer conn.deinit();
+
+    const bunker = nip46.Bunker.initSingleKey(h.signer_ctx, h.signer_kp, denyAll());
+    try serve(gpa, io, &conn, bunker, h.signer_kp);
+
+    const reply_event_json = try findPublishedEvent(gpa, written.items);
+    defer gpa.free(reply_event_json);
+    var reply_event = try nostr.event.fromJson(gpa, reply_event_json);
+    defer reply_event.deinit();
+    const reply = try nip46.open(gpa, h.client_ctx, h.client_kp.secret_key, reply_event.value);
+    defer gpa.free(reply);
+
+    var parsed = try nip46.parseResponse(gpa, reply);
+    defer parsed.deinit();
+    try testing.expectEqualStrings("deny-1", parsed.value.id);
+    try testing.expect(parsed.value.err.len > 0);
+}
+
+fn denyAllFn(_: ?*anyopaque, _: *const nip46.Request) nip46.Decision {
+    return .reject;
+}
+
+fn denyAll() nip46.Policy {
+    return .{ .decideFn = &denyAllFn };
+}


### PR DESCRIPTION
Turns the scaffold into a working remote signer: it still prints the `bunker://` token on startup, then connects to each configured relay and answers NIP-46 requests until stopped.

## What's here

- **`serve.zig` — the serving loop.** Subscribes for the `kind:24133` requests addressed to the signer, decrypts and dispatches each through the NIP-46 `Bunker`, and publishes the sealed reply back to the requesting client. It's generic over the connection type, so the whole **seal → decrypt → dispatch → sign → seal → publish → decrypt** cycle runs against an in-memory stream in tests — no socket required, mirroring how the nostr library proves its relay transport hermetically.
- **`main.zig` — the daemon wiring.** Dials each relay on its own thread, each with its own secp256k1 context and bunker (only read-only key material is shared), auto-approving requests behind the optional connection secret and reconnecting after a short delay when a relay drops.
- Depends on the **nostr `v0.3.0`** release tag instead of a pinned commit.

## Tests (hermetic, no network)

- `get_public_key` round-trips and returns the signer's pubkey.
- `sign_event` returns a signed event whose signature **verifies**.
- a policy-denied request comes back as an error reply.

All 5 tests pass; `zig build`, `zig build test`, and `zig fmt --check .` are green locally.

## Not yet

Encrypted key storage (NIP-49 `ncryptsec`) and a real per-request approval UX are the next slices.