### PR TITLE
feat: ad-hoc signed macOS releases on version tags

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,0 +1,14 @@
+**Signet** — a native NIP-46 remote signer for Nostr. macOS, **ad-hoc signed (not notarized)**.
+
+### Install
+
+Download the `Signet-*-macos.zip` asset below, unzip it, and move `Signet.app` to `/Applications`.
+
+Because Signet isn't notarized, macOS quarantines the download and shows *"Signet.app is damaged and can't be opened"* on first launch — that's Gatekeeper, not actual damage. Clear the quarantine flag once, then open normally:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/Signet.app
+open /Applications/Signet.app
+```
+
+Removing `com.apple.quarantine` only drops the "downloaded from the internet" marker; the app stays ad-hoc signed. The trust anchor is a reproducible build — this artifact was built by CI from the tagged commit, and you can rebuild it yourself (see the [README](https://github.com/zig-nostr/signet#build)). **Your key never leaves the daemon.**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+# On a version tag, build the daemon + GUI, package a single ad-hoc-signed
+# (not notarized) macOS .app, and publish it as a GitHub release. The artifact
+# is reproducible: it is built here from the tagged commit, and anyone can
+# rebuild it from source (see the README).
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write # create the release and upload the .app
+
+jobs:
+  macos-app:
+    name: package · ad-hoc sign · publish
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read Zig version
+        id: zig-version
+        run: echo "version=$(cat daemon/.zigversion)" >> "$GITHUB_OUTPUT"
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ steps.zig-version.outputs.version }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install the Native SDK CLI
+        run: npm install -g @native-sdk/cli@0.4.1
+
+      - name: Build the daemon (ReleaseFast)
+        run: cd daemon && zig build -Doptimize=ReleaseFast
+
+      - name: Package the app (ad-hoc signed)
+        run: cd gui && scripts/package-macos.sh --signer ../daemon/zig-out/bin/signer
+
+      - name: Zip the .app (ditto preserves the signature)
+        run: ditto -c -k --sequesterRsrc --keepParent "gui/dist/Signet.app" "Signet-${{ github.ref_name }}-macos.zip"
+
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          gh release create "${{ github.ref_name }}"
+          "Signet-${{ github.ref_name }}-macos.zip"
+          --title "Signet ${{ github.ref_name }}"
+          --notes-file .github/RELEASE_NOTES.md

--- a/README.md
+++ b/README.md
@@ -8,14 +8,41 @@ never leaves the signer, and every request waits for your explicit approval.
 Built on [`zig-nostr/nostr`](https://github.com/zig-nostr/nostr).
 
 > **Status: early / work in progress.** The signer works end-to-end over public
-> relays; the native approval GUI and a signed, notarized distributable are in
-> progress.
+> relays, including those that require NIP-42 authentication. Downloads are
+> ad-hoc signed (not notarized) — see [Download](#download).
 
 ![Signet: first-run key setup, then approving a live signing request](gui/assets/demo.gif)
 
 <sub>First-run key setup (create a new key, or import an existing `nsec`), then
 approving a live NIP-46 signing request from a connected client. The key is
 generated and held by the signer daemon — it never enters the GUI.</sub>
+
+## Download
+
+Grab the latest **`Signet-<version>-macos.zip`** from the
+[**releases page**](https://github.com/zig-nostr/signet/releases/latest), unzip
+it, and move `Signet.app` to `/Applications`.
+
+Signet is **ad-hoc signed, not notarized** — on purpose. It holds your keys, so
+the trust anchor is a build you can read and reproduce, not an Apple signature:
+every release is built by CI from a tagged commit
+([`.github/workflows/release.yml`](.github/workflows/release.yml)), and you can
+reproduce it yourself with the [Build](#build) steps below. (Notarizing would
+mean routing each build through an Apple Developer account, which buys a WIP
+key-holder little over a build you verified yourself.)
+
+Because it isn't notarized, macOS Gatekeeper quarantines the download on first
+open (you'll see *"Signet.app is damaged and can't be opened"* — that's the
+quarantine flag, not actual damage). Clear it once, then open normally:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/Signet.app
+open /Applications/Signet.app
+```
+
+Removing `com.apple.quarantine` only drops the "downloaded from the internet"
+marker; the app stays ad-hoc signed. Prefer to trust nothing you didn't build?
+Skip the download and [build from source](#build).
 
 ## Two components, one product
 

--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .signer,
-    .version = "0.0.0",
+    .version = "0.1.0",
     .fingerprint = 0xea6f6d92d62e08e5,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/gui/README.md
+++ b/gui/README.md
@@ -8,7 +8,8 @@ signing requests from your [signer daemon](../daemon).
 > or import), unlocks the key on later launches, then shows each pending signing
 > request and sends back your approve/deny decision — and spawns and supervises
 > the daemon itself. `scripts/package-macos.sh` bundles both into a single
-> `.app`; a signed, notarized distributable is next.
+> `.app`, shipped as ad-hoc-signed macOS releases (not notarized — see the
+> top-level [Download](../README.md#download)).
 
 ![Signet: first-run key setup, then approving a live signing request](assets/demo.gif)
 
@@ -116,9 +117,16 @@ The daemon comes from the [`daemon/`](../daemon) package in this repo; build it
 (`cd ../daemon && zig build -Doptimize=ReleaseFast`) and the script finds
 `../daemon/zig-out/bin/signer` on its own, or pass `--signer <path>`.
 
-Ad-hoc signing (the default) is enough to run the bundle locally. A
-distributable, Gatekeeper-friendly build additionally needs a Developer ID and
-notarization, which require your own Apple credentials:
+Ad-hoc signing (the default) is what releases ship: the release workflow
+([`.github/workflows/release.yml`](../.github/workflows/release.yml)) runs this
+on every version tag and attaches the zipped `.app`. Ad-hoc bundles aren't
+notarized, so macOS Gatekeeper quarantines the download — see
+[**Download**](../README.md#download) in the top-level README for the one-line
+`xattr` step to open it.
+
+Notarizing is deliberately out of scope (a WIP key-holder gains little over a
+build you can reproduce yourself), but the Developer-ID path is still available
+if you want a Gatekeeper-friendly build with your own Apple credentials:
 
 ```sh
 scripts/package-macos.sh --signing identity \
@@ -132,7 +140,7 @@ scripts/package-macos.sh --signing identity \
 - [x] Supervise the daemon as a child process (one launch, key stays isolated)
 - [x] Bundle the daemon into the app — one `.app`, discovered and supervised
 - [x] First-run key onboarding in-app (create / import / unlock)
-- [ ] Signed, notarized distributable (Developer ID)
+- [x] Ad-hoc signed macOS releases (CI on tag; open past Gatekeeper with one `xattr`)
 
 ## License
 

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "signet",
     .display_name = "Signet",
     .description = "Signet — approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.0.0",
+    .version = "0.1.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command" },


### PR DESCRIPTION
Sets up downloadable macOS releases and documents how to install and open them.

- **`.github/workflows/release.yml`** — on a `v*` tag, builds the daemon + GUI, runs `scripts/package-macos.sh` (ad-hoc signed, the default), zips the `.app` with `ditto`, and publishes a GitHub release with the artifact. `permissions: contents: write`, `github.token` only. Reproducible: built by CI from the tagged commit, rebuildable from source.
- **Ad-hoc, not notarized — on purpose.** Signet holds keys, so the trust anchor is a build you can read and reproduce, not an Apple signature. The Developer-ID path stays available (`--signing identity`) for anyone who wants it.
- **Docs** — a **Download** section in the top-level README (and the GUI README) explains the ad-hoc approach and the one-line `xattr -dr com.apple.quarantine` step to open past Gatekeeper (which shows a misleading *"is damaged"* for un-notarized apps). `.github/RELEASE_NOTES.md` carries the same install/open steps onto every release page.
- Versions bumped to **0.1.0** (`gui/app.zon`, `daemon/build.zig.zon`).

Dry-ran the exact build/package/zip steps locally: `Signet.app` (6.2 MB) → `Signet-v0.1.0-macos.zip` (2.5 MB). After merge, tagging `v0.1.0` triggers the first release.