### PR TITLE
chore: depend on nostr v0.3.3

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.3.2.tar.gz",
-            .hash = "nostr-0.3.2-CMyPzQrRBQCwYRw7tT5RBeYwpwbB5FXaQUeC8ZYVXYgh",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.3.3.tar.gz",
+            .hash = "nostr-0.3.3-CMyPzVzZBQBDcCgGIjq9_h3V4Fn-n0NjMtTmXxaTzUAc",
         },
     },
     .paths = .{


### PR DESCRIPTION
Bumps `nostr` to **v0.3.3**, which fixes the `wss://` TLS handshake regression from v0.3.2 ([zig-nostr/nostr#46](https://github.com/zig-nostr/nostr/pull/46)). The daemon now completes the websocket handshake against TLS relays too (verified live against relay.damus.io: `connected; listening`, no `HandshakeFailed`).