### PR TITLE
chore: depend on nostr v0.3.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.3.0.tar.gz",
-            .hash = "nostr-0.3.0-CMyPzZ69BQCEFcseEAnzNcjx87ql2zLrG_KGGzIj5juN",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.3.1.tar.gz",
+            .hash = "nostr-0.3.1-CMyPzZXFBQCiWBC_G1tU1wlaoN_V01USsHLLlmXb2i-5",
         },
     },
     .paths = .{


### PR DESCRIPTION
Bumps the nostr dependency v0.3.0 → **v0.3.1**, picking up the macOS hostname-resolution fix for the live relay dialer ([zig-nostr/nostr#41](https://github.com/zig-nostr/nostr/pull/41)).

Before this, the signer built fine but couldn't actually connect to a relay by hostname on macOS (std's DNS resolver hung). With v0.3.1 the dialer resolves via the system resolver.

Verified live: the signer resolves `relay.damus.io`, completes the TLS + WebSocket handshake, and holds an `ESTABLISHED` connection subscribed for NIP-46 requests. `zig build`, `zig build test`, and `zig fmt --check .` are green.