### PR TITLE
feat: per-request authorization policy (method + kind allowlists)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ native clients over a relay — the secret key never reaches the client.
 > **Status: early / work in progress.** This is Showcase 1 of the zig-nostr
 > roadmap. The current build loads an encrypted (NIP-49) key from disk, connects
 > to your relays, and answers NIP-46 requests — `get_public_key`, `sign_event`,
-> `ping`, and NIP-44 encrypt/decrypt — auto-approving each one behind the
-> connection secret. A per-request approval UX is landing next.
+> `ping`, and NIP-44 encrypt/decrypt — behind the connection secret and an
+> optional method/event-kind allowlist. A native approval UI is landing later.
 
 ## Build
 
@@ -56,12 +56,27 @@ For quick local testing you can skip the key file and pass an unencrypted key
 directly with `SIGNER_SECRET_KEY=<64-char hex>` — but that keeps the key in your
 environment in the clear, so prefer the encrypted file otherwise.
 
+### Restricting what the signer will do
+
+By default the signer honors every NIP-46 request behind the connection secret.
+Two optional variables narrow that to least privilege:
+
+- `SIGNER_ALLOWED_METHODS` — comma-separated methods the signer will honor, e.g.
+  `get_public_key,sign_event`. `connect`, `ping`, and `logout` are always
+  allowed so the handshake can't be locked out. Use this to run a **sign-only**
+  bunker that refuses `nip44_decrypt`, so a connected client can't read your DMs
+  through it.
+- `SIGNER_ALLOWED_KINDS` — comma-separated event kinds `sign_event` may sign,
+  e.g. `1,7`. A request to sign any other kind is denied.
+
+Denied requests are answered with a NIP-46 error and logged.
+
 ## Roadmap
 
 - [x] `bunker://` connection token from a key + relays
 - [x] Relay listen/sign loop (answer NIP-46 requests over a relay)
 - [ ] Encrypted key storage at rest (NIP-49 `ncryptsec`)
-- [ ] Per-request approval policy
+- [x] Per-request approval policy (method + event-kind allowlists)
 - [ ] Native macOS app + downloadable build
 
 ## License

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,14 +4,15 @@
 //! clients over a relay. On startup it loads the key — decrypting an encrypted
 //! NIP-49 key file at rest (see `keystore.zig`), or an unencrypted dev key —
 //! prints the `bunker://` connection token, then connects to each configured
-//! relay and serves NIP-46 requests (see `serve.zig`) until stopped. A
-//! per-request approval UX is the next slice; this build auto-approves every
-//! request behind the connection secret.
+//! relay and serves NIP-46 requests (see `serve.zig`) until stopped. Requests
+//! are authorized by an optional method/event-kind allowlist (see `policy.zig`)
+//! behind the connection secret; a native approval UI comes later.
 
 const std = @import("std");
 const nostr = @import("nostr");
 const serve = @import("serve.zig");
 const keystore = @import("keystore.zig");
+const policy = @import("policy.zig");
 
 const keys = nostr.keys;
 const nip46 = nostr.nip46;
@@ -27,6 +28,10 @@ const usage =
     \\  SIGNER_SECRET_KEY      64-char hex secret key (unencrypted; dev use only)
     \\  SIGNER_RELAYS          comma-separated wss:// relay URLs (required to serve)
     \\  SIGNER_CONNECT_SECRET  optional connection secret clients must echo
+    \\  SIGNER_ALLOWED_METHODS comma-separated NIP-46 methods to honor (default: all;
+    \\                         connect/ping/logout are always allowed)
+    \\  SIGNER_ALLOWED_KINDS   comma-separated event kinds sign_event may sign
+    \\                         (default: any kind)
     \\  SIGNER_INIT            if set, create/import an encrypted key file and exit
     \\
     \\Provide the key either as an encrypted file (SIGNER_KEY_FILE +
@@ -49,6 +54,9 @@ pub fn main() !void {
     const relays_env = getEnv("SIGNER_RELAYS") orelse
         fail("set SIGNER_RELAYS to a comma-separated list of wss:// URLs");
     const conn_secret = getEnv("SIGNER_CONNECT_SECRET");
+
+    // Authorization rules, parsed once and shared read-only across relay threads.
+    const policy_config = buildPolicyConfig(gpa);
 
     // Load the secret key once (decrypting the at-rest key file if configured).
     // The deliberately-expensive scrypt KDF runs here and only here; the relay
@@ -93,7 +101,7 @@ pub fn main() !void {
     var threads: std.ArrayList(std.Thread) = .empty;
     defer threads.deinit(gpa);
     for (relays.items) |url| {
-        const t = std.Thread.spawn(.{}, serveRelayForever, .{ gpa, url, secret_key, conn_secret }) catch |err| {
+        const t = std.Thread.spawn(.{}, serveRelayForever, .{ gpa, url, secret_key, conn_secret, &policy_config }) catch |err| {
             std.debug.print("signer: [{s}] could not start: {s}\n", .{ url, @errorName(err) });
             continue;
         };
@@ -111,6 +119,7 @@ fn serveRelayForever(
     url: []const u8,
     secret_key: [32]u8,
     conn_secret: ?[]const u8,
+    policy_config: *const policy.Config,
 ) void {
     var threaded = std.Io.Threaded.init(gpa, .{});
     defer threaded.deinit();
@@ -123,7 +132,7 @@ fn serveRelayForever(
         return;
     };
 
-    var bunker = nip46.Bunker.initSingleKey(signer, kp, nip46.approveAll());
+    var bunker = nip46.Bunker.initSingleKey(signer, kp, policy_config.policy());
     bunker.secret = conn_secret;
 
     while (true) {
@@ -234,6 +243,46 @@ fn runInit(gpa: std.mem.Allocator) noreturn {
     std.process.exit(0);
 }
 
+/// Parses the authorization allowlists from the environment into a
+/// `policy.Config`. Empty/unset variables mean "no restriction"; an unknown
+/// method name or a non-numeric kind is a startup error. The returned slices
+/// live for the process (shared read-only by every relay thread).
+fn buildPolicyConfig(gpa: std.mem.Allocator) policy.Config {
+    var cfg = policy.Config{ .gpa = gpa };
+
+    if (getEnv("SIGNER_ALLOWED_METHODS")) |raw| {
+        var list: std.ArrayList(nip46.Method) = .empty;
+        var it = std.mem.splitScalar(u8, raw, ',');
+        while (it.next()) |item| {
+            const name = std.mem.trim(u8, item, " \t");
+            if (name.len == 0) continue;
+            const method = nip46.Method.fromString(name) orelse
+                failFmt("SIGNER_ALLOWED_METHODS: unknown method '{s}'", .{name});
+            list.append(gpa, method) catch fail("out of memory building the method allowlist");
+        }
+        if (list.items.len == 0) list.deinit(gpa) else {
+            cfg.allowed_methods = list.toOwnedSlice(gpa) catch fail("out of memory");
+        }
+    }
+
+    if (getEnv("SIGNER_ALLOWED_KINDS")) |raw| {
+        var list: std.ArrayList(u16) = .empty;
+        var it = std.mem.splitScalar(u8, raw, ',');
+        while (it.next()) |item| {
+            const s = std.mem.trim(u8, item, " \t");
+            if (s.len == 0) continue;
+            const kind = std.fmt.parseInt(u16, s, 10) catch
+                failFmt("SIGNER_ALLOWED_KINDS: invalid kind '{s}'", .{s});
+            list.append(gpa, kind) catch fail("out of memory building the kind allowlist");
+        }
+        if (list.items.len == 0) list.deinit(gpa) else {
+            cfg.allowed_kinds = list.toOwnedSlice(gpa) catch fail("out of memory");
+        }
+    }
+
+    return cfg;
+}
+
 fn getEnv(name: [*:0]const u8) ?[]const u8 {
     const value = std.c.getenv(name) orelse return null;
     return std.mem.span(value);
@@ -252,10 +301,11 @@ fn failFmt(comptime fmt: []const u8, args: anytype) noreturn {
 }
 
 test {
-    // Ensure the serve loop's and keystore's hermetic tests run under
-    // `zig build test`.
+    // Ensure the serve loop's, keystore's, and policy's hermetic tests run
+    // under `zig build test`.
     _ = @import("serve.zig");
     _ = @import("keystore.zig");
+    _ = @import("policy.zig");
 }
 
 test "derives the pubkey and builds a bunker token" {

--- a/src/policy.zig
+++ b/src/policy.zig
@@ -1,0 +1,153 @@
+//! Request-authorization policy for the headless signer.
+//!
+//! The NIP-46 `Bunker` consults an injectable `nip46.Policy` for every request.
+//! This module builds one from operator configuration so the signer can follow
+//! the principle of least privilege instead of blanket auto-approve: it restricts
+//! which key-touching methods are honored, and which event kinds it will sign.
+//!
+//! The `connect`, `ping`, and `logout` protocol methods are always permitted —
+//! rejecting them would only break the client handshake, not protect the key.
+//!
+//! Performance: the default (unrestricted) config decides in O(1) with no
+//! allocation. A configured kind allowlist parses only the event template's
+//! `kind` field, only for `sign_event` — off the hot `get_public_key`/`ping`
+//! path, and dwarfed by the Schnorr signing a permitted request then triggers.
+
+const std = @import("std");
+const nostr = @import("nostr");
+
+const nip46 = nostr.nip46;
+
+/// Operator-configured authorization rules. A null allowlist means "no
+/// restriction"; a non-null one is an allowlist. Passed to the policy by
+/// pointer as `ctx`, so it must outlive the bunker (it lives for the process).
+pub const Config = struct {
+    /// Allocator used to parse an event template's kind when `allowed_kinds`
+    /// is set; unused when it is null.
+    gpa: std.mem.Allocator,
+    /// Key-touching methods the signer will honor; null = no restriction.
+    /// `connect`/`ping`/`logout` are always allowed regardless.
+    allowed_methods: ?[]const nip46.Method = null,
+    /// Event kinds the signer will `sign_event` for; null = any kind.
+    allowed_kinds: ?[]const u16 = null,
+
+    /// Builds the `nip46.Policy` backed by this config. `self` must outlive the
+    /// bunker that holds the returned policy (it is threaded through as `ctx`).
+    pub fn policy(self: *const Config) nip46.Policy {
+        return .{ .ctx = @constCast(self), .decideFn = &decide };
+    }
+};
+
+/// Methods that are never restricted: rejecting them would break the NIP-46
+/// handshake/liveness, not protect the key.
+fn alwaysAllowed(method: nip46.Method) bool {
+    return switch (method) {
+        .connect, .ping, .logout => true,
+        else => false,
+    };
+}
+
+fn decide(ctx: ?*anyopaque, request: *const nip46.Request) nip46.Decision {
+    const cfg: *const Config = @ptrCast(@alignCast(ctx.?));
+
+    // Unknown/unsupported method: fail closed. (The bunker rejects these too,
+    // but the policy must never approve something it can't classify.)
+    const method = nip46.Method.fromString(request.method) orelse return .reject;
+
+    if (!alwaysAllowed(method)) {
+        if (cfg.allowed_methods) |allowed| {
+            if (std.mem.indexOfScalar(nip46.Method, allowed, method) == null) return .reject;
+        }
+    }
+
+    if (method == .sign_event) {
+        if (cfg.allowed_kinds) |kinds| {
+            const kind = signEventKind(cfg.gpa, request) orelse return .reject;
+            if (std.mem.indexOfScalar(u16, kinds, kind) == null) return .reject;
+        }
+    }
+
+    return .approve;
+}
+
+/// Parses the `kind` from a `sign_event` request's event template (params[0]),
+/// or null if it is missing or unparseable (the caller treats null as "deny").
+fn signEventKind(gpa: std.mem.Allocator, request: *const nip46.Request) ?u16 {
+    if (request.params.len < 1) return null;
+    const parsed = std.json.parseFromSlice(
+        struct { kind: u16 },
+        gpa,
+        request.params[0],
+        .{ .ignore_unknown_fields = true },
+    ) catch return null;
+    defer parsed.deinit();
+    return parsed.value.kind;
+}
+
+// ---------------------------------------------------------------------------
+// Tests — the policy is pure: feed it requests and assert approve/reject.
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "default config approves every supported request" {
+    var cfg = Config{ .gpa = testing.allocator };
+    const p = cfg.policy();
+
+    const gpk = nip46.Request{ .id = "1", .method = "get_public_key", .params = &.{} };
+    try testing.expectEqual(nip46.Decision.approve, p.decide(&gpk));
+
+    const tmpl = "{\"kind\":4,\"content\":\"x\",\"tags\":[],\"created_at\":1}";
+    const se = nip46.Request{ .id = "2", .method = "sign_event", .params = &[_][]const u8{tmpl} };
+    try testing.expectEqual(nip46.Decision.approve, p.decide(&se));
+}
+
+test "method allowlist blocks a key-touching method but never connect/ping" {
+    const allowed = [_]nip46.Method{ .get_public_key, .sign_event };
+    var cfg = Config{ .gpa = testing.allocator, .allowed_methods = &allowed };
+    const p = cfg.policy();
+
+    // A sign-only bunker refuses nip44_decrypt so a client can't read the
+    // user's DMs through it.
+    const dec = nip46.Request{ .id = "1", .method = "nip44_decrypt", .params = &[_][]const u8{ "aa", "bb" } };
+    try testing.expectEqual(nip46.Decision.reject, p.decide(&dec));
+
+    // connect/ping are always allowed even though they're not listed.
+    const con = nip46.Request{ .id = "2", .method = "connect", .params = &.{} };
+    try testing.expectEqual(nip46.Decision.approve, p.decide(&con));
+    const png = nip46.Request{ .id = "3", .method = "ping", .params = &.{} };
+    try testing.expectEqual(nip46.Decision.approve, p.decide(&png));
+
+    // A listed method still passes.
+    const gpk = nip46.Request{ .id = "4", .method = "get_public_key", .params = &.{} };
+    try testing.expectEqual(nip46.Decision.approve, p.decide(&gpk));
+}
+
+test "kind allowlist gates sign_event by event kind, failing closed" {
+    const kinds = [_]u16{1};
+    var cfg = Config{ .gpa = testing.allocator, .allowed_kinds = &kinds };
+    const p = cfg.policy();
+
+    const note = "{\"kind\":1,\"content\":\"gm\",\"tags\":[],\"created_at\":1}";
+    const ok = nip46.Request{ .id = "1", .method = "sign_event", .params = &[_][]const u8{note} };
+    try testing.expectEqual(nip46.Decision.approve, p.decide(&ok));
+
+    const del = "{\"kind\":5,\"content\":\"\",\"tags\":[],\"created_at\":1}";
+    const no = nip46.Request{ .id = "2", .method = "sign_event", .params = &[_][]const u8{del} };
+    try testing.expectEqual(nip46.Decision.reject, p.decide(&no));
+
+    // Unparseable template → deny.
+    const junk = nip46.Request{ .id = "3", .method = "sign_event", .params = &[_][]const u8{"not json"} };
+    try testing.expectEqual(nip46.Decision.reject, p.decide(&junk));
+
+    // A kind restriction doesn't affect non-signing methods.
+    const gpk = nip46.Request{ .id = "4", .method = "get_public_key", .params = &.{} };
+    try testing.expectEqual(nip46.Decision.approve, p.decide(&gpk));
+}
+
+test "unknown method is rejected" {
+    var cfg = Config{ .gpa = testing.allocator };
+    const p = cfg.policy();
+    const bogus = nip46.Request{ .id = "1", .method = "delete_everything", .params = &.{} };
+    try testing.expectEqual(nip46.Decision.reject, p.decide(&bogus));
+}

--- a/src/serve.zig
+++ b/src/serve.zig
@@ -92,10 +92,13 @@ fn handleRequest(
 
     const client_hex = try hex.encode(gpa, &request_event.pubkey);
     defer gpa.free(client_hex);
-    std.debug.print("signer: '{s}' from {s}…\n", .{ parsed.value.method, client_hex[0..16] });
 
     var response = try bunker.handle(gpa, io, parsed.value);
     defer response.deinit();
+
+    // Audit line: the request, the client, and the authorization outcome.
+    const outcome = if (response.value.err.len == 0) "ok" else response.value.err;
+    std.debug.print("signer: {s} '{s}' from {s}…\n", .{ outcome, parsed.value.method, client_hex[0..16] });
 
     const response_json = try response.value.toJson(gpa);
     defer gpa.free(response_json);


### PR DESCRIPTION
Replaces blanket auto-approve with a configurable NIP-46 authorization policy, so the signer can run with least privilege instead of honoring everything behind the connection secret.

## What

- **`src/policy.zig`** — builds an `nip46.Policy` from operator config (the `Bunker` already consults an injectable policy per request):
  - **`SIGNER_ALLOWED_METHODS`** — allowlist of key-touching methods, e.g. a *sign-only* bunker that refuses `nip44_decrypt` so a connected client can't read the user's DMs. `connect`/`ping`/`logout` are always allowed so the handshake can't be locked out.
  - **`SIGNER_ALLOWED_KINDS`** — which event kinds `sign_event` will sign (e.g. `1,7`); any other kind is denied.
  - Fails closed: unknown methods and unparseable event templates are rejected.
- **`main.zig`** — parses the allowlists once at startup and shares the config read-only across the relay threads.
- **`serve.zig`** — logs the authorization outcome per request (`ok` / the error).

## Performance

The default (unconfigured) path decides in O(1) with no allocation. A configured kind allowlist parses only the template's `kind` field, only for `sign_event` — off the hot `get_public_key`/`ping` path and dwarfed by the Schnorr signing a permitted request then triggers.

## Testing

- Hermetic tests (`zig build test`, 11/11): method gating with always-allowed handshake methods, kind gating, fail-closed on unparseable templates, and unknown-method rejection. The existing serve round-trip already proves a policy-denied request comes back to the client as a sealed NIP-46 error.
- Manual CLI: unknown method / non-numeric kind fail fast with a clear startup error; a valid allowlist parses through.

Roadmap: ticks off "Per-request approval policy". The interactive/native approval **UI** remains a later slice.