### PR TITLE
chore: depend on nostr v0.3.4

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.3.3.tar.gz",
-            .hash = "nostr-0.3.3-CMyPzVzZBQBDcCgGIjq9_h3V4Fn-n0NjMtTmXxaTzUAc",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.3.4.tar.gz",
+            .hash = "nostr-0.3.4-CMyPzZPcBQAm7zyh5rlr7Uf8frguU8-MiA-8X__IybOV",
         },
     },
     .paths = .{


### PR DESCRIPTION
Bumps the `nostr` dependency to **v0.3.4**, which fixes the `wss://` request-delivery stall (zig-nostr/nostr#49): the live relay read no longer blocks on the *next* TLS record before handing back an already-received relay message, so NIP-46 requests reach the signer promptly over public relays.

With this, the daemon works end-to-end over `relay.damus.io` — verified live: a full NIP-46 round-trip (client `connect` → ACK → `sign_event` → signed reply) completes in ~3 s at sub-second per-request latency, key never leaving the daemon. No signer code change is needed; the fix is entirely in the library's transport.