### PR TITLE
feat: loopback approval API for interactive (GUI) mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ native clients over a relay — the secret key never reaches the client.
 > roadmap. The current build loads an encrypted (NIP-49) key from disk, connects
 > to your relays, and answers NIP-46 requests — `get_public_key`, `sign_event`,
 > `ping`, and NIP-44 encrypt/decrypt — behind the connection secret and an
-> optional method/event-kind allowlist. A native approval UI is landing later.
+> optional method/event-kind allowlist. It can also run in **GUI mode**, holding
+> each request for interactive approval over a loopback API — the key never
+> leaves the daemon. The native approval app itself is landing next.
 
 ## Build
 
@@ -71,13 +73,37 @@ Two optional variables narrow that to least privilege:
 
 Denied requests are answered with a NIP-46 error and logged.
 
+### Interactive approval (GUI mode)
+
+By default a request that passes the allowlist is answered immediately. Set
+`SIGNER_APPROVAL_HTTP` to instead hold each one for interactive approval: the
+daemon serves a small **loopback-only** HTTP API that a separate GUI connects
+to, so you approve or deny each request on screen. The key never leaves the
+daemon — the GUI only ever sees request metadata and sends back a yes/no.
+
+```sh
+SIGNER_KEY_FILE="$HOME/.zig-nostr-signer.ncryptsec" \
+SIGNER_PASSPHRASE="a strong passphrase" \
+SIGNER_RELAYS="wss://relay.example.com" \
+SIGNER_APPROVAL_HTTP="127.0.0.1:8787" \
+SIGNER_APPROVAL_TOKEN_FILE="$HOME/.zig-nostr-signer.token" \
+  zig build run
+```
+
+The API is bound to loopback and every request must carry the bearer token
+written (mode `0600`) to `SIGNER_APPROVAL_TOKEN_FILE`. Endpoints: `GET /pending`
+(long-poll), `POST /decision`, `GET /info`. A request left unanswered past the
+timeout is denied, and the allowlist still applies first — so disallowed
+requests are rejected without ever prompting.
+
 ## Roadmap
 
 - [x] `bunker://` connection token from a key + relays
 - [x] Relay listen/sign loop (answer NIP-46 requests over a relay)
-- [ ] Encrypted key storage at rest (NIP-49 `ncryptsec`)
+- [x] Encrypted key storage at rest (NIP-49 `ncryptsec`)
 - [x] Per-request approval policy (method + event-kind allowlists)
-- [ ] Native macOS app + downloadable build
+- [x] Loopback approval API for interactive GUI approval
+- [ ] Native macOS approval app + downloadable build
 
 ## License
 

--- a/src/approval.zig
+++ b/src/approval.zig
@@ -1,0 +1,261 @@
+//! Cross-thread approval broker + the interactive NIP-46 policy for GUI mode.
+//!
+//! Architecture (see README): the daemon holds the key and does all Nostr work;
+//! a separate GUI process approves requests over the loopback HTTP API (see
+//! `approval_http.zig`). This module is the seam between the two:
+//!
+//! - A relay thread, inside `bunker.handle`, calls the interactive policy's
+//!   `decide`. For a request the static allowlist already permits, `decide`
+//!   SUBMITS it to the broker and blocks the relay thread until the GUI resolves
+//!   it (or a timeout denies it, so a relay thread never blocks forever).
+//! - The HTTP server thread lists the queue (`snapshot`) and applies the GUI's
+//!   decisions (`resolve`).
+//!
+//! The broker is deliberately independent of the `std.Io` model: a tiny atomic
+//! spinlock guards the small pending array (contention is near-zero — approvals
+//! are human-paced and rare), and each entry carries an atomic decision slot.
+//! Only the submit poll-wait uses the caller's `io.sleep`, exactly as the relay
+//! reconnect loop already does.
+
+const std = @import("std");
+const nostr = @import("nostr");
+const policy = @import("policy.zig");
+
+const nip46 = nostr.nip46;
+
+pub const Decision = enum(u8) { pending, approve, reject };
+
+/// Display metadata for one awaiting request. Strings are copied in, so the
+/// broker never aliases relay-thread memory.
+pub const Pending = struct {
+    id: u64 = 0,
+    method_buf: [24]u8 = undefined,
+    method_len: u8 = 0,
+    /// Event kind for `sign_event`, else -1.
+    kind: i32 = -1,
+    created_at: i64 = 0,
+
+    pub fn method(self: *const Pending) []const u8 {
+        return self.method_buf[0..self.method_len];
+    }
+};
+
+const Slot = struct {
+    in_use: bool = false,
+    info: Pending = .{},
+    decision: std.atomic.Value(Decision) = .init(.pending),
+};
+
+pub const Broker = struct {
+    /// Max simultaneously-pending approvals; further submits fail closed.
+    pub const capacity = 32;
+
+    lock: std.atomic.Value(bool) = .init(false),
+    slots: [capacity]Slot = [_]Slot{.{}} ** capacity,
+    next_id: u64 = 1,
+    /// Bumps on every queue change so a poller can detect activity.
+    version: std.atomic.Value(u64) = .init(0),
+    /// Milliseconds a submitted request waits before it is auto-denied when no
+    /// GUI resolves it.
+    timeout_ms: u64 = 120_000,
+
+    fn acquire(self: *Broker) void {
+        while (self.lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) {
+            std.Thread.yield() catch {};
+        }
+    }
+    fn release(self: *Broker) void {
+        self.lock.store(false, .release);
+    }
+
+    /// Submits `info` and blocks until the GUI resolves it or the timeout denies
+    /// it. Runs on a relay thread; `io.sleep` paces the poll.
+    pub fn submit(self: *Broker, io: std.Io, info: Pending) Decision {
+        const idx = self.claim(info) orelse return .reject;
+
+        // Poll the decision slot, pacing with io.sleep (as the reconnect loop
+        // does). Elapsed time is counted in sleep steps — no wall clock needed.
+        const step_ms = 50;
+        var waited_ms: u64 = 0;
+        var decision = self.slots[idx].decision.load(.acquire);
+        while (decision == .pending and waited_ms < self.timeout_ms) {
+            io.sleep(std.Io.Duration.fromMilliseconds(step_ms), .awake) catch {};
+            waited_ms += step_ms;
+            decision = self.slots[idx].decision.load(.acquire);
+        }
+
+        // Honor a last-moment resolve that raced the timeout; else deny.
+        self.acquire();
+        const final = self.slots[idx].decision.load(.acquire);
+        self.slots[idx].in_use = false;
+        self.release();
+        _ = self.version.fetchAdd(1, .monotonic);
+        return if (final != .pending) final else .reject;
+    }
+
+    fn claim(self: *Broker, info: Pending) ?usize {
+        self.acquire();
+        defer self.release();
+        for (&self.slots, 0..) |*slot, i| {
+            if (!slot.in_use) {
+                slot.* = .{ .in_use = true, .info = info, .decision = .init(.pending) };
+                slot.info.id = self.next_id;
+                self.next_id += 1;
+                _ = self.version.fetchAdd(1, .monotonic);
+                return i;
+            }
+        }
+        return null;
+    }
+
+    /// Copies the still-pending entries into `out`, returning the count.
+    pub fn snapshot(self: *Broker, out: []Pending) usize {
+        self.acquire();
+        defer self.release();
+        var n: usize = 0;
+        for (&self.slots) |*slot| {
+            if (n >= out.len) break;
+            if (slot.in_use and slot.decision.load(.monotonic) == .pending) {
+                out[n] = slot.info;
+                n += 1;
+            }
+        }
+        return n;
+    }
+
+    /// Applies the GUI's decision to pending entry `id`. Returns true if it was
+    /// found and still pending.
+    pub fn resolve(self: *Broker, id: u64, decision: Decision) bool {
+        if (decision == .pending) return false;
+        self.acquire();
+        var found = false;
+        for (&self.slots) |*slot| {
+            if (slot.in_use and slot.info.id == id and slot.decision.load(.monotonic) == .pending) {
+                slot.decision.store(decision, .release);
+                found = true;
+                break;
+            }
+        }
+        self.release();
+        if (found) _ = self.version.fetchAdd(1, .monotonic);
+        return found;
+    }
+};
+
+/// The interactive policy: pre-filter through the static allowlist, then escalate
+/// anything it permits to the GUI via the broker. One per relay thread (each
+/// carries that thread's `io`/allocator), constructed in `serveRelayForever`.
+pub const Interactive = struct {
+    broker: *Broker,
+    config: *const policy.Config,
+    io: std.Io,
+    gpa: std.mem.Allocator,
+
+    pub fn asPolicy(self: *const Interactive) nip46.Policy {
+        return .{ .ctx = @constCast(self), .decideFn = &decide };
+    }
+};
+
+fn decide(ctx: ?*anyopaque, request: *const nip46.Request) nip46.Decision {
+    const self: *const Interactive = @ptrCast(@alignCast(ctx.?));
+
+    // The static allowlist is the first gate: a disallowed request is denied
+    // outright and never bothers the human.
+    if (self.config.policy().decide(request) == .reject) return .reject;
+
+    var info = Pending{};
+    const mlen = @min(request.method.len, info.method_buf.len);
+    @memcpy(info.method_buf[0..mlen], request.method[0..mlen]);
+    info.method_len = @intCast(mlen);
+    info.created_at = std.Io.Timestamp.now(self.io, .real).toSeconds();
+    if (nip46.Method.fromString(request.method)) |method| {
+        if (method == .sign_event) {
+            if (policy.signEventKind(self.gpa, request)) |k| info.kind = k;
+        }
+    }
+
+    return switch (self.broker.submit(self.io, info)) {
+        .approve => .approve,
+        else => .reject,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — drive the broker across real threads (a resolver thread stands in for
+// the GUI), and check the interactive policy's allowlist pre-filter.
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+/// Stand-in for the GUI: waits for one pending entry, then resolves it.
+fn resolveFirst(broker: *Broker, decision: Decision) void {
+    var buf: [4]Pending = undefined;
+    var tries: usize = 0;
+    while (tries < 1_000_000) : (tries += 1) {
+        if (broker.snapshot(&buf) > 0) {
+            _ = broker.resolve(buf[0].id, decision);
+            return;
+        }
+        std.Thread.yield() catch {};
+    }
+}
+
+test "broker submit blocks until the GUI resolves it" {
+    var threaded = std.Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var broker = Broker{ .timeout_ms = 5_000 };
+    const t = try std.Thread.spawn(.{}, resolveFirst, .{ &broker, Decision.approve });
+    defer t.join();
+
+    var info = Pending{};
+    info.method_len = 10;
+    @memcpy(info.method_buf[0..10], "sign_event");
+    try testing.expectEqual(Decision.approve, broker.submit(io, info));
+}
+
+test "broker denies on timeout when nothing resolves it" {
+    var threaded = std.Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var broker = Broker{ .timeout_ms = 120 };
+    try testing.expectEqual(Decision.reject, broker.submit(io, Pending{}));
+}
+
+test "interactive policy denies allowlist-disallowed requests without prompting" {
+    var threaded = std.Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var broker = Broker{};
+    const allowed = [_]nip46.Method{.get_public_key}; // sign_event NOT allowed
+    var cfg = policy.Config{ .gpa = testing.allocator, .allowed_methods = &allowed };
+    const inter = Interactive{ .broker = &broker, .config = &cfg, .io = io, .gpa = testing.allocator };
+    const p = inter.asPolicy();
+
+    const tmpl = "{\"kind\":1,\"content\":\"x\",\"tags\":[],\"created_at\":1}";
+    const req = nip46.Request{ .id = "1", .method = "sign_event", .params = &[_][]const u8{tmpl} };
+    try testing.expectEqual(nip46.Decision.reject, p.decide(&req));
+    // Never enqueued: a disallowed request must not reach the GUI.
+    var buf: [1]Pending = undefined;
+    try testing.expectEqual(@as(usize, 0), broker.snapshot(&buf));
+}
+
+test "interactive policy escalates an allowed request and returns the GUI decision" {
+    var threaded = std.Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var broker = Broker{ .timeout_ms = 5_000 };
+    var cfg = policy.Config{ .gpa = testing.allocator }; // no restriction
+    const inter = Interactive{ .broker = &broker, .config = &cfg, .io = io, .gpa = testing.allocator };
+    const p = inter.asPolicy();
+
+    const t = try std.Thread.spawn(.{}, resolveFirst, .{ &broker, Decision.reject });
+    defer t.join();
+
+    const req = nip46.Request{ .id = "1", .method = "get_public_key", .params = &.{} };
+    try testing.expectEqual(nip46.Decision.reject, p.decide(&req));
+}

--- a/src/approval_http.zig
+++ b/src/approval_http.zig
@@ -1,0 +1,280 @@
+//! Minimal, hardened loopback HTTP approval API for GUI mode.
+//!
+//! The GUI process drives approvals over this API — it never holds the key.
+//! Deliberately tiny (fixed routes, no keep-alive, no chunked encoding) to keep
+//! the key-holding daemon's attack surface small:
+//!
+//!   GET  /pending?since=N   long-poll (~1s) → {"version":N,"pending":[...]}
+//!   POST /decision          {"id":N,"decision":"approve"|"reject"} → {"ok":bool}
+//!   GET  /info              {"pubkey":"..","relays":[..],"timeout_ms":N}
+//!
+//! Every request must carry `Authorization: Bearer <token>`; the token is
+//! generated at startup and written to a 0600 file only the same user can read.
+//! Bound to loopback only.
+
+const std = @import("std");
+const approval = @import("approval.zig");
+
+const net = std.Io.net;
+const Broker = approval.Broker;
+const Pending = approval.Pending;
+
+pub const Info = struct {
+    pubkey_hex: []const u8,
+    relays: []const []const u8,
+    timeout_ms: u64,
+};
+
+pub const Server = struct {
+    gpa: std.mem.Allocator,
+    broker: *Broker,
+    /// Bearer token clients must present.
+    token: []const u8,
+    info: Info,
+    host: []const u8,
+    port: u16,
+
+    active: std.atomic.Value(u32) = .init(0),
+    const max_conns = 8;
+
+    /// Binds loopback and serves forever on the calling thread.
+    pub fn run(self: *Server, io: std.Io) !void {
+        const addr = try net.IpAddress.parseIp4(self.host, self.port);
+        var server = try addr.listen(io, .{ .reuse_address = true });
+        while (true) {
+            const stream = server.accept(io) catch continue;
+            if (self.active.load(.monotonic) >= max_conns) {
+                stream.close(io);
+                continue;
+            }
+            _ = self.active.fetchAdd(1, .monotonic);
+            const t = std.Thread.spawn(.{}, handle, .{ self, stream }) catch {
+                _ = self.active.fetchSub(1, .monotonic);
+                stream.close(io);
+                continue;
+            };
+            t.detach();
+        }
+    }
+};
+
+/// One connection on its own thread with its own io (for the long-poll sleep).
+fn handle(self: *Server, stream: net.Stream) void {
+    defer _ = self.active.fetchSub(1, .monotonic);
+    var threaded = std.Io.Threaded.init(self.gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    defer stream.close(io);
+    handleConn(self, io, stream) catch {};
+}
+
+fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
+    var read_storage: [8192]u8 = undefined;
+    var write_storage: [4096]u8 = undefined;
+    var sr = stream.reader(io, &read_storage);
+    var sw = stream.writer(io, &write_storage);
+    const r = &sr.interface;
+    const w = &sw.interface;
+
+    // Read the request head (and whatever body bytes ride with it) up to the
+    // blank line separating headers from the body.
+    // Read available bytes until the blank line ends the headers. `readVec`
+    // returns after one read (unlike `readSliceShort`, which blocks until it has
+    // filled the whole buffer or hit EOF — a deadlock when the client sends a
+    // short request and then waits for our response).
+    var buf: [8192]u8 = undefined;
+    var len: usize = 0;
+    const head_end = while (true) {
+        if (len >= buf.len) return respond(w, 431, "{\"error\":\"headers too large\"}");
+        var data: [1][]u8 = .{buf[len..]};
+        const n = r.readVec(&data) catch return;
+        if (n == 0) return; // EOF before a full request
+        len += n;
+        if (std.mem.indexOf(u8, buf[0..len], "\r\n\r\n")) |i| break i;
+    };
+
+    var lines = std.mem.splitSequence(u8, buf[0..head_end], "\r\n");
+    const request_line = lines.next() orelse return respond(w, 400, bad_request);
+    var parts = std.mem.splitScalar(u8, request_line, ' ');
+    const method = parts.next() orelse return respond(w, 400, bad_request);
+    const path = parts.next() orelse return respond(w, 400, bad_request);
+
+    var auth: []const u8 = "";
+    var content_length: usize = 0;
+    while (lines.next()) |line| {
+        if (headerValue(line, "authorization")) |v| auth = v;
+        if (headerValue(line, "content-length")) |v|
+            content_length = std.fmt.parseInt(usize, v, 10) catch 0;
+    }
+
+    if (!authOk(auth, self.token)) return respond(w, 401, "{\"error\":\"unauthorized\"}");
+
+    // Assemble the body: bytes already read after the head, plus any remainder.
+    var body_storage: [4096]u8 = undefined;
+    var body: []const u8 = "";
+    if (content_length > 0) {
+        if (content_length > body_storage.len) return respond(w, 413, "{\"error\":\"body too large\"}");
+        const body_start = head_end + 4;
+        var got = @min(len - body_start, content_length);
+        @memcpy(body_storage[0..got], buf[body_start .. body_start + got]);
+        while (got < content_length) {
+            const n = r.readSliceShort(body_storage[got..content_length]) catch break;
+            if (n == 0) break;
+            got += n;
+        }
+        body = body_storage[0..got];
+    }
+
+    if (eql(method, "GET") and std.mem.startsWith(u8, path, "/pending"))
+        return handlePending(self, io, w, path);
+    if (eql(method, "POST") and eql(path, "/decision"))
+        return handleDecision(self, w, body);
+    if (eql(method, "GET") and eql(path, "/info"))
+        return handleInfo(self, w);
+    return respond(w, 404, "{\"error\":\"not found\"}");
+}
+
+fn handlePending(self: *Server, io: std.Io, w: *std.Io.Writer, path: []const u8) !void {
+    const since = parseSince(path);
+    // Long-poll: wait briefly for a queue change so the GUI can loop fetch→
+    // refetch without busy-polling. Returns at once when something changed.
+    var waited: u64 = 0;
+    while (waited < 1000 and self.broker.version.load(.monotonic) == since) {
+        io.sleep(std.Io.Duration.fromMilliseconds(100), .awake) catch {};
+        waited += 100;
+    }
+
+    var pending: [Broker.capacity]Pending = undefined;
+    const n = self.broker.snapshot(&pending);
+    const version = self.broker.version.load(.monotonic);
+
+    var json: std.ArrayList(u8) = .empty;
+    defer json.deinit(self.gpa);
+    const head = try std.fmt.allocPrint(self.gpa, "{{\"version\":{d},\"pending\":[", .{version});
+    defer self.gpa.free(head);
+    try json.appendSlice(self.gpa, head);
+    for (pending[0..n], 0..) |p, i| {
+        if (i != 0) try json.append(self.gpa, ',');
+        const item = try std.fmt.allocPrint(self.gpa, "{{\"id\":{d},\"method\":\"{s}\",\"kind\":{d},\"created_at\":{d}}}", .{ p.id, p.method(), p.kind, p.created_at });
+        defer self.gpa.free(item);
+        try json.appendSlice(self.gpa, item);
+    }
+    try json.appendSlice(self.gpa, "]}");
+    return respond(w, 200, json.items);
+}
+
+fn handleDecision(self: *Server, w: *std.Io.Writer, body: []const u8) !void {
+    const Body = struct { id: u64, decision: []const u8 };
+    const parsed = std.json.parseFromSlice(Body, self.gpa, body, .{ .ignore_unknown_fields = true }) catch
+        return respond(w, 400, bad_request);
+    defer parsed.deinit();
+
+    const decision: approval.Decision = if (eql(parsed.value.decision, "approve"))
+        .approve
+    else if (eql(parsed.value.decision, "reject") or eql(parsed.value.decision, "deny"))
+        .reject
+    else
+        return respond(w, 400, bad_request);
+
+    const ok = self.broker.resolve(parsed.value.id, decision);
+    var out: [32]u8 = undefined;
+    const j = std.fmt.bufPrint(&out, "{{\"ok\":{s}}}", .{if (ok) "true" else "false"}) catch unreachable;
+    return respond(w, 200, j);
+}
+
+fn handleInfo(self: *Server, w: *std.Io.Writer) !void {
+    var json: std.ArrayList(u8) = .empty;
+    defer json.deinit(self.gpa);
+    const head = try std.fmt.allocPrint(self.gpa, "{{\"pubkey\":\"{s}\",\"timeout_ms\":{d},\"relays\":[", .{ self.info.pubkey_hex, self.info.timeout_ms });
+    defer self.gpa.free(head);
+    try json.appendSlice(self.gpa, head);
+    for (self.info.relays, 0..) |relay, i| {
+        if (i != 0) try json.append(self.gpa, ',');
+        const item = try std.fmt.allocPrint(self.gpa, "\"{s}\"", .{relay}); // relay URLs carry no JSON metacharacters
+        defer self.gpa.free(item);
+        try json.appendSlice(self.gpa, item);
+    }
+    try json.appendSlice(self.gpa, "]}");
+    return respond(w, 200, json.items);
+}
+
+// --- HTTP plumbing -------------------------------------------------------
+
+const bad_request = "{\"error\":\"bad request\"}";
+
+fn respond(w: *std.Io.Writer, status: u16, json: []const u8) !void {
+    var head: [160]u8 = undefined;
+    const h = std.fmt.bufPrint(&head, "HTTP/1.1 {d} {s}\r\nContent-Type: application/json\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n", .{ status, reason(status), json.len }) catch unreachable;
+    try w.writeAll(h);
+    try w.writeAll(json);
+    try w.flush();
+}
+
+fn reason(status: u16) []const u8 {
+    return switch (status) {
+        200 => "OK",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        404 => "Not Found",
+        413 => "Payload Too Large",
+        431 => "Request Header Fields Too Large",
+        else => "Error",
+    };
+}
+
+/// Returns the value of header `name` (lowercased match) from `line`, trimmed.
+fn headerValue(line: []const u8, name: []const u8) ?[]const u8 {
+    const colon = std.mem.indexOfScalar(u8, line, ':') orelse return null;
+    if (!std.ascii.eqlIgnoreCase(std.mem.trim(u8, line[0..colon], " "), name)) return null;
+    return std.mem.trim(u8, line[colon + 1 ..], " ");
+}
+
+/// Constant-time check that `header` is `Bearer <token>`.
+fn authOk(header: []const u8, token: []const u8) bool {
+    const prefix = "Bearer ";
+    if (!std.mem.startsWith(u8, header, prefix)) return false;
+    const got = header[prefix.len..];
+    if (got.len != token.len) return false;
+    var diff: u8 = 0;
+    for (got, token) |a, b| diff |= a ^ b;
+    return diff == 0;
+}
+
+/// Parses the `?since=N` query value from a path, defaulting to 0.
+fn parseSince(path: []const u8) u64 {
+    const q = std.mem.indexOfScalar(u8, path, '?') orelse return 0;
+    var params = std.mem.splitScalar(u8, path[q + 1 ..], '&');
+    while (params.next()) |param| {
+        if (std.mem.startsWith(u8, param, "since="))
+            return std.fmt.parseInt(u64, param["since=".len..], 10) catch 0;
+    }
+    return 0;
+}
+
+fn eql(a: []const u8, b: []const u8) bool {
+    return std.mem.eql(u8, a, b);
+}
+
+// --- Tests ---------------------------------------------------------------
+
+const testing = std.testing;
+
+test "headerValue parses case-insensitively and trims" {
+    try testing.expectEqualStrings("Bearer abc", headerValue("Authorization: Bearer abc", "authorization").?);
+    try testing.expectEqualStrings("42", headerValue("content-length:  42 ", "content-length").?);
+    try testing.expect(headerValue("Host: x", "authorization") == null);
+}
+
+test "authOk requires an exact bearer token" {
+    try testing.expect(authOk("Bearer s3cret", "s3cret"));
+    try testing.expect(!authOk("Bearer s3cret", "other"));
+    try testing.expect(!authOk("Bearer s3cre", "s3cret"));
+    try testing.expect(!authOk("s3cret", "s3cret"));
+    try testing.expect(!authOk("", "s3cret"));
+}
+
+test "parseSince reads the query parameter" {
+    try testing.expectEqual(@as(u64, 0), parseSince("/pending"));
+    try testing.expectEqual(@as(u64, 7), parseSince("/pending?since=7"));
+    try testing.expectEqual(@as(u64, 3), parseSince("/pending?foo=1&since=3"));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,6 +13,8 @@ const nostr = @import("nostr");
 const serve = @import("serve.zig");
 const keystore = @import("keystore.zig");
 const policy = @import("policy.zig");
+const approval = @import("approval.zig");
+const approval_http = @import("approval_http.zig");
 
 const keys = nostr.keys;
 const nip46 = nostr.nip46;
@@ -85,15 +87,50 @@ pub fn main() !void {
     const pk_hex = try hex.encode(gpa, &kp.public_key);
     defer gpa.free(pk_hex);
 
+    // Interactive (GUI) mode: when SIGNER_APPROVAL_HTTP is set, stand up the
+    // loopback approval API and hand every relay thread a broker so requests are
+    // held for the GUI instead of auto-approved. The broker/server live in this
+    // frame (which never returns — the threads are joined below), so their
+    // addresses are stable for the lifetime of the process.
+    var broker_storage: approval.Broker = .{};
+    var approval_server: approval_http.Server = undefined;
+    const broker_ptr: ?*approval.Broker = if (getEnv("SIGNER_APPROVAL_HTTP")) |addr| blk: {
+        const token_path = getEnv("SIGNER_APPROVAL_TOKEN_FILE") orelse
+            fail("SIGNER_APPROVAL_HTTP requires SIGNER_APPROVAL_TOKEN_FILE (where to write the API token)");
+        const hp = parseHostPort(addr) orelse
+            fail("SIGNER_APPROVAL_HTTP must be host:port, e.g. 127.0.0.1:8787");
+        const token_hex = makeAndWriteToken(gpa, token_path);
+        approval_server = .{
+            .gpa = gpa,
+            .broker = &broker_storage,
+            .token = token_hex,
+            .info = .{ .pubkey_hex = pk_hex, .relays = relays.items, .timeout_ms = broker_storage.timeout_ms },
+            .host = hp.host,
+            .port = hp.port,
+        };
+        const server_thread = std.Thread.spawn(.{}, runApprovalServer, .{&approval_server}) catch
+            fail("could not start the approval server");
+        server_thread.detach();
+        std.debug.print("signer: approval API on http://{s} (bearer token written to {s})\n", .{ addr, token_path });
+        break :blk &broker_storage;
+    } else null;
+
+    const approval_note = if (broker_ptr != null)
+        "held until you approve them in the connected GUI"
+    else if (conn_secret == null)
+        "auto-approved (no connection secret set)"
+    else
+        "auto-approved behind the connection secret";
+
     std.debug.print(
         \\zig-nostr signer (headless)
         \\  pubkey : {s}
         \\  bunker : {s}
         \\
         \\Share the bunker:// token with a client to connect. Requests are
-        \\auto-approved{s}. Press Ctrl-C to stop.
+        \\{s}. Press Ctrl-C to stop.
         \\
-    , .{ pk_hex, token, if (conn_secret == null) " (no connection secret set)" else "" });
+    , .{ pk_hex, token, approval_note });
 
     // Serve each relay on its own thread. Each thread owns its secp256k1
     // context and bunker, so nothing mutable is shared between them; the only
@@ -101,7 +138,7 @@ pub fn main() !void {
     var threads: std.ArrayList(std.Thread) = .empty;
     defer threads.deinit(gpa);
     for (relays.items) |url| {
-        const t = std.Thread.spawn(.{}, serveRelayForever, .{ gpa, url, secret_key, conn_secret, &policy_config }) catch |err| {
+        const t = std.Thread.spawn(.{}, serveRelayForever, .{ gpa, url, secret_key, conn_secret, &policy_config, broker_ptr }) catch |err| {
             std.debug.print("signer: [{s}] could not start: {s}\n", .{ url, @errorName(err) });
             continue;
         };
@@ -120,6 +157,7 @@ fn serveRelayForever(
     secret_key: [32]u8,
     conn_secret: ?[]const u8,
     policy_config: *const policy.Config,
+    broker: ?*approval.Broker,
 ) void {
     var threaded = std.Io.Threaded.init(gpa, .{});
     defer threaded.deinit();
@@ -132,7 +170,19 @@ fn serveRelayForever(
         return;
     };
 
-    var bunker = nip46.Bunker.initSingleKey(signer, kp, policy_config.policy());
+    // In GUI mode the interactive policy escalates to the broker (which blocks
+    // this thread until the GUI decides); otherwise the static allowlist policy
+    // decides. `interactive` lives for this forever-looping frame, so the policy
+    // may hold a pointer to it.
+    var interactive = approval.Interactive{
+        .broker = broker orelse undefined,
+        .config = policy_config,
+        .io = io,
+        .gpa = gpa,
+    };
+    const request_policy = if (broker != null) interactive.asPolicy() else policy_config.policy();
+
+    var bunker = nip46.Bunker.initSingleKey(signer, kp, request_policy);
     bunker.secret = conn_secret;
 
     while (true) {
@@ -283,6 +333,45 @@ fn buildPolicyConfig(gpa: std.mem.Allocator) policy.Config {
     return cfg;
 }
 
+const HostPort = struct { host: []const u8, port: u16 };
+
+/// Parses a `host:port` string (e.g. `127.0.0.1:8787`).
+fn parseHostPort(s: []const u8) ?HostPort {
+    const colon = std.mem.lastIndexOfScalar(u8, s, ':') orelse return null;
+    const host = s[0..colon];
+    if (host.len == 0) return null;
+    const port = std.fmt.parseInt(u16, s[colon + 1 ..], 10) catch return null;
+    return .{ .host = host, .port = port };
+}
+
+/// Generates a fresh random bearer token, writes it to `path` as a `0600` file
+/// (overwriting a stale one), and returns the hex token (owned, process-lived).
+fn makeAndWriteToken(gpa: std.mem.Allocator, path: []const u8) []u8 {
+    var startup = std.Io.Threaded.init(gpa, .{});
+    defer startup.deinit();
+    const io = startup.io();
+
+    var raw: [24]u8 = undefined;
+    io.randomSecure(&raw) catch |err| failFmt("could not generate an API token: {s}", .{@errorName(err)});
+    const token_hex = hex.encode(gpa, &raw) catch fail("out of memory generating the API token");
+
+    std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = path,
+        .data = token_hex,
+        .flags = .{ .truncate = true, .permissions = std.Io.File.Permissions.fromMode(0o600) },
+    }) catch |err| failFmt("could not write the token file '{s}': {s}", .{ path, @errorName(err) });
+    return token_hex;
+}
+
+/// Runs the approval HTTP server on its own thread with its own io.
+fn runApprovalServer(server: *approval_http.Server) void {
+    var threaded = std.Io.Threaded.init(server.gpa, .{});
+    defer threaded.deinit();
+    server.run(threaded.io()) catch |err| {
+        std.debug.print("signer: approval server stopped: {s}\n", .{@errorName(err)});
+    };
+}
+
 fn getEnv(name: [*:0]const u8) ?[]const u8 {
     const value = std.c.getenv(name) orelse return null;
     return std.mem.span(value);
@@ -306,6 +395,8 @@ test {
     _ = @import("serve.zig");
     _ = @import("keystore.zig");
     _ = @import("policy.zig");
+    _ = @import("approval.zig");
+    _ = @import("approval_http.zig");
 }
 
 test "derives the pubkey and builds a bunker token" {

--- a/src/policy.zig
+++ b/src/policy.zig
@@ -72,7 +72,7 @@ fn decide(ctx: ?*anyopaque, request: *const nip46.Request) nip46.Decision {
 
 /// Parses the `kind` from a `sign_event` request's event template (params[0]),
 /// or null if it is missing or unparseable (the caller treats null as "deny").
-fn signEventKind(gpa: std.mem.Allocator, request: *const nip46.Request) ?u16 {
+pub fn signEventKind(gpa: std.mem.Allocator, request: *const nip46.Request) ?u16 {
     if (request.params.len < 1) return null;
     const parsed = std.json.parseFromSlice(
         struct { kind: u16 },


### PR DESCRIPTION
The daemon side of the native approval app — **architecture B**: the daemon keeps holding the key and doing all Nostr/relay work, and a separate GUI (a follow-up, in its own repo) approves requests over a loopback-only HTTP API. The key never enters the GUI process.

## What

- **`src/approval.zig`** — a thread-safe approval `Broker` + an interactive `nip46.Policy`. The policy pre-filters through the static allowlist we already ship, then escalates anything it permits to the broker, **blocking the relay thread until the GUI resolves it** (or a timeout denies it, so a relay thread never blocks forever). The broker is independent of the `std.Io` model: an atomic spinlock guards the small pending array (contention is near-zero — approvals are human-paced) and each entry carries an atomic decision slot; only the submit poll-wait uses `io.sleep`, exactly as the reconnect loop already does.
- **`src/approval_http.zig`** — a minimal, hardened HTTP server bound to **loopback only**: `GET /pending` (long-poll so the GUI loops fetch→refetch without busy-polling), `POST /decision`, `GET /info`. Every request needs `Authorization: Bearer <token>`; the token is generated at startup and written `0600`. Fixed routes, no keep-alive, bounded reads — deliberately tiny to keep the key-holding daemon's attack surface small.
- **`src/main.zig`** — `SIGNER_APPROVAL_HTTP` + `SIGNER_APPROVAL_TOKEN_FILE` turn on GUI mode; each relay thread then uses the interactive policy instead of auto-approve.
- Also fixes a stale README roadmap checkbox (NIP-49 storage was already shipped in #3).

## Why HTTP + loopback

The GUI will be a Native SDK app whose idiomatic external-data path is `fx.fetch` (HTTP). Loopback HTTP + a `0600` bearer-token file gives the GUI a clean client while keeping the daemon minimal and the key isolated to the daemon process.

## Testing

- Hermetic tests (`zig build test`, 18/18): the broker across **real threads** (approve, timeout-denies, allowlist pre-filter that never enqueues a disallowed request), and the HTTP request parsing / bearer auth.
- Verified live end to end with `curl` against a running daemon: `GET /info` returns the pubkey + relays, `GET /pending` long-polls then returns the (empty) queue, `POST /decision` resolves, a bad token is `401`, an unknown route is `404`.

Roadmap: ticks off the loopback approval API. The native GUI app that consumes it is the next slice (new repo).