### PR TITLE
chore: rebrand the app from Signer Approvals to Signet

### DIFF
--- a/gui/README.md
+++ b/gui/README.md
@@ -1,6 +1,6 @@
-# signer-app
+# Signet — the GUI
 
-**Signer Approvals** — a native desktop app that approves or denies Nostr
+**Signet** — a native desktop app that approves or denies Nostr
 signing requests from your [signer daemon](../daemon).
 
 > **Status: early / work in progress.** This is the interactive front end for
@@ -10,7 +10,7 @@ signing requests from your [signer daemon](../daemon).
 > the daemon itself. `scripts/package-macos.sh` bundles both into a single
 > `.app`; a signed, notarized distributable is next.
 
-![Signer Approvals: first-run key setup, then approving a live signing request](assets/demo.gif)
+![Signet: first-run key setup, then approving a live signing request](assets/demo.gif)
 
 <sub>First-run key setup (create a new key, or import an existing `nsec`), then
 approving a live NIP-46 signing request from a connected client. The key is
@@ -104,8 +104,8 @@ in the daemon child.
 ## Packaging
 
 `scripts/package-macos.sh` produces a single, self-contained
-`Signer Approvals.app` with both executables side by side in `Contents/MacOS`
-(`signer-app` and `signer`), so one download brings up both:
+`Signet.app` with both executables side by side in `Contents/MacOS`
+(`signet` and `signer`), so one download brings up both:
 
 ```sh
 # builds the GUI, packages the .app, injects the daemon, and ad-hoc signs it

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -1,8 +1,8 @@
 .{
-    .id = "com.zig-nostr.signer-app",
-    .name = "signer-app",
-    .display_name = "Signer Approvals",
-    .description = "Approve or deny Nostr signing requests from your zig-nostr signer.",
+    .id = "com.zig-nostr.signet",
+    .name = "signet",
+    .display_name = "Signet",
+    .description = "Signet — approve or deny Nostr signing requests; your key stays in the signer daemon.",
     .version = "0.0.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
@@ -12,13 +12,13 @@
         .windows = .{
             .{
                 .label = "main",
-                .title = "Signer Approvals",
+                .title = "Signet",
                 .width = 460,
                 .height = 560,
                 .restore_state = false,
                 .restore_policy = "center_on_primary",
                 .views = .{
-                    .{ .label = "main-canvas", .kind = "gpu_surface", .fill = true, .role = "Approvals canvas", .accessibility_label = "Approvals", .gpu_backend = "metal", .gpu_pixel_format = "bgra8_unorm", .gpu_present_mode = "timer", .gpu_alpha_mode = "opaque", .gpu_color_space = "srgb", .gpu_vsync = true },
+                    .{ .label = "main-canvas", .kind = "gpu_surface", .fill = true, .role = "Signet canvas", .accessibility_label = "Signet", .gpu_backend = "metal", .gpu_pixel_format = "bgra8_unorm", .gpu_present_mode = "timer", .gpu_alpha_mode = "opaque", .gpu_color_space = "srgb", .gpu_vsync = true },
                 },
             },
         },

--- a/gui/scripts/package-macos.sh
+++ b/gui/scripts/package-macos.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Package Signer Approvals as a single, self-contained macOS .app.
+# Package Signet as a single, self-contained macOS .app.
 #
 # The bundle carries two executables side by side in Contents/MacOS:
 #
-#   Signer Approvals.app/Contents/MacOS/signer-app   the GUI (CFBundleExecutable)
-#   Signer Approvals.app/Contents/MacOS/signer       the daemon it supervises
+#   Signet.app/Contents/MacOS/signet   the GUI (CFBundleExecutable)
+#   Signet.app/Contents/MacOS/signer       the daemon it supervises
 #
 # so one download brings up both: at launch the GUI discovers the `signer`
 # sitting beside it and spawns it (see bundledDaemonPath in src/main.zig). No
@@ -38,7 +38,7 @@ signer_bin="${SIGNER_BIN:-}"
 signing="adhoc"
 identity=""
 outdir="dist"
-app_name="Signer Approvals.app"
+app_name="Signet.app"
 
 usage() { sed -n '2,38p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
@@ -76,7 +76,7 @@ signer_bin="$(cd "$(dirname "$signer_bin")" && pwd)/$(basename "$signer_bin")"
 
 echo "==> building the GUI (native build, ReleaseFast)"
 native build
-gui_bin="$root/zig-out/bin/signer-app"
+gui_bin="$root/zig-out/bin/signet"
 [ -x "$gui_bin" ] || { echo "error: $gui_bin missing after native build" >&2; exit 1; }
 
 app="$outdir/$app_name"

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -1,11 +1,11 @@
-<!-- Signer Approvals — the live view. The header shows the connection state
+<!-- Signet — the live view. The header shows the connection state
      and which key you are approving for; the body is one of several mutually
      exclusive states (signer stopped / first-run setup / unlock / no requests /
      the request queue); the status bar counts the queue. Logic is in
      src/main.zig. Validate with: native check -->
 <column gap="0">
   <column gap="4" padding="16">
-    <text size="heading">Signer Approvals</text>
+    <text size="heading">Signet</text>
     <text>{status}</text>
     <text>signer {pubkey_short}</text>
   </column>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -1,4 +1,4 @@
-//! Signer Approvals — a native desktop approver for a zig-nostr signer.
+//! Signet — a native desktop approver for the signer daemon.
 //!
 //! Architecture: the signer daemon (the daemon/ package in this repo) holds the
 //! secret key and does all Nostr work; this app is a *separate process* that
@@ -41,11 +41,11 @@ const window_height: f32 = 560;
 
 const app_permissions = [_][]const u8{ native_sdk.security.permission_command, native_sdk.security.permission_view };
 const shell_views = [_]native_sdk.ShellView{
-    .{ .label = canvas_label, .kind = .gpu_surface, .fill = true, .role = "Approvals canvas", .accessibility_label = "Approvals", .gpu_backend = .metal, .gpu_pixel_format = .bgra8_unorm, .gpu_present_mode = .timer, .gpu_alpha_mode = .@"opaque", .gpu_color_space = .srgb, .gpu_vsync = true },
+    .{ .label = canvas_label, .kind = .gpu_surface, .fill = true, .role = "Signet canvas", .accessibility_label = "Signet", .gpu_backend = .metal, .gpu_pixel_format = .bgra8_unorm, .gpu_present_mode = .timer, .gpu_alpha_mode = .@"opaque", .gpu_color_space = .srgb, .gpu_vsync = true },
 };
 const shell_windows = [_]native_sdk.ShellWindow{.{
     .label = "main",
-    .title = "Signer Approvals",
+    .title = "Signet",
     .width = window_width,
     .height = window_height,
     .restore_state = false,
@@ -419,8 +419,8 @@ pub const Msg = union(enum) {
 pub const AppUi = canvas.Ui(Msg);
 pub const app_markup = @embedFile("app.native");
 
-const ApprovalsApp = native_sdk.UiApp(Model, Msg);
-const Effects = ApprovalsApp.Effects;
+const SignetApp = native_sdk.UiApp(Model, Msg);
+const Effects = SignetApp.Effects;
 
 fn spawnDaemon(model: *Model, fx: *Effects) void {
     model.phase = .starting;
@@ -838,8 +838,8 @@ fn loadConfig(model: *Model, io: std.Io, environ: *const std.process.Environ.Map
 }
 
 pub fn main(init: std.process.Init) !void {
-    const app_state = try ApprovalsApp.create(std.heap.page_allocator, .{
-        .name = "signer-app",
+    const app_state = try SignetApp.create(std.heap.page_allocator, .{
+        .name = "signet",
         .scene = shell_scene,
         .canvas_label = canvas_label,
         .init_fx = boot,
@@ -851,9 +851,9 @@ pub fn main(init: std.process.Init) !void {
     loadConfig(&app_state.model, init.io, init.environ_map);
 
     try runner.runWithOptions(app_state.app(), .{
-        .app_name = "signer-app",
-        .window_title = "Signer Approvals",
-        .bundle_id = "com.zig-nostr.signer-app",
+        .app_name = "signet",
+        .window_title = "Signet",
+        .bundle_id = "com.zig-nostr.signet",
         .icon_path = "assets/icon.png",
         .default_frame = geometry.RectF.init(0, 0, window_width, window_height),
         .restore_state = false,

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -122,7 +122,7 @@ test "the empty view shows the connection status and a zero count" {
     var model = main.initialModel(); // .connecting, empty queue
     const tree = try buildTree(arena_state.allocator(), &model);
 
-    _ = try expectByText(tree.root, .text, "Signer Approvals");
+    _ = try expectByText(tree.root, .text, "Signet");
     _ = try expectByText(tree.root, .text, "Connecting to the signer…");
     _ = try expectByText(tree.root, .status_bar, "0 pending");
 }


### PR DESCRIPTION
Names the GUI after the product. Updates the app manifest (`id` → `com.zig-nostr.signet`, `name` → `signet`, display name and window title → **Signet**), the header, the binary name (`signet`), the packaged bundle (`Signet.app`), the accessibility labels, and the docs. The daemon binary stays `signer`. Verified: `native check`/`test`/`build` pass and `scripts/package-macos.sh` produces `Signet.app` (`signer` + `signet` in Contents/MacOS).