### PR TITLE
feat: bundle the signer daemon into the app (single download)

### DIFF
--- a/gui/.gitignore
+++ b/gui/.gitignore
@@ -3,3 +3,4 @@ zig-out/
 .zig-cache/
 .DS_Store
 .claude/
+dist/

--- a/gui/README.md
+++ b/gui/README.md
@@ -5,9 +5,9 @@ signing requests from your [signer daemon](../daemon).
 
 > **Status: early / work in progress.** This is the interactive front end for
 > the headless signer daemon. It connects to the daemon's loopback approval
-> API, shows each pending request, and sends back your approve/deny decision —
-> and can spawn and supervise the daemon itself (managed mode). Bundling the two
-> into a single download lands next.
+> API, shows each pending request, and sends back your approve/deny decision,
+> and spawns and supervises the daemon itself. `scripts/package-macos.sh`
+> bundles both into a single `.app`; a signed, notarized distributable is next.
 
 ## Architecture
 
@@ -60,11 +60,13 @@ a change), renders each pending request, and sends your decision back over
 `POST /decision`. The bearer token authenticates every call; the secret key
 stays in the daemon.
 
-### Managed mode (spawn the daemon for you)
+### Managed mode (the app supervises the daemon)
 
-Set `SIGNER_BIN` to the path of the `signer` binary and the app **spawns and
-supervises the daemon itself** — one launch brings up both. The daemon child
-inherits this process's environment, so pass its config alongside:
+A packaged app is self-contained: the `.app` ships the `signer` daemon beside
+the GUI in `Contents/MacOS`, and at launch the GUI discovers that sibling and
+spawns it — one launch brings up both, no configuration. In development you get
+the same one-launch behavior without packaging by pointing `SIGNER_BIN` at a
+built daemon (it takes precedence over any bundled one):
 
 ```sh
 SIGNER_BIN="$(which signer)" \
@@ -75,18 +77,45 @@ SIGNER_APPROVAL_TOKEN_FILE="$HOME/.zig-nostr-signer.token" \
   native dev
 ```
 
-The app waits for the daemon to write its token, then connects. If the daemon
-exits, the app shows **Signer stopped** with a **Restart** button; when the app
-quits, the daemon child is stopped with it, so none is left orphaned holding
-the approval port. The key still only ever lives in the daemon child. (A future
-slice bundles the daemon binary into the app so it's a single download.)
+Either way the daemon child inherits this process's environment (so it gets its
+key and relay config), the app waits for it to write its token and then
+connects, and if the daemon exits the app shows **Signer stopped** with a
+**Restart** button. When the app quits, the daemon child is stopped with it, so
+none is left orphaned holding the approval port. The key still only ever lives
+in the daemon child.
+
+## Packaging
+
+`scripts/package-macos.sh` produces a single, self-contained
+`Signer Approvals.app` with both executables side by side in `Contents/MacOS`
+(`signer-app` and `signer`), so one download brings up both:
+
+```sh
+# builds the GUI, packages the .app, injects the daemon, and ad-hoc signs it
+scripts/package-macos.sh --signer path/to/signer
+```
+
+The daemon comes from the [`daemon/`](../daemon) package in this repo; build it
+(`cd ../daemon && zig build -Doptimize=ReleaseFast`) and the script finds
+`../daemon/zig-out/bin/signer` on its own, or pass `--signer <path>`.
+
+Ad-hoc signing (the default) is enough to run the bundle locally. A
+distributable, Gatekeeper-friendly build additionally needs a Developer ID and
+notarization, which require your own Apple credentials:
+
+```sh
+scripts/package-macos.sh --signing identity \
+  --identity "Developer ID Application: Your Name (TEAMID)"
+```
 
 ## Roadmap
 
 - [x] App scaffold (native window, shell view, logic tests)
 - [x] Approval queue over the daemon's loopback API (poll, approve, deny)
 - [x] Supervise the daemon as a child process (one launch, key stays isolated)
-- [ ] Bundle the daemon into the app (single download) + packaged, signed build
+- [x] Bundle the daemon into the app — one `.app`, discovered and supervised
+- [ ] Signed, notarized distributable (Developer ID)
+- [ ] First-run onboarding (generate/import a key) so a fresh download is turnkey
 
 ## License
 

--- a/gui/scripts/package-macos.sh
+++ b/gui/scripts/package-macos.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Package Signer Approvals as a single, self-contained macOS .app.
+#
+# The bundle carries two executables side by side in Contents/MacOS:
+#
+#   Signer Approvals.app/Contents/MacOS/signer-app   the GUI (CFBundleExecutable)
+#   Signer Approvals.app/Contents/MacOS/signer       the daemon it supervises
+#
+# so one download brings up both: at launch the GUI discovers the `signer`
+# sitting beside it and spawns it (see bundledDaemonPath in src/main.zig). No
+# SIGNER_BIN, no second download. The key still only ever lives in the daemon
+# child.
+#
+# The daemon binary is built from the `daemon/` package in this repo; this
+# script does not build it — point --signer at a prebuilt binary (or build it:
+# `cd ../daemon && zig build -Doptimize=ReleaseFast`).
+#
+# Usage:
+#   scripts/package-macos.sh [options]
+#     --signer PATH     signer daemon binary to bundle
+#                       (default: $SIGNER_BIN, else ../daemon/zig-out/bin/signer)
+#     --signing MODE    none | adhoc | identity     (default: adhoc)
+#     --identity NAME   codesign identity, required for --signing identity
+#                       (e.g. "Developer ID Application: Your Name (TEAMID)")
+#     --output DIR      directory to write the .app into (default: dist)
+#     -h, --help
+#
+# Ad-hoc signing is enough to run the bundle locally. A distributable, Gatekeeper
+# -friendly build needs --signing identity plus notarization + stapling, which
+# require your Apple Developer credentials and are left to you.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+signer_bin="${SIGNER_BIN:-}"
+signing="adhoc"
+identity=""
+outdir="dist"
+app_name="Signer Approvals.app"
+
+usage() { sed -n '2,38p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --signer)   signer_bin="${2:?}"; shift 2 ;;
+    --signing)  signing="${2:?}"; shift 2 ;;
+    --identity) identity="${2:?}"; shift 2 ;;
+    --output)   outdir="${2:?}"; shift 2 ;;
+    -h|--help)  usage; exit 0 ;;
+    *) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+case "$signing" in
+  none|adhoc) ;;
+  identity) [ -n "$identity" ] || { echo "error: --signing identity requires --identity <name>" >&2; exit 2; } ;;
+  *) echo "error: --signing must be none, adhoc, or identity" >&2; exit 2 ;;
+esac
+
+# Locate the daemon binary if one wasn't given.
+if [ -z "$signer_bin" ]; then
+  for cand in "$root/../daemon/zig-out/bin/signer"; do
+    [ -x "$cand" ] && { signer_bin="$cand"; break; }
+  done
+fi
+if [ -z "$signer_bin" ] || [ ! -x "$signer_bin" ]; then
+  echo "error: signer daemon binary not found or not executable: ${signer_bin:-<none>}" >&2
+  echo "  build it:  (cd ../daemon && zig build -Doptimize=ReleaseFast)" >&2
+  echo "  or pass:   --signer <path>   (or set SIGNER_BIN)" >&2
+  exit 1
+fi
+# Absolutize so the copy works regardless of cwd.
+signer_bin="$(cd "$(dirname "$signer_bin")" && pwd)/$(basename "$signer_bin")"
+
+echo "==> building the GUI (native build, ReleaseFast)"
+native build
+gui_bin="$root/zig-out/bin/signer-app"
+[ -x "$gui_bin" ] || { echo "error: $gui_bin missing after native build" >&2; exit 1; }
+
+app="$outdir/$app_name"
+echo "==> packaging an unsigned bundle at $app"
+rm -rf "$app"
+mkdir -p "$outdir"
+# Package unsigned: we inject the daemon and then sign inside-out, so the
+# packager must not sign first (that signature would break on injection).
+native package --target macos --signing none --binary "$gui_bin" --output "$app" >/dev/null
+
+echo "==> bundling the signer daemon into Contents/MacOS/signer"
+cp "$signer_bin" "$app/Contents/MacOS/signer"
+chmod +x "$app/Contents/MacOS/signer"
+
+# Sign inside-out: the nested helper first, then the bundle (Apple's order).
+case "$signing" in
+  none)
+    echo "==> leaving the bundle unsigned (--signing none)" ;;
+  adhoc)
+    echo "==> ad-hoc signing the daemon, then the bundle"
+    codesign --force --sign - "$app/Contents/MacOS/signer"
+    codesign --force --sign - "$app" ;;
+  identity)
+    echo "==> signing with \"$identity\" (hardened runtime + timestamp)"
+    codesign --force --options runtime --timestamp --sign "$identity" "$app/Contents/MacOS/signer"
+    codesign --force --options runtime --timestamp --sign "$identity" "$app" ;;
+esac
+
+if [ "$signing" != "none" ]; then
+  codesign --verify --strict "$app"
+  codesign --verify --strict "$app/Contents/MacOS/signer"
+  echo "==> signatures verified"
+fi
+
+echo
+echo "built: $app"
+du -sh "$app" | awk '{printf "  size:   %s\n", $1}'
+echo "  binaries in Contents/MacOS:"
+/bin/ls -1 "$app/Contents/MacOS" | sed 's/^/    /'

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -10,13 +10,16 @@
 //!
 //!  - **Attached** (default): the daemon is already running; the app connects
 //!    to its approval API at `SIGNER_APPROVAL_HTTP`.
-//!  - **Managed** (`SIGNER_BIN` set): the app *spawns and supervises* the
-//!    daemon binary as a child process — one launch brings up both. The child
-//!    inherits this process's environment (so it gets `SIGNER_KEY_FILE`,
-//!    `SIGNER_PASSPHRASE`, `SIGNER_RELAYS`, `SIGNER_APPROVAL_HTTP`,
-//!    `SIGNER_APPROVAL_TOKEN_FILE`), and the runtime kills it when the app
-//!    quits, so no daemon is orphaned holding the approval port. The key still
-//!    only ever lives in the daemon child.
+//!  - **Managed**: the app *spawns and supervises* the daemon binary as a child
+//!    process — one launch brings up both. The daemon is either a `signer`
+//!    bundled beside this executable (`…/Contents/MacOS/signer` in a packaged
+//!    app, so a single download is self-contained) or, taking precedence, an
+//!    explicit `SIGNER_BIN` override for development. The child inherits this
+//!    process's environment (so it gets `SIGNER_KEY_FILE`, `SIGNER_PASSPHRASE`,
+//!    `SIGNER_RELAYS`, `SIGNER_APPROVAL_HTTP`, `SIGNER_APPROVAL_TOKEN_FILE`),
+//!    and the runtime kills it when the app quits, so no daemon is orphaned
+//!    holding the approval port. The key still only ever lives in the daemon
+//!    child.
 //!
 //! The view lives in `app.native`; this file is the logic. All I/O is through
 //! the Native SDK effects channel (`fx.spawn` supervises the daemon, `fx.fetch`
@@ -553,17 +556,47 @@ pub fn initialModel() Model {
     return .{};
 }
 
-/// Resolves the daemon address, token-file path, and (optional) daemon binary
-/// from the environment. `SIGNER_APPROVAL_HTTP` defaults to 127.0.0.1:8787;
-/// the token-file path defaults to `$HOME/.zig-nostr-signer.token`; setting
-/// `SIGNER_BIN` switches on managed mode (the app supervises that binary). The
-/// token *contents* are read later through the effects channel, so a managed
-/// daemon that writes the file after we launch is picked up on retry.
-fn loadConfig(model: *Model, environ: *const std.process.Environ.Map) void {
+/// Which daemon binary to supervise, or null for attached mode (connect to a
+/// daemon someone else started). An explicit `SIGNER_BIN` always wins — it is
+/// the development / override path — otherwise a `signer` bundled beside this
+/// executable is used, so a downloaded app needs no configuration. `bundled`
+/// is expected to be null or non-empty (see `bundledDaemonPath`).
+pub fn chooseDaemonBin(env_bin: ?[]const u8, bundled: ?[]const u8) ?[]const u8 {
+    if (env_bin) |b| {
+        if (b.len > 0) return b;
+    }
+    return bundled;
+}
+
+/// Absolute path to a runnable `signer` sitting next to this executable — the
+/// layout a packaged app has (`…/Contents/MacOS/signer` beside the GUI binary),
+/// so a single download is self-contained. Returns null when there is no
+/// runnable sibling (e.g. under `native dev`, where the binary lives in the
+/// build cache with no daemon beside it), so the app falls back to attached
+/// mode. The path is written into `buf`.
+fn bundledDaemonPath(io: std.Io, buf: []u8) ?[]const u8 {
+    var dir_buf: [1024]u8 = undefined;
+    const dir_len = std.process.executableDirPath(io, &dir_buf) catch return null;
+    const path = std.fmt.bufPrint(buf, "{s}/signer", .{dir_buf[0..dir_len]}) catch return null;
+    // Only claim managed mode when the sibling is actually there and runnable;
+    // otherwise the spawn would fail at boot and mask the intended attached mode.
+    std.Io.Dir.accessAbsolute(io, path, .{ .execute = true }) catch return null;
+    return path;
+}
+
+/// Resolves the daemon address, token-file path, and (optional) daemon binary.
+/// `SIGNER_APPROVAL_HTTP` defaults to 127.0.0.1:8787; the token-file path
+/// defaults to `$HOME/.zig-nostr-signer.token`. Managed mode is switched on by
+/// a `signer` bundled beside the app, or an overriding `SIGNER_BIN`. The token
+/// *contents* are read later through the effects channel, so a managed daemon
+/// that writes the file after we launch is picked up on retry.
+fn loadConfig(model: *Model, io: std.Io, environ: *const std.process.Environ.Map) void {
     const address = environ.get("SIGNER_APPROVAL_HTTP") orelse default_address;
     model.setBaseUrl(address);
 
-    if (environ.get("SIGNER_BIN")) |bin| {
+    var bundled_buf: [1024]u8 = undefined;
+    const bundled = bundledDaemonPath(io, &bundled_buf);
+    if (chooseDaemonBin(environ.get("SIGNER_BIN"), bundled)) |bin| {
         model.setDaemonBin(bin);
         model.managed = true;
     }
@@ -589,7 +622,7 @@ pub fn main(init: std.process.Init) !void {
     });
     defer app_state.destroy();
     app_state.model = initialModel();
-    loadConfig(&app_state.model, init.environ_map);
+    loadConfig(&app_state.model, init.io, init.environ_map);
 
     try runner.runWithOptions(app_state.app(), .{
         .app_name = "signer-app",

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -156,6 +156,18 @@ test "a populated view renders rows and dispatches typed approve/deny" {
 
 // ------------------------------------------------------- supervision
 
+test "chooseDaemonBin prefers SIGNER_BIN, then a bundled sibling, else attached" {
+    // An explicit SIGNER_BIN overrides a bundled sibling (the dev path).
+    try testing.expectEqualStrings("/env/signer", main.chooseDaemonBin("/env/signer", "/bundle/signer").?);
+    // An empty SIGNER_BIN is treated as unset and falls through to the bundle.
+    try testing.expectEqualStrings("/bundle/signer", main.chooseDaemonBin("", "/bundle/signer").?);
+    // No override: the bundled sibling is supervised (the single-download path).
+    try testing.expectEqualStrings("/bundle/signer", main.chooseDaemonBin(null, "/bundle/signer").?);
+    // Neither present: attached mode (connect to a daemon someone else started).
+    try testing.expect(main.chooseDaemonBin(null, null) == null);
+    try testing.expect(main.chooseDaemonBin("", null) == null);
+}
+
 test "the phase and row count pick exactly one body state" {
     var m = Model{};
 


### PR DESCRIPTION
`scripts/package-macos.sh` produces a single, self-contained `Signer Approvals.app` with both executables side by side in `Contents/MacOS` (`signer-app` and `signer`), so one download brings up both. At launch the GUI discovers the `signer` bundled beside it and spawns it — no `SIGNER_BIN`, no second download, key still isolated in the daemon child. The daemon binary comes from the `daemon/` package in this repo (`cd ../daemon && zig build -Doptimize=ReleaseFast`); ad-hoc signing is the default, with Developer-ID + notarization available via flags.