### PR TITLE
fix: pass --approval-http to the bundled daemon so a Finder launch works

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -4,11 +4,14 @@
 
 Download the `Signet-*-macos.zip` asset below, unzip it, and move `Signet.app` to `/Applications`.
 
-Because Signet isn't notarized, macOS quarantines the download and shows *"Signet.app is damaged and can't be opened"* on first launch — that's Gatekeeper, not actual damage. Clear the quarantine flag once, then open normally:
+Because Signet isn't notarized, macOS Gatekeeper blocks the first launch. To open it:
 
-```sh
-xattr -dr com.apple.quarantine /Applications/Signet.app
-open /Applications/Signet.app
-```
+- **Finder (no Terminal):** Control-click (right-click) `Signet.app` → **Open**, then **Open** in the dialog. On recent macOS, if that's still blocked, open **System Settings → Privacy & Security**, scroll to *Security*, and click **Open Anyway** next to the Signet message.
+- **If macOS says it "is damaged":** it isn't — that's the download-quarantine flag on an ad-hoc-signed app, for which Apple withholds the one-click Finder bypass. Clear it from Terminal instead:
 
-Removing `com.apple.quarantine` only drops the "downloaded from the internet" marker; the app stays ad-hoc signed. The trust anchor is a reproducible build — this artifact was built by CI from the tagged commit, and you can rebuild it yourself (see the [README](https://github.com/zig-nostr/signet#build)). **Your key never leaves the daemon.**
+  ```sh
+  xattr -dr com.apple.quarantine /Applications/Signet.app
+  open /Applications/Signet.app
+  ```
+
+Either way you're only clearing the "downloaded from the internet" marker; the app stays ad-hoc signed. The trust anchor is a reproducible build — this artifact was built by CI from the tagged commit, and you can rebuild it yourself (see the [README](https://github.com/zig-nostr/signet#build)). **Your key never leaves the daemon.**

--- a/README.md
+++ b/README.md
@@ -31,18 +31,23 @@ reproduce it yourself with the [Build](#build) steps below. (Notarizing would
 mean routing each build through an Apple Developer account, which buys a WIP
 key-holder little over a build you verified yourself.)
 
-Because it isn't notarized, macOS Gatekeeper quarantines the download on first
-open (you'll see *"Signet.app is damaged and can't be opened"* — that's the
-quarantine flag, not actual damage). Clear it once, then open normally:
+Because it isn't notarized, macOS Gatekeeper blocks the first launch. To open it:
 
-```sh
-xattr -dr com.apple.quarantine /Applications/Signet.app
-open /Applications/Signet.app
-```
+- **Finder (no Terminal):** Control-click (right-click) `Signet.app` → **Open**,
+  then **Open** in the dialog. On recent macOS, if that's still blocked, open
+  **System Settings → Privacy & Security**, scroll to *Security*, and click
+  **Open Anyway** next to the Signet message.
+- **If macOS says it "is damaged":** it isn't — that's the download-quarantine
+  flag on an ad-hoc-signed app, for which Apple withholds the one-click Finder
+  bypass. Clear the flag from Terminal instead:
+  ```sh
+  xattr -dr com.apple.quarantine /Applications/Signet.app
+  open /Applications/Signet.app
+  ```
 
-Removing `com.apple.quarantine` only drops the "downloaded from the internet"
-marker; the app stays ad-hoc signed. Prefer to trust nothing you didn't build?
-Skip the download and [build from source](#build).
+Either way you're only clearing the "downloaded from the internet" marker; the
+app stays ad-hoc signed. Prefer to trust nothing you didn't build? Skip the
+download and [build from source](#build).
 
 ## Two components, one product
 

--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .signer,
-    .version = "0.1.0",
+    .version = "0.1.1",
     .fingerprint = 0xea6f6d92d62e08e5,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -55,7 +55,7 @@ const usage =
     \\
 ;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     const gpa = std.heap.page_allocator;
 
     // `SIGNER_INIT` bootstraps an encrypted key file at rest, then exits.
@@ -66,12 +66,26 @@ pub fn main() !void {
     // Authorization rules, parsed once and shared read-only across relay threads.
     const policy_config = buildPolicyConfig(gpa);
 
-    // GUI mode: when SIGNER_APPROVAL_HTTP is set, the daemon may boot WITHOUT a
-    // key. It stands up the loopback approval API first (reporting its key
-    // state), lets the connected GUI create or unlock the key over /setup and
-    // /unlock, and only then serves. The key is created/decrypted in the daemon;
-    // the GUI never receives it. See onboarding.zig + approval_http.zig.
-    if (getEnv("SIGNER_APPROVAL_HTTP")) |addr| {
+    // GUI/managed mode: the daemon may boot WITHOUT a key. It stands up the
+    // loopback approval API first (reporting its key state), lets the connected
+    // GUI create or unlock the key over /setup and /unlock, and only then serves.
+    // The key is created/decrypted here; the GUI never receives it (see
+    // onboarding.zig + approval_http.zig). The approval address arrives as
+    // `--approval-http <addr>` — how the GUI passes it when it spawns us, since a
+    // Finder-launched app has no environment for the child to inherit — or via
+    // `SIGNER_APPROVAL_HTTP`. Parse argv here so the slice lives for the process
+    // (GUI/relay mode never returns).
+    var approval_addr = getEnv("SIGNER_APPROVAL_HTTP");
+    var args = std.process.Args.Iterator.init(init.minimal.args);
+    _ = args.skip(); // argv[0]
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--approval-http")) {
+            approval_addr = args.next();
+            break;
+        }
+    }
+
+    if (approval_addr) |addr| {
         runGuiMode(gpa, addr, conn_secret, &policy_config);
     }
 

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "signet",
     .display_name = "Signet",
     .description = "Signet — approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.1.0",
+    .version = "0.1.1",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command" },

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -189,6 +189,13 @@ pub const Model = struct {
     pub fn baseUrl(self: *const Model) []const u8 {
         return self.base_url_buf[0..self.base_url_len];
     }
+    /// The bare `host:port` we poll — passed to the spawned daemon as
+    /// `--approval-http` so it serves the API there (a Finder-launched `.app`
+    /// carries no `SIGNER_APPROVAL_HTTP` env for the child to inherit).
+    pub fn approvalAddress(self: *const Model) []const u8 {
+        const url = self.baseUrl();
+        return if (std.mem.startsWith(u8, url, "http://")) url["http://".len..] else url;
+    }
     pub fn setTokenPath(self: *Model, path: []const u8) void {
         const n = @min(path.len, self.token_path_buf.len);
         @memcpy(self.token_path_buf[0..n], path[0..n]);
@@ -426,7 +433,7 @@ fn spawnDaemon(model: *Model, fx: *Effects) void {
     model.phase = .starting;
     fx.spawn(.{
         .key = daemon_key,
-        .argv = &.{model.daemonBin()},
+        .argv = &.{ model.daemonBin(), "--approval-http", model.approvalAddress() },
         .on_line = Effects.lineMsg(.daemon_line),
         .on_exit = Effects.exitMsg(.daemon_exited),
     });


### PR DESCRIPTION
**Fixes the v0.1.0 download** — a Finder-launched `Signet.app` showed *"Signer stopped … The signer exited (code 1)."*

## Root cause

A macOS app launched from Finder inherits a minimal environment (no `SIGNER_*` vars). The GUI spawned the bundled daemon relying on env inheritance, so the daemon saw no `SIGNER_APPROVAL_HTTP`, fell through to **headless** mode, found no relays/key, and `exit(1)`. (Earlier "verified" runs launched from a shell that happened to carry the vars; `setenv` from the GUI doesn't help — the SDK snapshots the env before `loadConfig`.)

## Fix

The GUI now passes the approval endpoint **as an argument** instead of relying on the environment:
- `gui`: `spawnDaemon` → `--argv = { bin, "--approval-http", <host:port> }` (new `Model.approvalAddress`).
- `daemon`: `main` takes `std.process.Init` and reads `--approval-http <addr>` from argv (still honoring `SIGNER_APPROVAL_HTTP`), then enters GUI mode.

Verified against the **real** launch path (`open Signet.app`, no `SIGNER_*` in the environment): the daemon comes up as `signer --approval-http 127.0.0.1:8787`, the approval API listens, the token is written, and `/info` returns `state: uninitialized` — so the GUI shows the **setup screen**, not "Signer stopped."

Also bumps to **0.1.1** and refreshes the Download docs: leads with the Finder / **System Settings → Open Anyway** flow (no Terminal), with the `xattr` one-liner as the fallback for the ad-hoc *"is damaged"* case.