### PR TITLE
feat: spawn and supervise the signer daemon

### DIFF
--- a/gui/README.md
+++ b/gui/README.md
@@ -5,8 +5,9 @@ signing requests from your [signer daemon](../daemon).
 
 > **Status: early / work in progress.** This is the interactive front end for
 > the headless signer daemon. It connects to the daemon's loopback approval
-> API, shows each pending request, and sends back your approve/deny decision.
-> Bundling it with the daemon as a single download lands next.
+> API, shows each pending request, and sends back your approve/deny decision —
+> and can spawn and supervise the daemon itself (managed mode). Bundling the two
+> into a single download lands next.
 
 ## Architecture
 
@@ -59,12 +60,33 @@ a change), renders each pending request, and sends your decision back over
 `POST /decision`. The bearer token authenticates every call; the secret key
 stays in the daemon.
 
+### Managed mode (spawn the daemon for you)
+
+Set `SIGNER_BIN` to the path of the `signer` binary and the app **spawns and
+supervises the daemon itself** — one launch brings up both. The daemon child
+inherits this process's environment, so pass its config alongside:
+
+```sh
+SIGNER_BIN="$(which signer)" \
+SIGNER_SECRET_KEY=<64-char hex, dev only — prefer SIGNER_KEY_FILE + SIGNER_PASSPHRASE> \
+SIGNER_RELAYS="wss://relay.example.com" \
+SIGNER_APPROVAL_HTTP=127.0.0.1:8787 \
+SIGNER_APPROVAL_TOKEN_FILE="$HOME/.zig-nostr-signer.token" \
+  native dev
+```
+
+The app waits for the daemon to write its token, then connects. If the daemon
+exits, the app shows **Signer stopped** with a **Restart** button; when the app
+quits, the daemon child is stopped with it, so none is left orphaned holding
+the approval port. The key still only ever lives in the daemon child. (A future
+slice bundles the daemon binary into the app so it's a single download.)
+
 ## Roadmap
 
 - [x] App scaffold (native window, shell view, logic tests)
 - [x] Approval queue over the daemon's loopback API (poll, approve, deny)
-- [ ] Supervise the daemon as a child process (one download, key stays isolated)
-- [ ] Packaged, signed, downloadable build
+- [x] Supervise the daemon as a child process (one launch, key stays isolated)
+- [ ] Bundle the daemon into the app (single download) + packaged, signed build
 
 ## License
 

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -1,7 +1,8 @@
 <!-- Signer Approvals — the live view. The header shows the connection state
-     and which key you are approving for; the body is the pending-request
-     queue (or an empty/status message); the status bar counts the queue.
-     Logic is in src/main.zig. Validate with: native check -->
+     and which key you are approving for; the body is one of three mutually
+     exclusive states (signer stopped / no requests / the request queue); the
+     status bar counts the queue. Logic is in src/main.zig. Validate with:
+     native check -->
 <column gap="0">
   <column gap="4" padding="16">
     <text size="heading">Signer Approvals</text>
@@ -9,12 +10,18 @@
     <text>signer {pubkey_short}</text>
   </column>
   <separator/>
-  <if test="{is_empty}">
+  <if test="{daemon_down}">
+    <column gap="12" main="center" cross="center" grow="1" padding="24">
+      <text>{exit_note}</text>
+      <button variant="primary" on-press="restart">Restart signer</button>
+    </column>
+  </if>
+  <if test="{show_empty}">
     <column gap="12" main="center" cross="center" grow="1" padding="24">
       <text>{empty_text}</text>
     </column>
   </if>
-  <else>
+  <if test="{show_queue}">
     <scroll grow="1">
       <column gap="8" padding="12">
         <for each="visible" key="id" as="r">
@@ -30,6 +37,6 @@
         </for>
       </column>
     </scroll>
-  </else>
+  </if>
   <status-bar>{count} pending</status-bar>
 </column>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -6,15 +6,22 @@
 //! the key never enters this process. This app only ever sees request
 //! metadata and sends back a yes/no.
 //!
-//! The view lives in `app.native`; this file is the logic (`Model`, `Msg`,
-//! `update`). All I/O is through the Native SDK effects channel (`fx.fetch`
-//! for HTTP, `fx.startTimer` for reconnect backoff) — the update function
-//! stays a pure state transition and the view stays declarative.
+//! Two ways to run:
 //!
-//! The poll loop is a long-poll chain: each `/pending` response re-arms the
-//! next request (the daemon holds the connection ~1s), so the queue updates
-//! within about a second of a change with no fixed polling cadence. A failed
-//! poll backs off through a one-shot timer instead of hot-looping.
+//!  - **Attached** (default): the daemon is already running; the app connects
+//!    to its approval API at `SIGNER_APPROVAL_HTTP`.
+//!  - **Managed** (`SIGNER_BIN` set): the app *spawns and supervises* the
+//!    daemon binary as a child process — one launch brings up both. The child
+//!    inherits this process's environment (so it gets `SIGNER_KEY_FILE`,
+//!    `SIGNER_PASSPHRASE`, `SIGNER_RELAYS`, `SIGNER_APPROVAL_HTTP`,
+//!    `SIGNER_APPROVAL_TOKEN_FILE`), and the runtime kills it when the app
+//!    quits, so no daemon is orphaned holding the approval port. The key still
+//!    only ever lives in the daemon child.
+//!
+//! The view lives in `app.native`; this file is the logic. All I/O is through
+//! the Native SDK effects channel (`fx.spawn` supervises the daemon, `fx.fetch`
+//! talks HTTP, `fx.readFile` reads the token, `fx.startTimer` backs off), so
+//! `update` stays a pure state transition and the view stays declarative.
 
 const std = @import("std");
 const runner = @import("runner");
@@ -48,11 +55,14 @@ const shell_scene: native_sdk.ShellConfig = .{ .windows = &shell_windows };
 const default_address = "127.0.0.1:8787";
 const default_token_file = ".zig-nostr-signer.token";
 
-// Effect keys. Fetch/spawn effects share one key space and 16 slots; timer
+// Effect keys. Fetch/spawn/file effects share one key space and 16 slots; the
+// long-lived daemon spawn holds one slot for the process's lifetime. Timer
 // keys are their own namespace. Decisions use a small pool so several can be
 // in flight at once (a fast double-approve never collides on one key).
-const info_key: u64 = 1;
-const pending_key: u64 = 2;
+const daemon_key: u64 = 1;
+const token_key: u64 = 2;
+const info_key: u64 = 3;
+const pending_key: u64 = 4;
 const decision_key_base: u64 = 8;
 const decision_key_slots: u64 = 8;
 const retry_timer_key: u64 = 100;
@@ -94,8 +104,21 @@ pub const Row = struct {
     }
 };
 
-/// Connection lifecycle, shown in the header.
-pub const Phase = enum { connecting, connected, disconnected, unauthorized };
+/// Connection / supervision lifecycle, shown in the header.
+pub const Phase = enum {
+    /// Managed mode: the daemon child is starting and we do not have a working
+    /// token / connection yet.
+    starting,
+    /// Attached mode: trying to reach an already-running daemon.
+    connecting,
+    connected,
+    /// Was reachable, now failing — retrying.
+    disconnected,
+    /// The API rejected our bearer token (attached mode).
+    unauthorized,
+    /// Managed mode: the daemon child exited; awaiting a manual restart.
+    daemon_exited,
+};
 
 pub const max_pending = 32; // matches the daemon broker's capacity
 
@@ -103,6 +126,14 @@ pub const Model = struct {
     // Resolved at boot from the environment; stable for the process.
     base_url_buf: [96]u8 = [_]u8{0} ** 96,
     base_url_len: usize = 0,
+    token_path_buf: [512]u8 = [_]u8{0} ** 512,
+    token_path_len: usize = 0,
+    daemon_bin_buf: [512]u8 = [_]u8{0} ** 512,
+    daemon_bin_len: usize = 0,
+    /// True when `SIGNER_BIN` is set: the app spawns and supervises the daemon.
+    managed: bool = false,
+
+    // Read from the token file via `fx.readFile`; the bearer header value.
     auth_buf: [96]u8 = [_]u8{0} ** 96,
     auth_len: usize = 0,
 
@@ -110,6 +141,10 @@ pub const Model = struct {
     pubkey_buf: [64]u8 = [_]u8{0} ** 64,
     pubkey_len: usize = 0,
     timeout_ms: u64 = 0,
+    /// Short human note for the `.daemon_exited` state, e.g. "signer exited
+    /// (code 1)".
+    exit_note_buf: [64]u8 = [_]u8{0} ** 64,
+    exit_note_len: usize = 0,
 
     rows: [max_pending]Row = [_]Row{.{}} ** max_pending,
     rows_len: usize = 0,
@@ -126,12 +161,35 @@ pub const Model = struct {
     pub fn baseUrl(self: *const Model) []const u8 {
         return self.base_url_buf[0..self.base_url_len];
     }
+    pub fn setTokenPath(self: *Model, path: []const u8) void {
+        const n = @min(path.len, self.token_path_buf.len);
+        @memcpy(self.token_path_buf[0..n], path[0..n]);
+        self.token_path_len = n;
+    }
+    pub fn tokenPath(self: *const Model) []const u8 {
+        return self.token_path_buf[0..self.token_path_len];
+    }
+    pub fn setDaemonBin(self: *Model, path: []const u8) void {
+        const n = @min(path.len, self.daemon_bin_buf.len);
+        @memcpy(self.daemon_bin_buf[0..n], path[0..n]);
+        self.daemon_bin_len = n;
+    }
+    pub fn daemonBin(self: *const Model) []const u8 {
+        return self.daemon_bin_buf[0..self.daemon_bin_len];
+    }
     pub fn setAuth(self: *Model, token: []const u8) void {
+        if (token.len == 0) {
+            self.auth_len = 0;
+            return;
+        }
         const s = std.fmt.bufPrint(&self.auth_buf, "Bearer {s}", .{token}) catch return;
         self.auth_len = s.len;
     }
     pub fn auth(self: *const Model) []const u8 {
         return self.auth_buf[0..self.auth_len];
+    }
+    pub fn hasToken(self: *const Model) bool {
+        return self.auth_len > 0;
     }
 
     // -- view bindings --
@@ -144,32 +202,48 @@ pub const Model = struct {
     pub fn count(self: *const Model) usize {
         return self.rows_len;
     }
-    pub fn is_empty(self: *const Model) bool {
-        return self.rows_len == 0;
+    /// Body states — exactly one is true, so the view renders three plain
+    /// `<if>` blocks instead of nested else chains.
+    pub fn daemon_down(self: *const Model) bool {
+        return self.phase == .daemon_exited;
+    }
+    pub fn show_empty(self: *const Model) bool {
+        return self.phase != .daemon_exited and self.rows_len == 0;
+    }
+    pub fn show_queue(self: *const Model) bool {
+        return self.phase != .daemon_exited and self.rows_len > 0;
     }
 
     /// Connection state line in the header.
     pub fn status(self: *const Model) []const u8 {
         return switch (self.phase) {
+            .starting => "Starting the signer…",
             .connecting => "Connecting to the signer…",
             .connected => "Connected",
             .disconnected => "Signer unreachable — retrying…",
             .unauthorized => "Unauthorized — check the token file",
+            .daemon_exited => "Signer stopped",
         };
     }
 
-    /// Message shown in the body while the queue is empty; tracks the phase
-    /// so a not-yet-connected app does not claim "no pending requests".
+    /// Message shown in the body while the queue is empty.
     pub fn empty_text(self: *const Model) []const u8 {
         return switch (self.phase) {
             .connected => "No pending requests",
+            .starting => "Starting the signer…",
             .connecting => "Connecting to the signer…",
             .disconnected => "Signer unreachable — retrying…",
             .unauthorized => "Unauthorized — check the token file",
+            .daemon_exited => "Signer stopped",
         };
     }
 
-    /// Abbreviated signer public key for the header (`aabbccdd…11223344`).
+    pub fn exit_note(self: *const Model) []const u8 {
+        if (self.exit_note_len == 0) return "The signer process stopped.";
+        return self.exit_note_buf[0..self.exit_note_len];
+    }
+
+    /// Abbreviated signer public key for the header (`aabbccddee…11223344`).
     pub fn pubkey_short(self: *const Model, arena: std.mem.Allocator) []const u8 {
         const pk = self.pubkey_buf[0..self.pubkey_len];
         if (pk.len == 0) return "not connected";
@@ -181,6 +255,19 @@ pub const Model = struct {
         const n = @min(pk.len, self.pubkey_buf.len);
         @memcpy(self.pubkey_buf[0..n], pk[0..n]);
         self.pubkey_len = n;
+    }
+
+    fn setExitNote(self: *Model, exit: native_sdk.EffectExit) void {
+        const s = switch (exit.reason) {
+            .spawn_failed, .rejected => std.fmt.bufPrint(&self.exit_note_buf, "The signer failed to start — check SIGNER_BIN.", .{}),
+            .signaled => std.fmt.bufPrint(&self.exit_note_buf, "The signer was terminated (signal).", .{}),
+            else => std.fmt.bufPrint(&self.exit_note_buf, "The signer exited (code {d}).", .{exit.code}),
+        } catch return;
+        self.exit_note_len = s.len;
+    }
+
+    pub fn clearRows(self: *Model) void {
+        self.rows_len = 0;
     }
 
     pub fn removeRow(self: *Model, id: u64) void {
@@ -199,12 +286,16 @@ pub const Model = struct {
 // -------------------------------------------------------------------- msg
 
 pub const Msg = union(enum) {
+    daemon_line: native_sdk.EffectLine,
+    daemon_exited: native_sdk.EffectExit,
+    token_read: native_sdk.EffectFileResult,
     info: native_sdk.EffectResponse,
     pending: native_sdk.EffectResponse,
     decided: native_sdk.EffectResponse,
     tick: native_sdk.EffectTimer,
     approve: u64,
     reject: u64,
+    restart,
 };
 
 // ---------------------------------------------------------------- effects
@@ -215,14 +306,41 @@ pub const app_markup = @embedFile("app.native");
 const ApprovalsApp = native_sdk.UiApp(Model, Msg);
 const Effects = ApprovalsApp.Effects;
 
-fn authHeader(model: *const Model) [1]std.http.Header {
-    return .{.{ .name = "authorization", .value = model.auth() }};
+fn spawnDaemon(model: *Model, fx: *Effects) void {
+    model.phase = .starting;
+    fx.spawn(.{
+        .key = daemon_key,
+        .argv = &.{model.daemonBin()},
+        .on_line = Effects.lineMsg(.daemon_line),
+        .on_exit = Effects.exitMsg(.daemon_exited),
+    });
+}
+
+/// One connection attempt: (re-)read the token file, then poll. Re-reading on
+/// every attempt means a freshly (re)started daemon's new token is always
+/// picked up, healing both the initial startup race and a restart.
+fn attemptConnect(model: *Model, fx: *Effects) void {
+    if (model.tokenPath().len == 0) {
+        // No token file configured at all: nothing to authenticate with.
+        model.phase = .unauthorized;
+        return;
+    }
+    fx.readFile(.{
+        .key = token_key,
+        .path = model.tokenPath(),
+        .on_result = Effects.fileMsg(.token_read),
+    });
+}
+
+fn startPolling(model: *Model, fx: *Effects) void {
+    fetchInfo(model, fx);
+    pollPending(model, fx);
 }
 
 fn fetchInfo(model: *Model, fx: *Effects) void {
     var buf: [128]u8 = undefined;
     const url = std.fmt.bufPrint(&buf, "{s}/info", .{model.baseUrl()}) catch return;
-    const headers = authHeader(model);
+    const headers = [_]std.http.Header{.{ .name = "authorization", .value = model.auth() }};
     fx.fetch(.{
         .key = info_key,
         .url = url,
@@ -235,7 +353,7 @@ fn fetchInfo(model: *Model, fx: *Effects) void {
 fn pollPending(model: *Model, fx: *Effects) void {
     var buf: [160]u8 = undefined;
     const url = std.fmt.bufPrint(&buf, "{s}/pending?since={d}", .{ model.baseUrl(), model.version }) catch return;
-    const headers = authHeader(model);
+    const headers = [_]std.http.Header{.{ .name = "authorization", .value = model.auth() }};
     // The daemon long-polls ~1s before answering; 35s is generous headroom.
     fx.fetch(.{
         .key = pending_key,
@@ -275,23 +393,67 @@ fn armRetry(fx: *Effects) void {
     });
 }
 
-/// Boot command: kick off the info fetch and the first queue poll.
+/// A poll came back unauthorized. In managed mode the daemon may have just
+/// (re)written its token, so drop ours and re-acquire on the next tick; in
+/// attached mode it is a real misconfiguration.
+fn onUnauthorized(model: *Model, fx: *Effects) void {
+    if (model.managed) {
+        model.setAuth("");
+        model.phase = .starting;
+    } else {
+        model.phase = .unauthorized;
+    }
+    armRetry(fx);
+}
+
+/// Boot command: in managed mode spawn the daemon; either way begin connecting.
 pub fn boot(model: *Model, fx: *Effects) void {
-    model.phase = .connecting;
-    fetchInfo(model, fx);
-    pollPending(model, fx);
+    if (model.managed) {
+        spawnDaemon(model, fx);
+    } else {
+        model.phase = .connecting;
+    }
+    attemptConnect(model, fx);
 }
 
 pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
     switch (msg) {
+        .daemon_line => {}, // daemon stdout; the connection state is the signal we surface
+
+        .daemon_exited => |exit| {
+            // A cancel we initiated (restart / app quit) reports `.cancelled` —
+            // that is expected teardown, not a crash to report.
+            if (exit.reason == .cancelled) return;
+            model.phase = .daemon_exited;
+            model.setExitNote(exit);
+            model.setAuth("");
+            model.clearRows();
+        },
+
+        .token_read => |r| switch (r.outcome) {
+            .ok => {
+                const token = std.mem.trim(u8, r.bytes, " \t\r\n");
+                if (token.len > 0) {
+                    model.setAuth(token);
+                    if (model.phase != .connected) model.phase = .connecting;
+                    startPolling(model, fx);
+                } else {
+                    armRetry(fx); // empty file — the daemon has not written it yet
+                }
+            },
+            // Not there yet (managed daemon still starting) or unreadable: retry.
+            else => armRetry(fx),
+        },
+
         .info => |r| {
             if (r.outcome == .ok and r.status == 200) {
                 parseInfo(model, r.body);
             } else if (r.outcome == .ok and r.status == 401) {
-                model.phase = .unauthorized;
+                onUnauthorized(model, fx);
             }
             // Otherwise best-effort: the /pending poll owns the phase.
         },
+
         .pending => |r| switch (r.outcome) {
             .ok => switch (r.status) {
                 200 => {
@@ -299,31 +461,31 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
                     parsePending(model, r.body);
                     pollPending(model, fx); // re-arm the long-poll chain
                 },
-                401 => {
-                    model.phase = .unauthorized;
-                    armRetry(fx);
-                },
+                401 => onUnauthorized(model, fx),
                 else => {
                     model.phase = .disconnected;
                     armRetry(fx);
                 },
             },
-            // Never started (e.g. a momentary duplicate key): try again soon.
+            // Never started (momentary duplicate key) or a transport failure:
+            // fall back to a timed reconnect (which re-reads the token).
             .rejected => armRetry(fx),
-            // connect_failed / tls_failed / protocol_failed / timed_out / cancelled
             else => {
-                model.phase = .disconnected;
+                if (model.phase == .connected) model.phase = .disconnected;
                 armRetry(fx);
             },
         },
+
         // The poll chain reflects the removal; nothing else to do on ack.
         .decided => {},
+
         .tick => |t| {
-            if (t.outcome == .fired) {
-                fetchInfo(model, fx);
-                pollPending(model, fx);
-            }
+            if (t.outcome != .fired) return;
+            if (model.phase == .daemon_exited) return; // wait for the Restart button
+            // A full reconnect attempt: re-read the token, then poll.
+            attemptConnect(model, fx);
         },
+
         .approve => |id| {
             sendDecision(model, fx, id, true);
             model.removeRow(id); // optimistic; a poll re-adds it if the send failed
@@ -331,6 +493,14 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         .reject => |id| {
             sendDecision(model, fx, id, false);
             model.removeRow(id);
+        },
+
+        .restart => {
+            if (!model.managed) return;
+            model.setAuth("");
+            model.clearRows();
+            spawnDaemon(model, fx);
+            attemptConnect(model, fx);
         },
     }
 }
@@ -383,30 +553,33 @@ pub fn initialModel() Model {
     return .{};
 }
 
-/// Resolves the daemon address and bearer token from the environment into the
-/// model. `SIGNER_APPROVAL_HTTP` defaults to 127.0.0.1:8787; the bearer token
-/// is read (mode 0600 on the daemon side) from `SIGNER_APPROVAL_TOKEN_FILE`,
-/// defaulting to `$HOME/.zig-nostr-signer.token`.
-fn loadConfig(model: *Model, environ: *const std.process.Environ.Map, io: std.Io, gpa: std.mem.Allocator) void {
+/// Resolves the daemon address, token-file path, and (optional) daemon binary
+/// from the environment. `SIGNER_APPROVAL_HTTP` defaults to 127.0.0.1:8787;
+/// the token-file path defaults to `$HOME/.zig-nostr-signer.token`; setting
+/// `SIGNER_BIN` switches on managed mode (the app supervises that binary). The
+/// token *contents* are read later through the effects channel, so a managed
+/// daemon that writes the file after we launch is picked up on retry.
+fn loadConfig(model: *Model, environ: *const std.process.Environ.Map) void {
     const address = environ.get("SIGNER_APPROVAL_HTTP") orelse default_address;
     model.setBaseUrl(address);
 
-    var path_buf: [512]u8 = undefined;
-    const token_path = environ.get("SIGNER_APPROVAL_TOKEN_FILE") orelse blk: {
-        const home = environ.get("HOME") orelse break :blk null;
-        break :blk std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ home, default_token_file }) catch null;
-    };
-    if (token_path) |path| {
-        const raw = std.Io.Dir.cwd().readFileAlloc(io, path, gpa, std.Io.Limit.limited(4096)) catch return;
-        defer gpa.free(raw);
-        const token = std.mem.trim(u8, raw, " \t\r\n");
-        if (token.len > 0) model.setAuth(token);
+    if (environ.get("SIGNER_BIN")) |bin| {
+        model.setDaemonBin(bin);
+        model.managed = true;
+    }
+
+    if (environ.get("SIGNER_APPROVAL_TOKEN_FILE")) |path| {
+        model.setTokenPath(path);
+    } else if (environ.get("HOME")) |home| {
+        var buf: [512]u8 = undefined;
+        if (std.fmt.bufPrint(&buf, "{s}/{s}", .{ home, default_token_file })) |path| {
+            model.setTokenPath(path);
+        } else |_| {}
     }
 }
 
 pub fn main(init: std.process.Init) !void {
-    const gpa = std.heap.page_allocator;
-    const app_state = try ApprovalsApp.create(gpa, .{
+    const app_state = try ApprovalsApp.create(std.heap.page_allocator, .{
         .name = "signer-app",
         .scene = shell_scene,
         .canvas_label = canvas_label,
@@ -416,7 +589,7 @@ pub fn main(init: std.process.Init) !void {
     });
     defer app_state.destroy();
     app_state.model = initialModel();
-    loadConfig(&app_state.model, init.environ_map, init.io, gpa);
+    loadConfig(&app_state.model, init.environ_map);
 
     try runner.runWithOptions(app_state.app(), .{
         .app_name = "signer-app",

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -153,3 +153,53 @@ test "a populated view renders rows and dispatches typed approve/deny" {
         else => return error.WrongMessage,
     }
 }
+
+// ------------------------------------------------------- supervision
+
+test "the phase and row count pick exactly one body state" {
+    var m = Model{};
+
+    m.phase = .connected;
+    try testing.expect(m.show_empty());
+    try testing.expect(!m.show_queue());
+    try testing.expect(!m.daemon_down());
+
+    m.rows_len = 1;
+    try testing.expect(!m.show_empty());
+    try testing.expect(m.show_queue());
+    try testing.expect(!m.daemon_down());
+
+    m.phase = .daemon_exited;
+    try testing.expect(m.daemon_down());
+    try testing.expect(!m.show_empty());
+    try testing.expect(!m.show_queue());
+}
+
+test "setAuth builds and clears the bearer header" {
+    var m = Model{};
+    try testing.expect(!m.hasToken());
+    m.setAuth("deadbeef");
+    try testing.expect(m.hasToken());
+    try testing.expectEqualStrings("Bearer deadbeef", m.auth());
+    m.setAuth("");
+    try testing.expect(!m.hasToken());
+    try testing.expectEqual(@as(usize, 0), m.auth().len);
+}
+
+test "the daemon-stopped view offers a restart" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+
+    var model = Model{};
+    model.phase = .daemon_exited; // as set when the daemon child exits
+    const tree = try buildTree(arena_state.allocator(), &model);
+
+    _ = try expectByText(tree.root, .text, "Signer stopped");
+    _ = try expectByText(tree.root, .text, "The signer process stopped.");
+
+    const restart = try expectByText(tree.root, .button, "Restart signer");
+    switch (tree.msgForPointer(restart.id, .up).?) {
+        .restart => {},
+        else => return error.WrongMessage,
+    }
+}


### PR DESCRIPTION
In managed mode (`SIGNER_BIN` set, or a daemon bundled beside the app), the GUI spawns the `daemon/` signer as a child and supervises it: one launch brings up both, the daemon inherits the environment (key + relays), and if it exits the app shows **Signer stopped** with a **Restart** button. On quit the child is stopped with the app, so none is left holding the approval port. The key still only ever lives in the daemon child.