### PR TITLE
feat: first-run key onboarding over the approval API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ native clients over a relay — the secret key never reaches the client.
 > roadmap. The current build loads an encrypted (NIP-49) key from disk, connects
 > to your relays, and answers NIP-46 requests — `get_public_key`, `sign_event`,
 > `ping`, and NIP-44 encrypt/decrypt — behind the connection secret and an
-> optional method/event-kind allowlist. It can also run in **GUI mode**, holding
-> each request for interactive approval over a loopback API — the key never
+> optional method/event-kind allowlist. It can also run in **GUI mode**: it
+> holds each request for interactive approval over a loopback API, and can
+> create or unlock the key on first run from that same API — the key never
 > leaves the daemon. The native approval app itself is landing next.
 
 ## Build
@@ -81,20 +82,32 @@ daemon serves a small **loopback-only** HTTP API that a separate GUI connects
 to, so you approve or deny each request on screen. The key never leaves the
 daemon — the GUI only ever sees request metadata and sends back a yes/no.
 
+In GUI mode the daemon can also boot **without a key** and let the GUI set one
+up on first run, so a freshly downloaded app is turnkey. It reports its key
+state on `GET /info` (`uninitialized` → `locked` → `unlocked`); the GUI creates
+a key with `POST /setup` (generate a fresh one, or import an existing `nsec1…`
+or 64-char hex) or decrypts an existing key file with `POST /unlock`. The key is
+generated and decrypted inside the daemon — only the passphrase (and, on import,
+the secret you type) ever crosses the API, never a derived key.
+
 ```sh
-SIGNER_KEY_FILE="$HOME/.zig-nostr-signer.ncryptsec" \
-SIGNER_PASSPHRASE="a strong passphrase" \
-SIGNER_RELAYS="wss://relay.example.com" \
+# Turnkey: no key file and no passphrase on the command line — the GUI provides
+# them. SIGNER_KEY_FILE ($HOME/.zig-nostr-signer.key), SIGNER_APPROVAL_TOKEN_FILE
+# ($HOME/.zig-nostr-signer.token) and SIGNER_RELAYS all default in this mode, so
+# this alone is enough:
 SIGNER_APPROVAL_HTTP="127.0.0.1:8787" \
-SIGNER_APPROVAL_TOKEN_FILE="$HOME/.zig-nostr-signer.token" \
   zig build run
 ```
 
+You can still preconfigure the key instead of onboarding it — set
+`SIGNER_KEY_FILE` + `SIGNER_PASSPHRASE` (or the dev-only `SIGNER_SECRET_KEY`) and
+the daemon boots straight to `unlocked`.
+
 The API is bound to loopback and every request must carry the bearer token
-written (mode `0600`) to `SIGNER_APPROVAL_TOKEN_FILE`. Endpoints: `GET /pending`
-(long-poll), `POST /decision`, `GET /info`. A request left unanswered past the
-timeout is denied, and the allowlist still applies first — so disallowed
-requests are rejected without ever prompting.
+written (mode `0600`) to `SIGNER_APPROVAL_TOKEN_FILE`. Endpoints: `GET /info`,
+`POST /setup`, `POST /unlock`, `GET /pending` (long-poll), `POST /decision`. A
+request left unanswered past the timeout is denied, and the allowlist still
+applies first — so disallowed requests are rejected without ever prompting.
 
 ## Roadmap
 
@@ -103,6 +116,7 @@ requests are rejected without ever prompting.
 - [x] Encrypted key storage at rest (NIP-49 `ncryptsec`)
 - [x] Per-request approval policy (method + event-kind allowlists)
 - [x] Loopback approval API for interactive GUI approval
+- [x] First-run key onboarding over the approval API (generate / import / unlock)
 - [ ] Native macOS approval app + downloadable build
 
 ## License

--- a/src/approval_http.zig
+++ b/src/approval_http.zig
@@ -4,9 +4,16 @@
 //! Deliberately tiny (fixed routes, no keep-alive, no chunked encoding) to keep
 //! the key-holding daemon's attack surface small:
 //!
+//!   GET  /info              {"state":..,"pubkey":..,"relays":[..],"timeout_ms":N}
+//!   POST /setup             {"passphrase":..,"secret":..?} → create/import a key
+//!   POST /unlock            {"passphrase":..} → decrypt the key file
 //!   GET  /pending?since=N   long-poll (~1s) → {"version":N,"pending":[...]}
 //!   POST /decision          {"id":N,"decision":"approve"|"reject"} → {"ok":bool}
-//!   GET  /info              {"pubkey":"..","relays":[..],"timeout_ms":N}
+//!
+//! `/info` reports the key state (`uninitialized`/`locked`/`unlocked`); the GUI
+//! drives first-run key onboarding through `/setup` and `/unlock`. The key is
+//! created and decrypted in the daemon — only the passphrase (and, on import,
+//! the operator's chosen secret) crosses the API, never a derived key.
 //!
 //! Every request must carry `Authorization: Bearer <token>`; the token is
 //! generated at startup and written to a 0600 file only the same user can read.
@@ -14,13 +21,14 @@
 
 const std = @import("std");
 const approval = @import("approval.zig");
+const onboarding = @import("onboarding.zig");
 
 const net = std.Io.net;
 const Broker = approval.Broker;
 const Pending = approval.Pending;
+const Gate = onboarding.Gate;
 
 pub const Info = struct {
-    pubkey_hex: []const u8,
     relays: []const []const u8,
     timeout_ms: u64,
 };
@@ -28,6 +36,10 @@ pub const Info = struct {
 pub const Server = struct {
     gpa: std.mem.Allocator,
     broker: *Broker,
+    /// Key-onboarding gate: reports its state on /info and is driven by /setup
+    /// and /unlock. The key it guards is created/decrypted in the daemon and
+    /// never crosses this API.
+    gate: *Gate,
     /// Bearer token clients must present.
     token: []const u8,
     info: Info,
@@ -83,6 +95,9 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
     // filled the whole buffer or hit EOF — a deadlock when the client sends a
     // short request and then waits for our response).
     var buf: [8192]u8 = undefined;
+    // A /setup or /unlock body carries a passphrase (and maybe an nsec) in these
+    // stack buffers; wipe them before the frame unwinds.
+    defer std.crypto.secureZero(u8, &buf);
     var len: usize = 0;
     const head_end = while (true) {
         if (len >= buf.len) return respond(w, 431, "{\"error\":\"headers too large\"}");
@@ -111,6 +126,7 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
 
     // Assemble the body: bytes already read after the head, plus any remainder.
     var body_storage: [4096]u8 = undefined;
+    defer std.crypto.secureZero(u8, &body_storage);
     var body: []const u8 = "";
     if (content_length > 0) {
         if (content_length > body_storage.len) return respond(w, 413, "{\"error\":\"body too large\"}");
@@ -125,12 +141,16 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
         body = body_storage[0..got];
     }
 
+    if (eql(method, "GET") and eql(path, "/info"))
+        return handleInfo(self, w);
+    if (eql(method, "POST") and eql(path, "/setup"))
+        return handleSetup(self, io, w, body);
+    if (eql(method, "POST") and eql(path, "/unlock"))
+        return handleUnlock(self, io, w, body);
     if (eql(method, "GET") and std.mem.startsWith(u8, path, "/pending"))
         return handlePending(self, io, w, path);
     if (eql(method, "POST") and eql(path, "/decision"))
         return handleDecision(self, w, body);
-    if (eql(method, "GET") and eql(path, "/info"))
-        return handleInfo(self, w);
     return respond(w, 404, "{\"error\":\"not found\"}");
 }
 
@@ -183,9 +203,18 @@ fn handleDecision(self: *Server, w: *std.Io.Writer, body: []const u8) !void {
 }
 
 fn handleInfo(self: *Server, w: *std.Io.Writer) !void {
+    const state = self.gate.current();
+    const state_str = switch (state) {
+        .uninitialized => "uninitialized",
+        .locked => "locked",
+        .unlocked => "unlocked",
+    };
+    // The pubkey is known only once unlocked; report "" until then.
+    const pubkey = if (state == .unlocked) self.gate.pubkeyHex() else "";
+
     var json: std.ArrayList(u8) = .empty;
     defer json.deinit(self.gpa);
-    const head = try std.fmt.allocPrint(self.gpa, "{{\"pubkey\":\"{s}\",\"timeout_ms\":{d},\"relays\":[", .{ self.info.pubkey_hex, self.info.timeout_ms });
+    const head = try std.fmt.allocPrint(self.gpa, "{{\"state\":\"{s}\",\"pubkey\":\"{s}\",\"timeout_ms\":{d},\"relays\":[", .{ state_str, pubkey, self.info.timeout_ms });
     defer self.gpa.free(head);
     try json.appendSlice(self.gpa, head);
     for (self.info.relays, 0..) |relay, i| {
@@ -196,6 +225,46 @@ fn handleInfo(self: *Server, w: *std.Io.Writer) !void {
     }
     try json.appendSlice(self.gpa, "]}");
     return respond(w, 200, json.items);
+}
+
+/// POST /setup — first-run key creation. Body: `{"passphrase":..,"secret":..?}`.
+/// A non-empty `secret` (an `nsec1…` or 64-char hex) imports an existing key;
+/// absent/empty generates a fresh one. The key is created and encrypted in the
+/// daemon; only the derived public key is returned.
+fn handleSetup(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !void {
+    const Body = struct { passphrase: []const u8 = "", secret: []const u8 = "" };
+    const parsed = std.json.parseFromSlice(Body, self.gpa, body, .{ .ignore_unknown_fields = true }) catch
+        return respond(w, 400, bad_request);
+    defer parsed.deinit();
+
+    self.gate.setup(io, parsed.value.passphrase, parsed.value.secret) catch |err| return switch (err) {
+        error.AlreadyInitialized => respond(w, 409, "{\"error\":\"already initialized\"}"),
+        error.EmptyPassphrase => respond(w, 400, "{\"error\":\"passphrase required\"}"),
+        error.InvalidSecretKey => respond(w, 400, "{\"error\":\"invalid secret key\"}"),
+        else => respond(w, 500, "{\"error\":\"could not create the key\"}"),
+    };
+    return respondPubkey(self, w);
+}
+
+/// POST /unlock — decrypt an existing key file. Body: `{"passphrase":".."}`.
+fn handleUnlock(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !void {
+    const Body = struct { passphrase: []const u8 = "" };
+    const parsed = std.json.parseFromSlice(Body, self.gpa, body, .{ .ignore_unknown_fields = true }) catch
+        return respond(w, 400, bad_request);
+    defer parsed.deinit();
+
+    self.gate.unlock(io, parsed.value.passphrase) catch |err| return switch (err) {
+        error.BadPassphrase => respond(w, 401, "{\"error\":\"bad passphrase\"}"),
+        error.NotLocked => respond(w, 409, "{\"error\":\"not locked\"}"),
+        else => respond(w, 500, "{\"error\":\"could not unlock\"}"),
+    };
+    return respondPubkey(self, w);
+}
+
+fn respondPubkey(self: *Server, w: *std.Io.Writer) !void {
+    var out: [128]u8 = undefined;
+    const j = std.fmt.bufPrint(&out, "{{\"ok\":true,\"pubkey\":\"{s}\"}}", .{self.gate.pubkeyHex()}) catch unreachable;
+    return respond(w, 200, j);
 }
 
 // --- HTTP plumbing -------------------------------------------------------
@@ -216,8 +285,10 @@ fn reason(status: u16) []const u8 {
         400 => "Bad Request",
         401 => "Unauthorized",
         404 => "Not Found",
+        409 => "Conflict",
         413 => "Payload Too Large",
         431 => "Request Header Fields Too Large",
+        500 => "Internal Server Error",
         else => "Error",
     };
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,11 +15,19 @@ const keystore = @import("keystore.zig");
 const policy = @import("policy.zig");
 const approval = @import("approval.zig");
 const approval_http = @import("approval_http.zig");
+const onboarding = @import("onboarding.zig");
 
 const keys = nostr.keys;
 const nip46 = nostr.nip46;
 const nip49 = nostr.nip49;
 const hex = nostr.hex;
+
+// Turnkey defaults for GUI mode, so a freshly downloaded app works with zero
+// configuration; each is overridable via its environment variable. The key and
+// token files sit under $HOME; relays default to a public relay.
+const default_token_file = ".zig-nostr-signer.token";
+const default_key_file = ".zig-nostr-signer.key";
+const default_gui_relays = "wss://relay.damus.io";
 
 const usage =
     \\zig-nostr signer — headless NIP-46 remote signer (bunker)
@@ -53,69 +61,128 @@ pub fn main() !void {
     // `SIGNER_INIT` bootstraps an encrypted key file at rest, then exits.
     if (getEnv("SIGNER_INIT") != null) runInit(gpa);
 
-    const relays_env = getEnv("SIGNER_RELAYS") orelse
-        fail("set SIGNER_RELAYS to a comma-separated list of wss:// URLs");
     const conn_secret = getEnv("SIGNER_CONNECT_SECRET");
 
     // Authorization rules, parsed once and shared read-only across relay threads.
     const policy_config = buildPolicyConfig(gpa);
 
+    // GUI mode: when SIGNER_APPROVAL_HTTP is set, the daemon may boot WITHOUT a
+    // key. It stands up the loopback approval API first (reporting its key
+    // state), lets the connected GUI create or unlock the key over /setup and
+    // /unlock, and only then serves. The key is created/decrypted in the daemon;
+    // the GUI never receives it. See onboarding.zig + approval_http.zig.
+    if (getEnv("SIGNER_APPROVAL_HTTP")) |addr| {
+        runGuiMode(gpa, addr, conn_secret, &policy_config);
+    }
+
+    // Headless mode: the key must already be available (from an encrypted key
+    // file or the dev-only SIGNER_SECRET_KEY), and relays are required up front.
+    const relays_env = getEnv("SIGNER_RELAYS") orelse
+        fail("set SIGNER_RELAYS to a comma-separated list of wss:// URLs");
+    var relays: std.ArrayList([]const u8) = .empty;
+    parseRelays(gpa, &relays, relays_env);
+    if (relays.items.len == 0) fail("SIGNER_RELAYS contained no relay URLs");
+
     // Load the secret key once (decrypting the at-rest key file if configured).
     // The deliberately-expensive scrypt KDF runs here and only here; the relay
-    // threads below receive the already-derived 32-byte key, so no per-request
-    // or per-connection key derivation ever happens.
+    // threads receive the already-derived 32-byte key, so no per-request or
+    // per-connection key derivation ever happens.
     const secret_key = loadSecretKey(gpa);
+    runRelays(gpa, relays.items, secret_key, conn_secret, &policy_config, null);
+}
 
+/// GUI mode: stand up the approval API (key-less if there is no key yet), run
+/// first-run key onboarding over it, then serve with the resulting key. The
+/// broker and server live in this frame, which never returns (it tail-calls the
+/// forever-serving `runRelays`), so their addresses are stable for the process.
+fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8, policy_config: *const policy.Config) noreturn {
+    const hp = parseHostPort(addr) orelse
+        fail("SIGNER_APPROVAL_HTTP must be host:port, e.g. 127.0.0.1:8787");
+
+    // Turnkey defaults so a fresh download needs no configuration.
+    const token_path = getEnv("SIGNER_APPROVAL_TOKEN_FILE") orelse resolveHome(gpa, default_token_file);
+    const key_file = getEnv("SIGNER_KEY_FILE") orelse resolveHome(gpa, default_key_file);
+    const relays_env = getEnv("SIGNER_RELAYS") orelse default_gui_relays;
+
+    var relays: std.ArrayList([]const u8) = .empty;
+    parseRelays(gpa, &relays, relays_env);
+    if (relays.items.len == 0) fail("SIGNER_RELAYS contained no relay URLs");
+
+    var startup = std.Io.Threaded.init(gpa, .{});
+    defer startup.deinit();
+    const io = startup.io();
+
+    // No key file yet → the GUI must create one; an encrypted file present →
+    // the GUI must unlock it.
+    const initial: onboarding.State = if (fileExists(io, key_file)) .locked else .uninitialized;
+
+    var broker_storage: approval.Broker = .{};
+    var gate = onboarding.Gate.init(gpa, std.Io.Dir.cwd(), key_file, initial);
+
+    // Honor a preconfigured key (dev SIGNER_SECRET_KEY, or an existing key file
+    // plus SIGNER_PASSPHRASE) so an operator can still bring their own; when none
+    // is configured — the turnkey case — the GUI onboards one over the API.
+    if (guiPreloadKey(gpa, io, key_file)) |kp| gate.preload(kp);
+    const booted = gate.current();
+
+    const token_hex = makeAndWriteToken(gpa, token_path);
+    var approval_server: approval_http.Server = .{
+        .gpa = gpa,
+        .broker = &broker_storage,
+        .gate = &gate,
+        .token = token_hex,
+        .info = .{ .relays = relays.items, .timeout_ms = broker_storage.timeout_ms },
+        .host = hp.host,
+        .port = hp.port,
+    };
+    const server_thread = std.Thread.spawn(.{}, runApprovalServer, .{&approval_server}) catch
+        fail("could not start the approval server");
+    server_thread.detach();
+
+    const key_note = switch (booted) {
+        .unlocked => "Key loaded from the environment; serving now.",
+        .locked => "Waiting for the GUI to unlock the key…",
+        .uninitialized => "Waiting for the GUI to set up the key…",
+    };
+    std.debug.print(
+        \\zig-nostr signer (GUI mode)
+        \\  approval API : http://{s}  (bearer token → {s})
+        \\  key file     : {s}
+        \\  key state    : {s}
+        \\
+        \\{s}
+        \\
+    , .{ addr, token_path, key_file, @tagName(booted), key_note });
+
+    // Block until the GUI creates or unlocks the key (returns at once if a
+    // preconfigured key was loaded above), then serve with it. The broker is
+    // already live, so approvals work the moment serving starts.
+    const secret_key = gate.waitUnlocked(io);
+    runRelays(gpa, relays.items, secret_key, conn_secret, policy_config, &broker_storage);
+}
+
+/// Derives the keypair, prints the connection banner, and serves every relay on
+/// its own thread until stopped. Each thread owns its secp256k1 context and
+/// bunker, so nothing mutable is shared between them; the only shared state is
+/// the read-only key material and the allocator. Never returns.
+fn runRelays(
+    gpa: std.mem.Allocator,
+    relays: []const []const u8,
+    secret_key: [32]u8,
+    conn_secret: ?[]const u8,
+    policy_config: *const policy.Config,
+    broker: ?*approval.Broker,
+) noreturn {
     var signer = keys.Signer.init();
     defer signer.deinit();
-
     const kp = signer.keyPairFromSecretKey(secret_key) catch
         fail("the configured key is not a valid secp256k1 secret key");
 
-    var relays: std.ArrayList([]const u8) = .empty;
-    defer relays.deinit(gpa);
-    var it = std.mem.splitScalar(u8, relays_env, ',');
-    while (it.next()) |raw| {
-        const url = std.mem.trim(u8, raw, " \t");
-        if (url.len != 0) try relays.append(gpa, url);
-    }
-    if (relays.items.len == 0) fail("SIGNER_RELAYS contained no relay URLs");
+    const token = nip46.buildBunkerUri(gpa, kp.public_key, relays, conn_secret) catch
+        fail("out of memory building the bunker token");
+    const pk_hex = hex.encode(gpa, &kp.public_key) catch fail("out of memory encoding the public key");
 
-    const token = try nip46.buildBunkerUri(gpa, kp.public_key, relays.items, conn_secret);
-    defer gpa.free(token);
-
-    const pk_hex = try hex.encode(gpa, &kp.public_key);
-    defer gpa.free(pk_hex);
-
-    // Interactive (GUI) mode: when SIGNER_APPROVAL_HTTP is set, stand up the
-    // loopback approval API and hand every relay thread a broker so requests are
-    // held for the GUI instead of auto-approved. The broker/server live in this
-    // frame (which never returns — the threads are joined below), so their
-    // addresses are stable for the lifetime of the process.
-    var broker_storage: approval.Broker = .{};
-    var approval_server: approval_http.Server = undefined;
-    const broker_ptr: ?*approval.Broker = if (getEnv("SIGNER_APPROVAL_HTTP")) |addr| blk: {
-        const token_path = getEnv("SIGNER_APPROVAL_TOKEN_FILE") orelse
-            fail("SIGNER_APPROVAL_HTTP requires SIGNER_APPROVAL_TOKEN_FILE (where to write the API token)");
-        const hp = parseHostPort(addr) orelse
-            fail("SIGNER_APPROVAL_HTTP must be host:port, e.g. 127.0.0.1:8787");
-        const token_hex = makeAndWriteToken(gpa, token_path);
-        approval_server = .{
-            .gpa = gpa,
-            .broker = &broker_storage,
-            .token = token_hex,
-            .info = .{ .pubkey_hex = pk_hex, .relays = relays.items, .timeout_ms = broker_storage.timeout_ms },
-            .host = hp.host,
-            .port = hp.port,
-        };
-        const server_thread = std.Thread.spawn(.{}, runApprovalServer, .{&approval_server}) catch
-            fail("could not start the approval server");
-        server_thread.detach();
-        std.debug.print("signer: approval API on http://{s} (bearer token written to {s})\n", .{ addr, token_path });
-        break :blk &broker_storage;
-    } else null;
-
-    const approval_note = if (broker_ptr != null)
+    const approval_note = if (broker != null)
         "held until you approve them in the connected GUI"
     else if (conn_secret == null)
         "auto-approved (no connection secret set)"
@@ -123,7 +190,7 @@ pub fn main() !void {
         "auto-approved behind the connection secret";
 
     std.debug.print(
-        \\zig-nostr signer (headless)
+        \\zig-nostr signer
         \\  pubkey : {s}
         \\  bunker : {s}
         \\
@@ -131,21 +198,70 @@ pub fn main() !void {
         \\{s}. Press Ctrl-C to stop.
         \\
     , .{ pk_hex, token, approval_note });
+    gpa.free(token);
+    gpa.free(pk_hex);
 
-    // Serve each relay on its own thread. Each thread owns its secp256k1
-    // context and bunker, so nothing mutable is shared between them; the only
-    // shared state is the read-only key material and the allocator.
     var threads: std.ArrayList(std.Thread) = .empty;
-    defer threads.deinit(gpa);
-    for (relays.items) |url| {
-        const t = std.Thread.spawn(.{}, serveRelayForever, .{ gpa, url, secret_key, conn_secret, &policy_config, broker_ptr }) catch |err| {
+    for (relays) |url| {
+        const t = std.Thread.spawn(.{}, serveRelayForever, .{ gpa, url, secret_key, conn_secret, policy_config, broker }) catch |err| {
             std.debug.print("signer: [{s}] could not start: {s}\n", .{ url, @errorName(err) });
             continue;
         };
-        try threads.append(gpa, t);
+        threads.append(gpa, t) catch fail("out of memory tracking relay threads");
     }
     if (threads.items.len == 0) fail("could not start any relay connections");
     for (threads.items) |t| t.join();
+    std.process.exit(0); // relay threads loop forever; reached only if all exit
+}
+
+/// Splits a comma-separated relay list into `list`, trimming and skipping empties.
+fn parseRelays(gpa: std.mem.Allocator, list: *std.ArrayList([]const u8), csv: []const u8) void {
+    var it = std.mem.splitScalar(u8, csv, ',');
+    while (it.next()) |raw| {
+        const url = std.mem.trim(u8, raw, " \t");
+        if (url.len != 0) list.append(gpa, url) catch fail("out of memory parsing SIGNER_RELAYS");
+    }
+}
+
+/// Resolves `$HOME/name`, or `name` alone if HOME is unset. The result is
+/// process-lived (the env string is, and an allocPrint uses the page allocator).
+fn resolveHome(gpa: std.mem.Allocator, name: []const u8) []const u8 {
+    if (getEnv("HOME")) |home| return std.fmt.allocPrint(gpa, "{s}/{s}", .{ home, name }) catch name;
+    return name;
+}
+
+/// Whether `path` exists (as a `Dir.cwd()` sub-path; an absolute path works too).
+fn fileExists(io: std.Io, path: []const u8) bool {
+    std.Io.Dir.cwd().access(io, path, .{}) catch return false;
+    return true;
+}
+
+/// In GUI mode, loads a key straight from the environment when one is fully
+/// specified — `SIGNER_SECRET_KEY` (dev), or an existing key file together with
+/// `SIGNER_PASSPHRASE` — so an operator can still preconfigure the key. Returns
+/// null (→ the GUI onboards the key) only when nothing is configured; a bad key
+/// or wrong passphrase still fails loudly rather than silently onboarding.
+fn guiPreloadKey(gpa: std.mem.Allocator, io: std.Io, key_file: []const u8) ?keys.KeyPair {
+    var signer = keys.Signer.init();
+    defer signer.deinit();
+
+    if (getEnv("SIGNER_SECRET_KEY")) |secret_hex| {
+        const sk = hex.decodeFixed(32, secret_hex) catch fail("SIGNER_SECRET_KEY must be exactly 64 hex characters");
+        return signer.keyPairFromSecretKey(sk) catch fail("SIGNER_SECRET_KEY is not a valid secp256k1 secret key");
+    }
+    if (getEnv("SIGNER_PASSPHRASE")) |passphrase| {
+        // Only unlock from the environment when the file is actually there;
+        // otherwise fall through so the GUI can create one.
+        if (fileExists(io, key_file)) {
+            const ncryptsec = keystore.readKeyFile(gpa, io, std.Io.Dir.cwd(), key_file) catch |err|
+                failFmt("could not read SIGNER_KEY_FILE '{s}': {s}", .{ key_file, @errorName(err) });
+            defer gpa.free(ncryptsec);
+            const sk = keystore.decryptKey(gpa, ncryptsec, passphrase) catch
+                fail("could not decrypt the key file (wrong SIGNER_PASSPHRASE?)");
+            return signer.keyPairFromSecretKey(sk) catch fail("the key file holds an invalid secret key");
+        }
+    }
+    return null;
 }
 
 /// Connects to `url` and serves requests forever, reconnecting after a short
@@ -397,6 +513,7 @@ test {
     _ = @import("policy.zig");
     _ = @import("approval.zig");
     _ = @import("approval_http.zig");
+    _ = @import("onboarding.zig");
 }
 
 test "derives the pubkey and builds a bunker token" {

--- a/src/onboarding.zig
+++ b/src/onboarding.zig
@@ -1,0 +1,253 @@
+//! First-run key onboarding for GUI mode.
+//!
+//! In GUI mode the daemon may boot without a key. This gate lets the connected
+//! GUI create one — generate a fresh key, or import an existing `nsec1…`/hex —
+//! or unlock an existing encrypted key file, all over the loopback approval API
+//! (see `approval_http.zig`). The secret key is generated and decrypted HERE,
+//! inside the key-holding daemon; only the passphrase (and, on import, the
+//! secret the operator chose to type) ever crosses the API. The key itself is
+//! never serialized back — the GUI only learns the derived public key.
+//!
+//! Once a key is available the gate publishes it to the serving path, which
+//! blocks in `waitUnlocked` until then. The handoff is a single atomic flip
+//! (release/acquire) — the same io-model-independent idiom the broker uses —
+//! so no key derivation happens on any request path.
+
+const std = @import("std");
+const nostr = @import("nostr");
+const keystore = @import("keystore.zig");
+
+const keys = nostr.keys;
+const nip19 = nostr.nip19;
+const nip49 = nostr.nip49;
+const hex = nostr.hex;
+const Dir = std.Io.Dir;
+
+pub const State = enum(u8) {
+    /// No key file yet — the GUI must `setup` (generate or import) one.
+    uninitialized,
+    /// A key file exists but is still encrypted — the GUI must `unlock` it.
+    locked,
+    /// The key is loaded and the daemon can serve.
+    unlocked,
+};
+
+pub const SetupError = error{ AlreadyInitialized, EmptyPassphrase, InvalidSecretKey, EncryptFailed, WriteFailed };
+pub const UnlockError = error{ NotLocked, BadPassphrase, ReadFailed };
+
+/// Coordinates the key-less boot with the setup/unlock handlers. Lives in the
+/// daemon's `main` frame (which never returns), so the HTTP server may hold a
+/// pointer to it for the process's lifetime.
+pub const Gate = struct {
+    gpa: std.mem.Allocator,
+    /// Directory holding the key file (the process cwd in production).
+    dir: Dir,
+    /// Encrypted key-file path within `dir`.
+    key_file: []const u8,
+
+    /// `State` as a plain integer for atomic access.
+    state: std.atomic.Value(u8),
+
+    // Published once, under the state flip (`.release`), and read by the serving
+    // path only after it observes `.unlocked` (`.acquire`). Never leaves the
+    // process.
+    secret_key: [32]u8 = undefined,
+    pubkey_hex_buf: [64]u8 = undefined,
+    pubkey_len: usize = 0,
+
+    pub fn init(gpa: std.mem.Allocator, dir: Dir, key_file: []const u8, initial: State) Gate {
+        return .{
+            .gpa = gpa,
+            .dir = dir,
+            .key_file = key_file,
+            .state = std.atomic.Value(u8).init(@intFromEnum(initial)),
+        };
+    }
+
+    pub fn current(self: *const Gate) State {
+        return @enumFromInt(self.state.load(.acquire));
+    }
+
+    /// The derived public key (hex), valid once `current() == .unlocked`.
+    pub fn pubkeyHex(self: *const Gate) []const u8 {
+        return self.pubkey_hex_buf[0..self.pubkey_len];
+    }
+
+    /// Creates the encrypted key file: imports `secret` (an `nsec1…` or 64-char
+    /// hex) when it is non-empty, otherwise generates a fresh key; encrypts it
+    /// with `passphrase` (NIP-49) and writes it `0600`. On success the gate is
+    /// `unlocked` and holds the derived key + public key. Only valid from the
+    /// `uninitialized` state.
+    pub fn setup(self: *Gate, io: std.Io, passphrase: []const u8, secret: []const u8) SetupError!void {
+        if (self.current() != .uninitialized) return error.AlreadyInitialized;
+        if (passphrase.len == 0) return error.EmptyPassphrase;
+
+        var signer = keys.Signer.init();
+        defer signer.deinit();
+
+        // Imported material has unknown provenance (it was typed in), so it is
+        // marked known-insecure in the NIP-49 metadata; a generated key is secure.
+        var security: nip49.KeySecurity = .known_secure;
+        const kp = if (secret.len != 0) blk: {
+            const sk = decodeSecret(self.gpa, secret) orelse return error.InvalidSecretKey;
+            security = .known_insecure;
+            break :blk signer.keyPairFromSecretKey(sk) catch return error.InvalidSecretKey;
+        } else signer.generateKeyPair(io) catch return error.EncryptFailed;
+
+        const ncryptsec = keystore.encryptKey(self.gpa, io, kp.secret_key, passphrase, security) catch
+            return error.EncryptFailed;
+        defer self.gpa.free(ncryptsec);
+
+        keystore.writeNewKeyFile(io, self.dir, self.key_file, ncryptsec) catch |err| switch (err) {
+            keystore.Error.KeyFileExists => return error.AlreadyInitialized,
+            else => return error.WriteFailed,
+        };
+
+        self.publish(kp);
+    }
+
+    /// Decrypts the existing key file with `passphrase`. On success the gate is
+    /// `unlocked` and holds the key + public key. Only valid from the `locked`
+    /// state; a wrong passphrase leaves it `locked` for a retry.
+    pub fn unlock(self: *Gate, io: std.Io, passphrase: []const u8) UnlockError!void {
+        if (self.current() != .locked) return error.NotLocked;
+
+        const ncryptsec = keystore.readKeyFile(self.gpa, io, self.dir, self.key_file) catch
+            return error.ReadFailed;
+        defer self.gpa.free(ncryptsec);
+
+        const sk = keystore.decryptKey(self.gpa, ncryptsec, passphrase) catch return error.BadPassphrase;
+
+        var signer = keys.Signer.init();
+        defer signer.deinit();
+        const kp = signer.keyPairFromSecretKey(sk) catch return error.BadPassphrase;
+        self.publish(kp);
+    }
+
+    /// Marks the gate `unlocked` with a key loaded outside the API — used in GUI
+    /// mode when the operator preconfigured a key in the environment, so the GUI
+    /// skips onboarding. `kp` must already be validated.
+    pub fn preload(self: *Gate, kp: keys.KeyPair) void {
+        self.publish(kp);
+    }
+
+    /// Blocks the calling (serving) thread until the gate is `unlocked`, then
+    /// returns the secret key. Paces with `io.sleep`, exactly like the broker's
+    /// poll-wait, so it never busy-spins.
+    pub fn waitUnlocked(self: *Gate, io: std.Io) [32]u8 {
+        while (self.current() != .unlocked) {
+            io.sleep(std.Io.Duration.fromMilliseconds(100), .awake) catch {};
+        }
+        return self.secret_key;
+    }
+
+    fn publish(self: *Gate, kp: keys.KeyPair) void {
+        self.secret_key = kp.secret_key;
+        const h = hex.encode(self.gpa, &kp.public_key) catch "";
+        defer if (h.len != 0) self.gpa.free(h);
+        const n = @min(h.len, self.pubkey_hex_buf.len);
+        @memcpy(self.pubkey_hex_buf[0..n], h[0..n]);
+        self.pubkey_len = n;
+        // Release: pairs with the acquire in `current()` so a thread that sees
+        // `.unlocked` also sees `secret_key`/`pubkey_hex_buf` fully written.
+        self.state.store(@intFromEnum(State.unlocked), .release);
+    }
+};
+
+/// Decodes a secret key from an `nsec1…` (NIP-19) or a 64-char hex string.
+/// Returns null on anything that is not a well-formed 32-byte key.
+fn decodeSecret(gpa: std.mem.Allocator, s: []const u8) ?[32]u8 {
+    const t = std.mem.trim(u8, s, " \t\r\n");
+    if (std.mem.startsWith(u8, t, "nsec1")) return nip19.decodeNsec(gpa, t) catch null;
+    return hex.decodeFixed(32, t) catch null;
+}
+
+// ---------------------------------------------------------------------------
+// Tests — exercise the gate end to end against a real temp dir: generate,
+// import (nsec + hex), reject bad input, unlock a locked file, and prove the
+// state machine's rails (no double-init, wrong passphrase stays locked).
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+const key_name = "k.ncryptsec";
+
+test "setup generates a key, writes it 0600, and unlocks" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var gate = Gate.init(gpa, tmp.dir, key_name, .uninitialized);
+    try gate.setup(io, "correct horse battery staple", "");
+    try testing.expectEqual(State.unlocked, gate.current());
+    try testing.expectEqual(@as(usize, 64), gate.pubkeyHex().len);
+
+    // The file is a real 0600 ncryptsec that decrypts back to the gate's key.
+    const st = try tmp.dir.statFile(io, key_name, .{});
+    try testing.expectEqual(@as(std.posix.mode_t, 0), st.permissions.toMode() & 0o077);
+    const ncryptsec = try keystore.readKeyFile(gpa, io, tmp.dir, key_name);
+    defer gpa.free(ncryptsec);
+    const sk = try keystore.decryptKey(gpa, ncryptsec, "correct horse battery staple");
+    try testing.expectEqualSlices(u8, &gate.secret_key, &sk);
+}
+
+test "setup imports an existing nsec and round-trips to the same key" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const secret = [_]u8{0x11} ** 32;
+    const nsec = try nip19.encodeNsec(gpa, secret);
+    defer gpa.free(nsec);
+
+    var gate = Gate.init(gpa, tmp.dir, key_name, .uninitialized);
+    try gate.setup(io, "pw", nsec);
+    try testing.expectEqualSlices(u8, &secret, &gate.secret_key);
+}
+
+test "setup accepts a 64-char hex secret" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var gate = Gate.init(gpa, tmp.dir, key_name, .uninitialized);
+    try gate.setup(io, "pw", "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const expect = try hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    try testing.expectEqualSlices(u8, &expect, &gate.secret_key);
+}
+
+test "setup rejects an empty passphrase and an invalid secret, and refuses a second init" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var gate = Gate.init(gpa, tmp.dir, key_name, .uninitialized);
+    try testing.expectError(error.EmptyPassphrase, gate.setup(io, "", ""));
+    try testing.expectError(error.InvalidSecretKey, gate.setup(io, "pw", "not-a-key"));
+    try testing.expectEqual(State.uninitialized, gate.current()); // failures don't advance
+
+    try gate.setup(io, "pw", ""); // now succeeds
+    try testing.expectError(error.AlreadyInitialized, gate.setup(io, "pw", ""));
+}
+
+test "unlock decrypts a locked file and rejects a wrong passphrase" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Create a key with one gate, then unlock it with a fresh (locked) gate.
+    var creator = Gate.init(gpa, tmp.dir, key_name, .uninitialized);
+    try creator.setup(io, "hunter2", "");
+    const created_key = creator.secret_key;
+
+    var gate = Gate.init(gpa, tmp.dir, key_name, .locked);
+    try testing.expectError(error.BadPassphrase, gate.unlock(io, "wrong"));
+    try testing.expectEqual(State.locked, gate.current()); // wrong passphrase → retry
+    try gate.unlock(io, "hunter2");
+    try testing.expectEqual(State.unlocked, gate.current());
+    try testing.expectEqualSlices(u8, &created_key, &gate.secret_key);
+}


### PR DESCRIPTION
Makes a freshly downloaded GUI app turnkey: in GUI mode the daemon can boot **without a key** and let the connected GUI create or unlock one on first run — the secret key is generated and decrypted **inside the daemon** and never crosses the API.

## What changed

**`src/onboarding.zig` (new)** — a `Gate` that owns the key lifecycle. It generates a fresh key or imports an existing `nsec1…`/64-hex, encrypts it (NIP-49, `0600`), or decrypts an existing key file — then publishes the derived key to the serving path via a single atomic release/acquire flip (the same io-model-independent idiom the broker uses, so no key derivation ever lands on a request path). Reuses the existing `keystore` + `nostr.nip19.decodeNsec`.

**`src/approval_http.zig`** — the loopback server is now key-state-aware:
- `GET /info` reports `state` (`uninitialized` → `locked` → `unlocked`) and the pubkey once unlocked.
- `POST /setup {passphrase, secret?}` — create a key (`secret` present = import, absent = generate). `409` if already initialized, `400` on empty passphrase / invalid secret.
- `POST /unlock {passphrase}` — decrypt the key file. `401` on a wrong passphrase (stays locked for a retry).
- Request buffers that carry the passphrase/secret are `secureZero`'d after each connection.

**`src/main.zig`** — GUI mode (`SIGNER_APPROVAL_HTTP` set) now stands up the approval API **first** (key-less if needed), runs onboarding, then serves with the resulting key; the serving tail is extracted into `runRelays`. `SIGNER_KEY_FILE`, `SIGNER_APPROVAL_TOKEN_FILE`, and `SIGNER_RELAYS` all take turnkey defaults in this mode. A preconfigured key (`SIGNER_KEY_FILE` + `SIGNER_PASSPHRASE`, or dev-only `SIGNER_SECRET_KEY`) still boots straight to `unlocked`, so this is **non-breaking**. Headless mode and `SIGNER_INIT` are untouched.

The key never enters the GUI — only the passphrase (and, on import, the secret the operator chose to type) ever crosses the loopback API.

## Tests

- 5 new hermetic `onboarding` tests (generate, nsec import, hex import, bad-input/double-init rails, unlock incl. wrong passphrase). **23/23** pass; `zig fmt --check` clean.
- Verified live over HTTP against the built daemon:
  - boot key-less → `/info` `uninitialized` → `POST /setup` (generate) → `unlocked` + pubkey; key file written `0600` as an `ncryptsec1…`.
  - restart → `locked` → wrong `/unlock` → `401` → right `/unlock` → **same** pubkey recovered.
  - `POST /setup` importing the BIP-340 test-vector secret returns its exact known pubkey (`dff1d77f…`); a second `/setup` returns `409`.
  - preconfigured `SIGNER_SECRET_KEY` boots straight to `unlocked`.

Follow-up: the native GUI's onboarding/unlock screens (in `zig-nostr/signer-app`) land next.