### PR TITLE
feat: NIP-49 encrypted key storage at rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ It keeps your `nsec` on a machine you control and signs on behalf of web and
 native clients over a relay — the secret key never reaches the client.
 
 > **Status: early / work in progress.** This is Showcase 1 of the zig-nostr
-> roadmap. The current build connects to your relays and answers NIP-46
-> requests — `get_public_key`, `sign_event`, `ping`, and NIP-44
-> encrypt/decrypt — auto-approving each one behind the connection secret.
-> Encrypted key storage (NIP-49) and a real approval UX are landing next.
+> roadmap. The current build loads an encrypted (NIP-49) key from disk, connects
+> to your relays, and answers NIP-46 requests — `get_public_key`, `sign_event`,
+> `ping`, and NIP-44 encrypt/decrypt — auto-approving each one behind the
+> connection secret. A per-request approval UX is landing next.
 
 ## Build
 
@@ -23,19 +23,38 @@ zig build
 
 ## Usage
 
-Configure the signer with environment variables, then run it:
+The signer is configured with environment variables. First create an encrypted
+key file — it is stored `0600` as a NIP-49 `ncryptsec`, so your key is never on
+disk in the clear:
 
 ```sh
-SIGNER_SECRET_KEY=<64-char hex secret key> \
+# Generates a fresh key (or set SIGNER_SECRET_KEY to import an existing hex key),
+# encrypts it, writes the file, and exits.
+SIGNER_INIT=1 \
+SIGNER_KEY_FILE="$HOME/.zig-nostr-signer.ncryptsec" \
+SIGNER_PASSPHRASE="a strong passphrase" \
+  zig build run
+```
+
+Then start serving:
+
+```sh
+SIGNER_KEY_FILE="$HOME/.zig-nostr-signer.ncryptsec" \
+SIGNER_PASSPHRASE="a strong passphrase" \
 SIGNER_RELAYS="wss://relay.example.com,wss://relay.two" \
 SIGNER_CONNECT_SECRET=<optional connection secret> \
   zig build run
 ```
 
-It prints the signer's public key and the `bunker://` token a client uses to
-connect, then dials each relay and serves NIP-46 requests until stopped
-(reconnecting automatically if a relay drops). Paste the token into a
-NIP-46-capable client to sign with a key that never leaves this process.
+It decrypts the key once at startup, prints the signer's public key and the
+`bunker://` token a client uses to connect, then dials each relay and serves
+NIP-46 requests until stopped (reconnecting automatically if a relay drops).
+Paste the token into a NIP-46-capable client to sign with a key that never
+leaves this process.
+
+For quick local testing you can skip the key file and pass an unencrypted key
+directly with `SIGNER_SECRET_KEY=<64-char hex>` — but that keeps the key in your
+environment in the clear, so prefer the encrypted file otherwise.
 
 ## Roadmap
 

--- a/src/keystore.zig
+++ b/src/keystore.zig
@@ -1,0 +1,146 @@
+//! Encrypted key storage at rest (NIP-49 `ncryptsec`).
+//!
+//! The signer never persists the user's secret key in plaintext. This module
+//! wraps `nostr.nip49` to turn a 32-byte secret key into an `ncryptsec1...`
+//! blob (scrypt + XChaCha20-Poly1305) and back, and to read and write that blob
+//! as a `0600` key file.
+//!
+//! Performance note: the scrypt KDF is deliberately expensive — it is the work
+//! factor that guards the key at rest, so it is *not* tuned down for speed. It
+//! runs exactly twice in a key's lifetime: once to encrypt at `init` time, once
+//! to decrypt at startup. It never runs in the request-serving path, which only
+//! ever touches the already-derived 32-byte key.
+
+const std = @import("std");
+const nostr = @import("nostr");
+
+const nip49 = nostr.nip49;
+const Dir = std.Io.Dir;
+
+/// scrypt cost parameter: 2^16 ≈ 100 ms / 64 MiB, the NIP-49 spec's baseline.
+/// Deliberately expensive (it is the at-rest protection) and off the hot path —
+/// paid once per encrypt/decrypt, never per request.
+pub const default_log_n: u6 = 16;
+
+/// An `ncryptsec` is ~162 chars; cap reads well above that (with slack for a
+/// trailing newline) so a wrong path to a large file fails fast instead of
+/// being slurped into memory.
+pub const max_key_file_bytes = 512;
+
+pub const Error = error{
+    /// The key file's contents are not an `ncryptsec1...` token.
+    NotAnNcryptsec,
+    /// The key file already exists; refusing to overwrite it.
+    KeyFileExists,
+    /// The key file is empty (or only whitespace).
+    EmptyKeyFile,
+};
+
+/// Encrypts `secret_key` into a fresh `ncryptsec1...` string at the module's
+/// default scrypt cost. `security` records how the key was handled before
+/// encryption (NIP-49 metadata). Caller owns the returned string.
+pub fn encryptKey(
+    gpa: std.mem.Allocator,
+    io: std.Io,
+    secret_key: [32]u8,
+    passphrase: []const u8,
+    security: nip49.KeySecurity,
+) ![]u8 {
+    return nip49.encrypt(gpa, io, secret_key, passphrase, default_log_n, security);
+}
+
+/// Decrypts an `ncryptsec1...` string back to the raw 32-byte secret key.
+pub fn decryptKey(gpa: std.mem.Allocator, ncryptsec: []const u8, passphrase: []const u8) ![32]u8 {
+    return nip49.decrypt(gpa, ncryptsec, passphrase);
+}
+
+/// Writes `ncryptsec` into `dir` at `path` as a new `0600` file, refusing to
+/// overwrite an existing one so a second `init` can't silently clobber a stored
+/// key. `dir` is the containing directory (the process cwd in production).
+pub fn writeNewKeyFile(io: std.Io, dir: Dir, path: []const u8, ncryptsec: []const u8) !void {
+    dir.writeFile(io, .{
+        .sub_path = path,
+        .data = ncryptsec,
+        .flags = .{
+            .exclusive = true,
+            .permissions = std.Io.File.Permissions.fromMode(0o600),
+        },
+    }) catch |err| switch (err) {
+        error.PathAlreadyExists => return Error.KeyFileExists,
+        else => return err,
+    };
+}
+
+/// Reads a key file from `dir` and returns the trimmed `ncryptsec1...` token it
+/// holds. Caller owns the returned slice.
+pub fn readKeyFile(gpa: std.mem.Allocator, io: std.Io, dir: Dir, path: []const u8) ![]u8 {
+    const raw = dir.readFileAlloc(io, path, gpa, std.Io.Limit.limited(max_key_file_bytes)) catch |err| switch (err) {
+        // A file too big to be an ncryptsec is not a key file.
+        error.StreamTooLong => return Error.NotAnNcryptsec,
+        else => return err,
+    };
+    defer gpa.free(raw);
+
+    const token = std.mem.trim(u8, raw, " \t\r\n");
+    if (token.len == 0) return Error.EmptyKeyFile;
+    if (!std.mem.startsWith(u8, token, "ncryptsec1")) return Error.NotAnNcryptsec;
+    return gpa.dupe(u8, token);
+}
+
+// ---------------------------------------------------------------------------
+// Tests — exercise the new file surface end to end against a real temp dir:
+// encrypt a key, write it 0600, read it back, decrypt, and prove the safety
+// rails (refuse overwrite, reject non-ncryptsec content).
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "writeNewKeyFile then readKeyFile round-trips, is 0600, and refuses overwrite" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const secret = [_]u8{0xab} ** 32;
+    const passphrase = "correct horse battery staple";
+    const ncryptsec = try encryptKey(gpa, io, secret, passphrase, .known_secure);
+    defer gpa.free(ncryptsec);
+    try testing.expect(std.mem.startsWith(u8, ncryptsec, "ncryptsec1"));
+
+    try writeNewKeyFile(io, tmp.dir, "key.ncryptsec", ncryptsec);
+
+    // Stored 0600: no group/other permission bits.
+    const st = try tmp.dir.statFile(io, "key.ncryptsec", .{});
+    try testing.expectEqual(@as(std.posix.mode_t, 0), st.permissions.toMode() & 0o077);
+
+    // Round-trips through the file and decrypts back to the same key.
+    const loaded = try readKeyFile(gpa, io, tmp.dir, "key.ncryptsec");
+    defer gpa.free(loaded);
+    try testing.expectEqualStrings(ncryptsec, loaded);
+    const back = try decryptKey(gpa, loaded, passphrase);
+    try testing.expectEqualSlices(u8, &secret, &back);
+
+    // A second init must not clobber an existing key file.
+    try testing.expectError(Error.KeyFileExists, writeNewKeyFile(io, tmp.dir, "key.ncryptsec", ncryptsec));
+}
+
+test "readKeyFile trims surrounding whitespace and rejects non-ncryptsec content" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // A leading/trailing whitespace + newline is trimmed off the token.
+    try tmp.dir.writeFile(io, .{ .sub_path = "ok", .data = "  ncryptsec1abcXYZ\n" });
+    const tok = try readKeyFile(gpa, io, tmp.dir, "ok");
+    defer gpa.free(tok);
+    try testing.expectEqualStrings("ncryptsec1abcXYZ", tok);
+
+    // A plaintext hex nsec (anything not starting with `ncryptsec1`) is rejected.
+    try tmp.dir.writeFile(io, .{ .sub_path = "bad", .data = "deadbeef" });
+    try testing.expectError(Error.NotAnNcryptsec, readKeyFile(gpa, io, tmp.dir, "bad"));
+
+    // An empty / whitespace-only file is rejected too.
+    try tmp.dir.writeFile(io, .{ .sub_path = "empty", .data = "   \n" });
+    try testing.expectError(Error.EmptyKeyFile, readKeyFile(gpa, io, tmp.dir, "empty"));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,27 +1,39 @@
 //! zig-nostr signer — a headless NIP-46 remote signer ("bunker").
 //!
 //! Keeps the user's secret key on a machine they control and signs for remote
-//! clients over a relay. On startup it derives the keypair, prints the
-//! `bunker://` connection token, then connects to each configured relay and
-//! serves NIP-46 requests (see `serve.zig`) until stopped. Encrypted key
-//! storage (NIP-49) and a per-request approval UX are the next slices; this
-//! build auto-approves every request behind the connection secret.
+//! clients over a relay. On startup it loads the key — decrypting an encrypted
+//! NIP-49 key file at rest (see `keystore.zig`), or an unencrypted dev key —
+//! prints the `bunker://` connection token, then connects to each configured
+//! relay and serves NIP-46 requests (see `serve.zig`) until stopped. A
+//! per-request approval UX is the next slice; this build auto-approves every
+//! request behind the connection secret.
 
 const std = @import("std");
 const nostr = @import("nostr");
 const serve = @import("serve.zig");
+const keystore = @import("keystore.zig");
 
 const keys = nostr.keys;
 const nip46 = nostr.nip46;
+const nip49 = nostr.nip49;
 const hex = nostr.hex;
 
 const usage =
     \\zig-nostr signer — headless NIP-46 remote signer (bunker)
     \\
     \\Configure via environment variables:
-    \\  SIGNER_SECRET_KEY      64-char hex secret key (required)
-    \\  SIGNER_RELAYS          comma-separated wss:// relay URLs (required)
+    \\  SIGNER_KEY_FILE        path to an encrypted (NIP-49) key file
+    \\  SIGNER_PASSPHRASE      passphrase for the encrypted key file
+    \\  SIGNER_SECRET_KEY      64-char hex secret key (unencrypted; dev use only)
+    \\  SIGNER_RELAYS          comma-separated wss:// relay URLs (required to serve)
     \\  SIGNER_CONNECT_SECRET  optional connection secret clients must echo
+    \\  SIGNER_INIT            if set, create/import an encrypted key file and exit
+    \\
+    \\Provide the key either as an encrypted file (SIGNER_KEY_FILE +
+    \\SIGNER_PASSPHRASE, recommended) or as SIGNER_SECRET_KEY (dev only). To create
+    \\an encrypted file, run once with SIGNER_INIT set plus SIGNER_KEY_FILE and
+    \\SIGNER_PASSPHRASE — it imports SIGNER_SECRET_KEY if present, else generates a
+    \\fresh key — then run again without SIGNER_INIT to start serving.
     \\
     \\Prints the signer's public key and the bunker:// token clients connect
     \\with, then serves NIP-46 requests over the relays until stopped.
@@ -31,20 +43,24 @@ const usage =
 pub fn main() !void {
     const gpa = std.heap.page_allocator;
 
-    const secret_hex = getEnv("SIGNER_SECRET_KEY") orelse
-        fail("set SIGNER_SECRET_KEY to a 64-char hex secret key");
+    // `SIGNER_INIT` bootstraps an encrypted key file at rest, then exits.
+    if (getEnv("SIGNER_INIT") != null) runInit(gpa);
+
     const relays_env = getEnv("SIGNER_RELAYS") orelse
         fail("set SIGNER_RELAYS to a comma-separated list of wss:// URLs");
     const conn_secret = getEnv("SIGNER_CONNECT_SECRET");
 
-    const secret_key = hex.decodeFixed(32, secret_hex) catch
-        fail("SIGNER_SECRET_KEY must be exactly 64 hex characters");
+    // Load the secret key once (decrypting the at-rest key file if configured).
+    // The deliberately-expensive scrypt KDF runs here and only here; the relay
+    // threads below receive the already-derived 32-byte key, so no per-request
+    // or per-connection key derivation ever happens.
+    const secret_key = loadSecretKey(gpa);
 
     var signer = keys.Signer.init();
     defer signer.deinit();
 
     const kp = signer.keyPairFromSecretKey(secret_key) catch
-        fail("SIGNER_SECRET_KEY is not a valid secp256k1 secret key");
+        fail("the configured key is not a valid secp256k1 secret key");
 
     var relays: std.ArrayList([]const u8) = .empty;
     defer relays.deinit(gpa);
@@ -133,6 +149,91 @@ fn serveOnce(
     try serve.serve(gpa, io, relay, bunker, remote);
 }
 
+/// Resolves the signer's 32-byte secret key from the environment, preferring
+/// the encrypted-at-rest key file over the plaintext `SIGNER_SECRET_KEY`. The
+/// scrypt decryption cost is paid once, here, at startup.
+fn loadSecretKey(gpa: std.mem.Allocator) [32]u8 {
+    if (getEnv("SIGNER_KEY_FILE")) |path| {
+        const passphrase = getEnv("SIGNER_PASSPHRASE") orelse
+            fail("SIGNER_KEY_FILE is set but SIGNER_PASSPHRASE is not");
+
+        var startup = std.Io.Threaded.init(gpa, .{});
+        defer startup.deinit();
+        const io = startup.io();
+
+        const ncryptsec = keystore.readKeyFile(gpa, io, std.Io.Dir.cwd(), path) catch |err|
+            failFmt("could not read SIGNER_KEY_FILE '{s}': {s}", .{ path, @errorName(err) });
+        defer gpa.free(ncryptsec);
+
+        return keystore.decryptKey(gpa, ncryptsec, passphrase) catch
+            fail("could not decrypt the key file (wrong SIGNER_PASSPHRASE?)");
+    }
+
+    if (getEnv("SIGNER_SECRET_KEY")) |secret_hex| {
+        std.debug.print(
+            \\warning: SIGNER_SECRET_KEY keeps your key UNENCRYPTED in the environment.
+            \\         Prefer an encrypted key file: run once with SIGNER_INIT set plus
+            \\         SIGNER_KEY_FILE + SIGNER_PASSPHRASE, then drop SIGNER_SECRET_KEY.
+            \\
+        , .{});
+        return hex.decodeFixed(32, secret_hex) catch
+            fail("SIGNER_SECRET_KEY must be exactly 64 hex characters");
+    }
+
+    fail("set SIGNER_KEY_FILE (+ SIGNER_PASSPHRASE), or SIGNER_SECRET_KEY (dev only)");
+}
+
+/// Creates the encrypted-at-rest key file and exits. Imports `SIGNER_SECRET_KEY`
+/// if present (marked known-insecure, since it was plaintext in the environment),
+/// otherwise generates a fresh key. Refuses to overwrite an existing file.
+fn runInit(gpa: std.mem.Allocator) noreturn {
+    const path = getEnv("SIGNER_KEY_FILE") orelse
+        fail("SIGNER_INIT requires SIGNER_KEY_FILE (path to write the encrypted key to)");
+    const passphrase = getEnv("SIGNER_PASSPHRASE") orelse
+        fail("SIGNER_INIT requires SIGNER_PASSPHRASE (to encrypt the key with)");
+
+    var startup = std.Io.Threaded.init(gpa, .{});
+    defer startup.deinit();
+    const io = startup.io();
+
+    var signer = keys.Signer.init();
+    defer signer.deinit();
+
+    var security: nip49.KeySecurity = .known_secure;
+    const kp = if (getEnv("SIGNER_SECRET_KEY")) |secret_hex| blk: {
+        const secret_key = hex.decodeFixed(32, secret_hex) catch
+            fail("SIGNER_SECRET_KEY must be exactly 64 hex characters");
+        security = .known_insecure; // it sat in the environment as plaintext
+        break :blk signer.keyPairFromSecretKey(secret_key) catch
+            fail("SIGNER_SECRET_KEY is not a valid secp256k1 secret key");
+    } else signer.generateKeyPair(io) catch |err|
+        failFmt("could not generate a key: {s}", .{@errorName(err)});
+
+    const ncryptsec = keystore.encryptKey(gpa, io, kp.secret_key, passphrase, security) catch |err|
+        failFmt("could not encrypt the key: {s}", .{@errorName(err)});
+    defer gpa.free(ncryptsec);
+
+    keystore.writeNewKeyFile(io, std.Io.Dir.cwd(), path, ncryptsec) catch |err| switch (err) {
+        keystore.Error.KeyFileExists => failFmt("SIGNER_KEY_FILE '{s}' already exists; refusing to overwrite", .{path}),
+        else => failFmt("could not write '{s}': {s}", .{ path, @errorName(err) }),
+    };
+
+    const pk_hex = hex.encode(gpa, &kp.public_key) catch |err|
+        failFmt("could not encode the public key: {s}", .{@errorName(err)});
+    defer gpa.free(pk_hex);
+
+    std.debug.print(
+        \\Initialized encrypted signer key.
+        \\  pubkey : {s}
+        \\  file   : {s}  (mode 0600, NIP-49 ncryptsec)
+        \\
+        \\To start serving, unset SIGNER_INIT and run again with SIGNER_KEY_FILE,
+        \\SIGNER_PASSPHRASE and SIGNER_RELAYS set.
+        \\
+    , .{ pk_hex, path });
+    std.process.exit(0);
+}
+
 fn getEnv(name: [*:0]const u8) ?[]const u8 {
     const value = std.c.getenv(name) orelse return null;
     return std.mem.span(value);
@@ -143,9 +244,18 @@ fn fail(message: []const u8) noreturn {
     std.process.exit(1);
 }
 
+fn failFmt(comptime fmt: []const u8, args: anytype) noreturn {
+    std.debug.print("error: ", .{});
+    std.debug.print(fmt, args);
+    std.debug.print("\n\n{s}", .{usage});
+    std.process.exit(1);
+}
+
 test {
-    // Ensure the serve loop's hermetic tests run under `zig build test`.
+    // Ensure the serve loop's and keystore's hermetic tests run under
+    // `zig build test`.
     _ = @import("serve.zig");
+    _ = @import("keystore.zig");
 }
 
 test "derives the pubkey and builds a bunker token" {


### PR DESCRIPTION
Adds encrypted-at-rest key storage to the signer so the secret key no longer has to live as plaintext hex in the environment.

## What

- **`src/keystore.zig`** — wraps `nostr.nip49` to turn a 32-byte key into an `ncryptsec1…` blob (scrypt + XChaCha20-Poly1305) and back, and to read/write it as a `0600` key file that refuses to overwrite an existing one.
- **`SIGNER_INIT`** — bootstraps the key file: imports `SIGNER_SECRET_KEY` if set (recorded as `known_insecure`, since it was plaintext in the env), otherwise generates a fresh key, writes `0600`, and exits.
- **Serving** — loads the key from `SIGNER_KEY_FILE` + `SIGNER_PASSPHRASE`, decrypting once at startup. `SIGNER_SECRET_KEY` remains a dev-only fallback and now prints a warning.

## Performance

The scrypt KDF is deliberately expensive (it is the at-rest protection). It runs exactly once — at init to encrypt, at startup to decrypt — and never in the request-serving path, which only ever touches the already-derived 32-byte key.

## Testing

- Hermetic tests (`zig build test`, 7/7): file round-trip, `0600` permissions, overwrite refusal, and rejection of non-`ncryptsec` content.
- Manual: `SIGNER_INIT` import (derives the expected pubkey) and fresh-generate; overwrite refusal; wrong-passphrase rejection; and a full decrypt → dial → connect to `wss://relay.damus.io` (held an ESTABLISHED TLS socket).

Roadmap: ticks off "Encrypted key storage at rest (NIP-49 `ncryptsec`)".