### PR TITLE
chore: depend on nostr v0.3.2

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.3.1.tar.gz",
-            .hash = "nostr-0.3.1-CMyPzZXFBQCiWBC_G1tU1wlaoN_V01USsHLLlmXb2i-5",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.3.2.tar.gz",
+            .hash = "nostr-0.3.2-CMyPzQrRBQCwYRw7tT5RBeYwpwbB5FXaQUeC8ZYVXYgh",
         },
     },
     .paths = .{


### PR DESCRIPTION
Bumps the `nostr` dependency to **v0.3.2**, which fixes the live relay handshake deadlock ([zig-nostr/nostr#44](https://github.com/zig-nostr/nostr/pull/44)).

Before this, the daemon connected to relays but **never received NIP-46 requests** — `IoStream.read` blocked the websocket handshake by trying to fill its whole buffer from a short `101` response.

Verified live against the released v0.3.2: `signer` pointed at a local relay now receives a real `sign_event` request from a `nak` client, holds it for approval over the loopback API, signs on approval, and returns a valid signed event — the key never leaving the signer.