### PR TITLE
feat: show the bunker:// connection URL in the GUI with a Copy button

### DIFF
--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -4,7 +4,7 @@
 //! Deliberately tiny (fixed routes, no keep-alive, no chunked encoding) to keep
 //! the key-holding daemon's attack surface small:
 //!
-//!   GET  /info              {"state":..,"pubkey":..,"relays":[..],"timeout_ms":N}
+//!   GET  /info              {"state":..,"pubkey":..,"bunker":..,"relays":[..],"timeout_ms":N}
 //!   POST /setup             {"passphrase":..,"secret":..?} → create/import a key
 //!   POST /unlock            {"passphrase":..} → decrypt the key file
 //!   GET  /pending?since=N   long-poll (~1s) → {"version":N,"pending":[...]}
@@ -20,10 +20,12 @@
 //! Bound to loopback only.
 
 const std = @import("std");
+const nostr = @import("nostr");
 const approval = @import("approval.zig");
 const onboarding = @import("onboarding.zig");
 
 const net = std.Io.net;
+const nip46 = nostr.nip46;
 const Broker = approval.Broker;
 const Pending = approval.Pending;
 const Gate = onboarding.Gate;
@@ -31,6 +33,9 @@ const Gate = onboarding.Gate;
 pub const Info = struct {
     relays: []const []const u8,
     timeout_ms: u64,
+    /// Optional connection secret clients must echo; folded into the `bunker://`
+    /// URI reported on `/info`. Null in the turnkey case.
+    secret: ?[]const u8 = null,
 };
 
 pub const Server = struct {
@@ -209,12 +214,23 @@ fn handleInfo(self: *Server, w: *std.Io.Writer) !void {
         .locked => "locked",
         .unlocked => "unlocked",
     };
-    // The pubkey is known only once unlocked; report "" until then.
+    // The pubkey and the bunker:// connection URI are known only once unlocked;
+    // report "" until then. The URI is the string a client needs to connect, so
+    // the GUI shows and copies it — building it here keeps the canonical NIP-46
+    // format (and the connection secret) in the daemon.
     const pubkey = if (state == .unlocked) self.gate.pubkeyHex() else "";
+    const bunker_uri: ?[]u8 = if (state == .unlocked)
+        nip46.buildBunkerUri(self.gpa, self.gate.pubkey(), self.info.relays, self.info.secret) catch null
+    else
+        null;
+    defer if (bunker_uri) |b| self.gpa.free(b);
+    const bunker = bunker_uri orelse "";
 
     var json: std.ArrayList(u8) = .empty;
     defer json.deinit(self.gpa);
-    const head = try std.fmt.allocPrint(self.gpa, "{{\"state\":\"{s}\",\"pubkey\":\"{s}\",\"timeout_ms\":{d},\"relays\":[", .{ state_str, pubkey, self.info.timeout_ms });
+    // Relay URLs and the bunker URI carry no JSON metacharacters (the URI
+    // percent-encodes relay params), so they are emitted without escaping.
+    const head = try std.fmt.allocPrint(self.gpa, "{{\"state\":\"{s}\",\"pubkey\":\"{s}\",\"bunker\":\"{s}\",\"timeout_ms\":{d},\"relays\":[", .{ state_str, pubkey, bunker, self.info.timeout_ms });
     defer self.gpa.free(head);
     try json.appendSlice(self.gpa, head);
     for (self.info.relays, 0..) |relay, i| {
@@ -348,4 +364,65 @@ test "parseSince reads the query parameter" {
     try testing.expectEqual(@as(u64, 0), parseSince("/pending"));
     try testing.expectEqual(@as(u64, 7), parseSince("/pending?since=7"));
     try testing.expectEqual(@as(u64, 3), parseSince("/pending?foo=1&since=3"));
+}
+
+test "GET /info reports the bunker URI once unlocked" {
+    const gpa = testing.allocator;
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    // BIP-340 test vector — the same key/pubkey the main.zig bunker-token test uses.
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    gate.preload(kp); // marks unlocked and stores the pubkey; touches no key file
+
+    var broker: Broker = .{};
+    const relays = [_][]const u8{"wss://relay.example.com"};
+    var server = Server{
+        .gpa = gpa,
+        .broker = &broker,
+        .gate = &gate,
+        .token = "t",
+        .info = .{ .relays = &relays, .timeout_ms = 1000, .secret = "s3cret" },
+        .host = "127.0.0.1",
+        .port = 0,
+    };
+
+    var out = std.Io.Writer.Allocating.init(gpa);
+    defer out.deinit();
+    try handleInfo(&server, &out.writer);
+    var body = out.toArrayList();
+    defer body.deinit(gpa);
+
+    try testing.expect(std.mem.indexOf(u8, body.items, "\"state\":\"unlocked\"") != null);
+    try testing.expect(std.mem.indexOf(u8, body.items, "\"bunker\":\"bunker://dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659?") != null);
+    try testing.expect(std.mem.indexOf(u8, body.items, "secret=s3cret") != null);
+}
+
+test "GET /info omits the bunker URI until the key is unlocked" {
+    const gpa = testing.allocator;
+
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    var broker: Broker = .{};
+    const relays = [_][]const u8{"wss://relay.example.com"};
+    var server = Server{
+        .gpa = gpa,
+        .broker = &broker,
+        .gate = &gate,
+        .token = "t",
+        .info = .{ .relays = &relays, .timeout_ms = 1000, .secret = null },
+        .host = "127.0.0.1",
+        .port = 0,
+    };
+
+    var out = std.Io.Writer.Allocating.init(gpa);
+    defer out.deinit();
+    try handleInfo(&server, &out.writer);
+    var body = out.toArrayList();
+    defer body.deinit(gpa);
+
+    try testing.expect(std.mem.indexOf(u8, body.items, "\"state\":\"uninitialized\"") != null);
+    try testing.expect(std.mem.indexOf(u8, body.items, "\"bunker\":\"\"") != null);
 }

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -145,7 +145,7 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
         .broker = &broker_storage,
         .gate = &gate,
         .token = token_hex,
-        .info = .{ .relays = relays.items, .timeout_ms = broker_storage.timeout_ms },
+        .info = .{ .relays = relays.items, .timeout_ms = broker_storage.timeout_ms, .secret = conn_secret },
         .host = hp.host,
         .port = hp.port,
     };

--- a/daemon/src/onboarding.zig
+++ b/daemon/src/onboarding.zig
@@ -52,6 +52,7 @@ pub const Gate = struct {
     // path only after it observes `.unlocked` (`.acquire`). Never leaves the
     // process.
     secret_key: [32]u8 = undefined,
+    pubkey_bytes: [32]u8 = undefined,
     pubkey_hex_buf: [64]u8 = undefined,
     pubkey_len: usize = 0,
 
@@ -71,6 +72,12 @@ pub const Gate = struct {
     /// The derived public key (hex), valid once `current() == .unlocked`.
     pub fn pubkeyHex(self: *const Gate) []const u8 {
         return self.pubkey_hex_buf[0..self.pubkey_len];
+    }
+
+    /// The derived public key (x-only bytes), valid once `current() == .unlocked`.
+    /// Used to build the `bunker://` connection URI reported on `/info`.
+    pub fn pubkey(self: *const Gate) [32]u8 {
+        return self.pubkey_bytes;
     }
 
     /// Creates the encrypted key file: imports `secret` (an `nsec1…` or 64-char
@@ -143,6 +150,7 @@ pub const Gate = struct {
 
     fn publish(self: *Gate, kp: keys.KeyPair) void {
         self.secret_key = kp.secret_key;
+        self.pubkey_bytes = kp.public_key;
         const h = hex.encode(self.gpa, &kp.public_key) catch "";
         defer if (h.len != 0) self.gpa.free(h);
         const n = @min(h.len, self.pubkey_hex_buf.len);

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -6,7 +6,7 @@
     .version = "0.1.1",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
-    .permissions = .{ "view", "command" },
+    .permissions = .{ "view", "command", "clipboard" },
     .capabilities = .{ "native_views", "gpu_surfaces" },
     .shell = .{
         .windows = .{

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -10,6 +10,18 @@
     <text>signer {pubkey_short}</text>
   </column>
   <separator/>
+  <if test="{show_bunker}">
+    <column gap="6" padding="16">
+      <text foreground="text_muted">Bunker URL — paste into your Nostr client to connect</text>
+      <card padding="12">
+        <column gap="10">
+          <text wrap="true">{bunker}</text>
+          <button variant="secondary" on-press="copy_bunker">{copy_label}</button>
+        </column>
+      </card>
+    </column>
+    <separator/>
+  </if>
   <if test="{daemon_down}">
     <column gap="12" main="center" cross="center" grow="1" padding="24">
       <text>{exit_note}</text>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -39,7 +39,7 @@ const canvas_label = "main-canvas";
 const window_width: f32 = 460;
 const window_height: f32 = 560;
 
-const app_permissions = [_][]const u8{ native_sdk.security.permission_command, native_sdk.security.permission_view };
+const app_permissions = [_][]const u8{ native_sdk.security.permission_command, native_sdk.security.permission_view, native_sdk.security.permission_clipboard };
 const shell_views = [_]native_sdk.ShellView{
     .{ .label = canvas_label, .kind = .gpu_surface, .fill = true, .role = "Signet canvas", .accessibility_label = "Signet", .gpu_backend = .metal, .gpu_pixel_format = .bgra8_unorm, .gpu_present_mode = .timer, .gpu_alpha_mode = .@"opaque", .gpu_color_space = .srgb, .gpu_vsync = true },
 };
@@ -68,9 +68,11 @@ const info_key: u64 = 3;
 const pending_key: u64 = 4;
 const setup_key: u64 = 5;
 const unlock_key: u64 = 6;
+const clipboard_key: u64 = 7;
 const decision_key_base: u64 = 8;
 const decision_key_slots: u64 = 8;
 const retry_timer_key: u64 = 100;
+const copy_reset_timer_key: u64 = 101;
 
 fn decisionKey(id: u64) u64 {
     return decision_key_base + (id % decision_key_slots);
@@ -153,6 +155,14 @@ pub const Model = struct {
     pubkey_buf: [64]u8 = [_]u8{0} ** 64,
     pubkey_len: usize = 0,
     timeout_ms: u64 = 0,
+    /// The `bunker://` connection URI from `/info`, valid while serving. This is
+    /// the string the user pastes into a Nostr client to connect, so the serving
+    /// screen shows it with a Copy button. Sized for the pubkey + several relays.
+    bunker_buf: [1024]u8 = [_]u8{0} ** 1024,
+    bunker_len: usize = 0,
+    /// True briefly after the Copy button writes the URI to the clipboard, so the
+    /// button can confirm with "Copied!". Reset by a short one-shot timer.
+    copied: bool = false,
     /// Short human note for the `.daemon_exited` state, e.g. "signer exited
     /// (code 1)".
     exit_note_buf: [64]u8 = [_]u8{0} ** 64,
@@ -344,6 +354,36 @@ pub const Model = struct {
         self.pubkey_len = n;
     }
 
+    /// The full `bunker://` connection URI, shown on the serving screen.
+    pub fn bunker(self: *const Model) []const u8 {
+        return self.bunker_buf[0..self.bunker_len];
+    }
+    /// Show the connection card only while serving with a URI in hand.
+    pub fn show_bunker(self: *const Model) bool {
+        return self.phase == .connected and self.bunker_len > 0;
+    }
+    /// Copy-button label, confirming briefly after a successful copy.
+    pub fn copy_label(self: *const Model) []const u8 {
+        return if (self.copied) "Copied!" else "Copy";
+    }
+
+    /// Stores the `bunker://` URI from `/info`; a changed URI clears the stale
+    /// "Copied!" confirmation. An over-long URI (absurd relay count) is dropped
+    /// rather than truncated, so the shown string is always a valid URI.
+    fn setBunker(self: *Model, uri: []const u8) void {
+        if (uri.len > self.bunker_buf.len) {
+            self.clearBunker();
+            return;
+        }
+        if (!std.mem.eql(u8, uri, self.bunker())) self.copied = false;
+        @memcpy(self.bunker_buf[0..uri.len], uri);
+        self.bunker_len = uri.len;
+    }
+    fn clearBunker(self: *Model) void {
+        self.bunker_len = 0;
+        self.copied = false;
+    }
+
     fn setExitNote(self: *Model, exit: native_sdk.EffectExit) void {
         const s = switch (exit.reason) {
             .spawn_failed, .rejected => std.fmt.bufPrint(&self.exit_note_buf, "The signer failed to start — check SIGNER_BIN.", .{}),
@@ -409,6 +449,12 @@ pub const Msg = union(enum) {
     approve: u64,
     reject: u64,
     restart,
+
+    // Copy the bunker:// URI to the clipboard, its result, and the timer that
+    // clears the transient "Copied!" confirmation.
+    copy_bunker,
+    bunker_copied: native_sdk.EffectClipboardResult,
+    copy_reset: native_sdk.EffectTimer,
 
     // Onboarding (first-run key setup / unlock).
     passphrase_edit: canvas.TextInputEvent,
@@ -595,6 +641,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             model.setExitNote(exit);
             model.setAuth("");
             model.clearRows();
+            model.clearBunker(); // the connection URI is stale once the daemon is gone
             model.clearSecrets(); // don't keep a passphrase around a dead daemon
             model.clearOnboardError();
             model.submitting = false;
@@ -690,6 +737,30 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             attemptConnect(model, fx);
         },
 
+        .copy_bunker => {
+            const uri = model.bunker();
+            if (uri.len == 0) return;
+            fx.writeClipboard(.{
+                .key = clipboard_key,
+                .text = uri,
+                .on_result = Effects.clipboardMsg(.bunker_copied),
+            });
+        },
+        .bunker_copied => |result| {
+            if (result.outcome != .ok) return;
+            model.copied = true;
+            // Return the button to "Copy" shortly after confirming.
+            fx.startTimer(.{
+                .key = copy_reset_timer_key,
+                .interval_ms = 1_500,
+                .mode = .one_shot,
+                .on_fire = Effects.timerMsg(.copy_reset),
+            });
+        },
+        .copy_reset => |t| {
+            if (t.outcome == .fired) model.copied = false;
+        },
+
         // -- onboarding --
         .passphrase_edit => |e| model.passphrase_buf.apply(e),
         .secret_edit => |e| model.secret_buf.apply(e),
@@ -727,7 +798,9 @@ fn onOnboardResponse(model: *Model, fx: *Effects, r: native_sdk.EffectResponse, 
         model.clearOnboardError();
         model.version = 0; // a fresh serving session; poll the queue from the start
         model.phase = .connected;
-        pollPending(model, fx);
+        // Pull /info so we learn the bunker:// URI to show the user; its handler
+        // arms the pending-queue poll once it confirms the unlocked state.
+        fetchInfo(model, fx);
         return;
     }
     if (r.outcome == .ok) switch (r.status) {
@@ -744,15 +817,17 @@ fn onOnboardResponse(model: *Model, fx: *Effects, r: native_sdk.EffectResponse, 
 // -------------------------------------------------------- response parsing
 
 /// Fills `model` from a `GET /info` body:
-/// `{"state":..,"pubkey":..,"timeout_ms":..}`. `state` selects the screen
-/// (onboarding vs the queue); malformed input is ignored.
+/// `{"state":..,"pubkey":..,"bunker":..,"timeout_ms":..}`. `state` selects the
+/// screen (onboarding vs the queue); `bunker` is the connection URI shown while
+/// serving (empty until unlocked); malformed input is ignored.
 pub fn parseInfo(model: *Model, body: []const u8) void {
     var buf: [4096]u8 = undefined;
     var fba = std.heap.FixedBufferAllocator.init(&buf);
-    const Info = struct { state: []const u8 = "", pubkey: []const u8 = "", timeout_ms: u64 = 0 };
+    const Info = struct { state: []const u8 = "", pubkey: []const u8 = "", bunker: []const u8 = "", timeout_ms: u64 = 0 };
     const parsed = std.json.parseFromSliceLeaky(Info, fba.allocator(), body, .{ .ignore_unknown_fields = true }) catch return;
     model.setInfoState(parsed.state);
     model.setPubkey(parsed.pubkey);
+    model.setBunker(parsed.bunker);
     model.timeout_ms = parsed.timeout_ms;
 }
 

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -53,6 +53,39 @@ test "parseInfo fills the header fields" {
     try testing.expectEqual(@as(u64, 120000), m.timeout_ms);
 }
 
+test "parseInfo reads the bunker URI and show_bunker gates on serving" {
+    var m = Model{};
+    main.parseInfo(&m, "{\"state\":\"unlocked\",\"pubkey\":\"aabb\",\"bunker\":\"bunker://aabb?relay=wss%3A%2F%2Fr.example\",\"timeout_ms\":0}");
+    try testing.expectEqualStrings("bunker://aabb?relay=wss%3A%2F%2Fr.example", m.bunker());
+
+    // The connection card shows only while serving (phase == .connected).
+    try testing.expect(!m.show_bunker());
+    m.phase = .connected;
+    try testing.expect(m.show_bunker());
+
+    // A still-locked daemon reports no URI, so there is nothing to show or copy.
+    var locked = Model{};
+    locked.phase = .connected;
+    main.parseInfo(&locked, "{\"state\":\"locked\"}");
+    try testing.expectEqualStrings("", locked.bunker());
+    try testing.expect(!locked.show_bunker());
+}
+
+test "the copy confirmation resets only when the bunker URI changes" {
+    var m = Model{};
+    const same = "{\"state\":\"unlocked\",\"bunker\":\"bunker://aabb?relay=wss%3A%2F%2Fr.example\"}";
+    main.parseInfo(&m, same);
+
+    m.copied = true;
+    main.parseInfo(&m, same); // an unchanged URI keeps the "Copied!" confirmation
+    try testing.expect(m.copied);
+    try testing.expectEqualStrings("Copied!", m.copy_label());
+
+    main.parseInfo(&m, "{\"state\":\"unlocked\",\"bunker\":\"bunker://cccc?relay=wss%3A%2F%2Fr.example\"}");
+    try testing.expect(!m.copied); // a changed URI clears the stale confirmation
+    try testing.expectEqualStrings("Copy", m.copy_label());
+}
+
 test "parsePending loads the queue with kinds and formatted labels" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();


### PR DESCRIPTION
## What

The GUI never surfaced the `bunker://` connection URI — the string a client needs to connect to the signer — even though the daemon builds it. It was only printed to the daemon's stderr in headless mode, so a GUI user had no way to connect a client.

Now:
- **Daemon** assembles the URI with `nip46.buildBunkerUri` (keeping the canonical NIP-46 format *and* the connection secret in the daemon) and reports it on `GET /info` once the key is unlocked — empty until then.
- **GUI** shows it on the serving screen with a **Copy** button (canvas text isn't reliably mouse-selectable) that writes it to the system clipboard and briefly confirms with "Copied!".

It appears after key **creation** and after **import/unlock** alike, since all three unlock the daemon's gate and the GUI refreshes from `/info`.

## Verification
- Daemon: `zig build test` — 26/26 (incl. two new `/info` tests: reports the URI once unlocked, omits it while locked). Live `curl /info` in GUI mode returns `"bunker":"bunker://<pubkey>?relay=…&secret=…"`.
- GUI: `native test` — 19/19 (incl. bunker parsing, `show_bunker` gating, copy-confirmation reset); model-contract validates the new bindings.
- **End-to-end via the automation harness**: created a key in the GUI → the bunker card rendered with the wrapped URL → clicked Copy → the full URI landed on the system clipboard (`pbpaste`) and the button confirmed "Copied!".