### PR TITLE
fix: wrap the imported key so a long nsec doesn't overflow the input

### DIFF
--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -25,9 +25,9 @@
         <toggle-button selected="{import_selected}" on-press="choose_import" grow="1">Import existing</toggle-button>
       </row>
       <if test="{import_selected}">
-        <text-field text="{secret}" placeholder="nsec1… or 64-char hex secret key" on-input="secret_edit"/>
+        <row><textarea text="{secret}" placeholder="nsec1… or 64-char hex secret key" on-input="secret_edit" grow="1"/></row>
       </if>
-      <text-field text="{passphrase}" placeholder="Passphrase (encrypts your key at rest)" on-input="passphrase_edit" on-submit="submit_setup" autofocus="true"/>
+      <row><text-field text="{passphrase}" placeholder="Passphrase (encrypts your key at rest)" on-input="passphrase_edit" on-submit="submit_setup" autofocus="true" grow="1"/></row>
       <if test="{has_onboard_error}">
         <text foreground="destructive">{onboard_error}</text>
       </if>
@@ -38,7 +38,7 @@
     <column gap="12" grow="1" padding="20">
       <text size="heading">Unlock your signer</text>
       <text>Enter your passphrase to unlock the signing key.</text>
-      <text-field text="{passphrase}" placeholder="Passphrase" on-input="passphrase_edit" on-submit="submit_unlock" autofocus="true"/>
+      <row><text-field text="{passphrase}" placeholder="Passphrase" on-input="passphrase_edit" on-submit="submit_unlock" autofocus="true" grow="1"/></row>
       <if test="{has_onboard_error}">
         <text foreground="destructive">{onboard_error}</text>
       </if>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -506,7 +506,9 @@ fn sendSetup(model: *Model, fx: *Effects) void {
     const url = std.fmt.bufPrint(&url_buf, "{s}/setup", .{model.baseUrl()}) catch return;
     var body_buf: [768]u8 = undefined;
     const Body = struct { passphrase: []const u8, secret: []const u8 };
-    const secret = if (model.import_mode) model.secret() else "";
+    // Trim whitespace so a stray space or newline (the key field is a wrapping
+    // textarea) can't corrupt a pasted nsec/hex secret.
+    const secret = if (model.import_mode) std.mem.trim(u8, model.secret(), " \t\r\n") else "";
     const body = std.fmt.bufPrint(&body_buf, "{f}", .{std.json.fmt(Body{ .passphrase = model.passphrase(), .secret = secret }, .{})}) catch return;
     const headers = [_]std.http.Header{
         .{ .name = "authorization", .value = model.auth() },


### PR DESCRIPTION
The import field is a single-line `text-field`, which sizes to its content and does not clip — so a full 63-char `nsec1…` grew the field past its border (the ugly overflow visible in the demo). This switches the secret field to a **wrapping `textarea`** (grow-bounded), so the whole key wraps neatly inside the box and is fully readable for verifying a paste; the passphrase fields are width-bounded the same way. `sendSetup` now trims whitespace from the secret so a stray newline (a textarea allows Enter) can't corrupt a pasted key. Verified live via the automation harness: a 63-char nsec wraps cleanly within the field, no overflow.