### PR TITLE
feat: one-line macOS installer; simplify install docs

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,16 +1,11 @@
-**Signet** — a native NIP-46 remote signer for Nostr. macOS, **ad-hoc signed (not notarized)**.
+**Signet** — a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
 ### Install
 
-Download the `Signet-*-macos.zip` asset below, unzip it, and move `Signet.app` to `/Applications`.
-
-Because Signet isn't notarized, macOS quarantines the download and Gatekeeper blocks the first launch. Clear the quarantine flag once — this is the reliable step:
-
 ```sh
-xattr -dr com.apple.quarantine /Applications/Signet.app
-open /Applications/Signet.app
+curl -fsSL https://raw.githubusercontent.com/zig-nostr/signet/main/scripts/install-macos.sh | bash
 ```
 
-(Finder's right-click → **Open**, or **System Settings → Privacy & Security → Open Anyway**, works on some setups too — but on recent macOS an ad-hoc app is often flagged *"is damaged"*, where only the command above clears it.)
+The installer downloads the latest release, verifies its SHA-256, installs `Signet.app` to `/Applications`, and opens it — ready to use.
 
-Either way you're only clearing the "downloaded from the internet" marker; the app stays ad-hoc signed. The trust anchor is a reproducible build — this artifact was built by CI from the tagged commit, and you can rebuild it yourself (see the [README](https://github.com/zig-nostr/signet#build)). **Your key never leaves the daemon.**
+Signet is ad-hoc signed, not notarized, on purpose: it holds your keys, so the trust anchor is a build you can reproduce, not an Apple signature. Read the [installer](https://github.com/zig-nostr/signet/blob/main/scripts/install-macos.sh) or [build from source](https://github.com/zig-nostr/signet#build). **Your key never leaves the daemon.**

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Built on [`zig-nostr/nostr`](https://github.com/zig-nostr/nostr).
 
 > **Status: early / work in progress.** The signer works end-to-end over public
 > relays, including those that require NIP-42 authentication. Downloads are
-> ad-hoc signed (not notarized) — see [Download](#download).
+> ad-hoc signed (not notarized) — see [Install](#install).
 
 ![Signet: first-run key setup, then approving a live signing request](gui/assets/demo.gif)
 
@@ -18,36 +18,23 @@ to copy into a client, live per-relay status, and approving a real NIP-46 signin
 request. The key is generated and held by the signer daemon — it never enters the
 GUI.</sub>
 
-## Download
+## Install
 
-Grab the latest **`Signet-<version>-macos.zip`** from the
-[**releases page**](https://github.com/zig-nostr/signet/releases/latest), unzip
-it, and move `Signet.app` to `/Applications`.
-
-Signet is **ad-hoc signed, not notarized** — on purpose. It holds your keys, so
-the trust anchor is a build you can read and reproduce, not an Apple signature:
-every release is built by CI from a tagged commit
-([`.github/workflows/release.yml`](.github/workflows/release.yml)), and you can
-reproduce it yourself with the [Build](#build) steps below. (Notarizing would
-mean routing each build through an Apple Developer account, which buys a WIP
-key-holder little over a build you verified yourself.)
-
-Because it isn't notarized, macOS quarantines the download and Gatekeeper blocks
-the first launch. Clear the quarantine flag once — this is the reliable step:
+**macOS (Apple Silicon):**
 
 ```sh
-xattr -dr com.apple.quarantine /Applications/Signet.app
-open /Applications/Signet.app
+curl -fsSL https://raw.githubusercontent.com/zig-nostr/signet/main/scripts/install-macos.sh | bash
 ```
 
-That only strips the "downloaded from the internet" marker; the app stays ad-hoc
-signed. (Finder's right-click → **Open**, or **System Settings → Privacy &
-Security → Open Anyway**, works on some setups too — but on recent macOS an
-ad-hoc app is often flagged *"is damaged"*, where only the command above clears
-it.)
+That downloads the latest release, verifies its SHA-256, installs `Signet.app`
+to `/Applications`, and opens it — ready to use.
 
-Prefer to trust nothing you didn't build? Skip the download and
-[build from source](#build).
+Signet is **ad-hoc signed, not notarized** — on purpose. It holds your keys, so
+the trust anchor is a build you can reproduce, not an Apple signature: every
+release is built by CI from a tagged commit
+([`.github/workflows/release.yml`](.github/workflows/release.yml)). Prefer to
+trust nothing you didn't run? Read the
+[installer](scripts/install-macos.sh) and [build from source](#build).
 
 ## Two components, one product
 

--- a/gui/README.md
+++ b/gui/README.md
@@ -9,7 +9,7 @@ signing requests from your [signer daemon](../daemon).
 > request and sends back your approve/deny decision — and spawns and supervises
 > the daemon itself. `scripts/package-macos.sh` bundles both into a single
 > `.app`, shipped as ad-hoc-signed macOS releases (not notarized — see the
-> top-level [Download](../README.md#download)).
+> top-level [Install](../README.md#install)).
 
 ![Signet: first-run key setup, then approving a live signing request](assets/demo.gif)
 
@@ -121,9 +121,9 @@ The daemon comes from the [`daemon/`](../daemon) package in this repo; build it
 Ad-hoc signing (the default) is what releases ship: the release workflow
 ([`.github/workflows/release.yml`](../.github/workflows/release.yml)) runs this
 on every version tag and attaches the zipped `.app`. Ad-hoc bundles aren't
-notarized, so macOS Gatekeeper quarantines the download — see
-[**Download**](../README.md#download) in the top-level README for the one-line
-`xattr` step to open it.
+notarized, so macOS quarantines the download; the
+[one-line installer](../README.md#install) clears that flag on install (or do it
+by hand with `xattr -dr com.apple.quarantine`).
 
 Notarizing is deliberately out of scope (a WIP key-holder gains little over a
 build you can reproduce yourself), but the Developer-ID path is still available
@@ -141,7 +141,7 @@ scripts/package-macos.sh --signing identity \
 - [x] Supervise the daemon as a child process (one launch, key stays isolated)
 - [x] Bundle the daemon into the app — one `.app`, discovered and supervised
 - [x] First-run key onboarding in-app (create / import / unlock)
-- [x] Ad-hoc signed macOS releases (CI on tag; open past Gatekeeper with one `xattr`)
+- [x] Ad-hoc signed macOS releases + one-line installer (CI on tag; clears quarantine on install)
 
 ## License
 

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Signet — one-line macOS installer.
+#
+#   curl -fsSL https://raw.githubusercontent.com/zig-nostr/signet/main/scripts/install-macos.sh | bash
+#
+# Downloads the latest release, verifies its SHA-256, installs Signet.app to
+# /Applications (or ~/Applications), clears the download-quarantine flag so it
+# opens without a Gatekeeper detour, and launches it. Signet is ad-hoc signed
+# (not notarized) on purpose — it holds your keys, so the trust anchor is a build
+# you can reproduce, not an Apple signature. Read this script and build from
+# source (https://github.com/zig-nostr/signet#build) if you'd rather.
+#
+set -euo pipefail
+
+repo="zig-nostr/signet"
+app="Signet.app"
+
+say()  { printf '\033[1m==>\033[0m %s\n' "$1"; }
+die()  { printf '\033[1;31merror:\033[0m %s\n' "$1" >&2; exit 1; }
+
+# --- platform checks -------------------------------------------------------
+[ "$(uname -s)" = "Darwin" ] || die "Signet is a macOS app; this installer is macOS-only."
+[ "$(uname -m)" = "arm64" ] || die "Signet ships for Apple Silicon (arm64) only. On an Intel Mac, build from source: https://github.com/$repo#build"
+
+for tool in curl shasum ditto xattr; do
+  command -v "$tool" >/dev/null 2>&1 || die "missing required tool: $tool"
+done
+
+# --- find the latest release asset -----------------------------------------
+say "Finding the latest Signet release…"
+api="https://api.github.com/repos/$repo/releases/latest"
+json="$(curl -fsSL "$api")" || die "could not reach the GitHub API."
+
+tag="$(printf '%s' "$json" | grep -o '"tag_name":[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+url="$(printf '%s' "$json" | grep -o '"browser_download_url":[[:space:]]*"[^"]*macos\.zip"' | head -1 | sed -E 's/.*"(https[^"]+)".*/\1/')"
+digest="$(printf '%s' "$json" | grep -o 'sha256:[0-9a-f]\{64\}' | head -1 | cut -d: -f2)"
+
+[ -n "$url" ] || die "no macOS build found on the latest release ($tag)."
+say "Latest release: ${tag:-unknown}"
+
+# --- download + verify -----------------------------------------------------
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+zip="$tmp/signet-macos.zip"
+
+say "Downloading $(basename "$url")…"
+curl -fSL --progress-bar -o "$zip" "$url" || die "download failed."
+
+if [ -n "$digest" ]; then
+  got="$(shasum -a 256 "$zip" | awk '{print $1}')"
+  [ "$got" = "$digest" ] || die "checksum mismatch (expected $digest, got $got). Aborting."
+  say "SHA-256 verified."
+else
+  say "No published checksum for this release; skipping verification."
+fi
+
+# --- unpack ----------------------------------------------------------------
+say "Unpacking…"
+ditto -x -k "$zip" "$tmp/unpack" || die "could not unzip the download."
+src="$tmp/unpack/$app"
+[ -d "$src" ] || die "the download did not contain $app."
+
+# --- choose an install location we can actually write to -------------------
+if [ -w "/Applications" ] || { [ ! -e "/Applications/$app" ] && mkdir -p "/Applications" 2>/dev/null && [ -w "/Applications" ]; }; then
+  dest="/Applications"
+else
+  dest="$HOME/Applications"
+  mkdir -p "$dest"
+fi
+
+# --- install (replace any existing copy) -----------------------------------
+if [ -e "$dest/$app" ]; then
+  say "Replacing the existing $app in $dest…"
+  # ${var:?} guards against ever expanding to "/" if a variable were empty.
+  rm -rf "${dest:?}/${app:?}" || die "could not remove the existing $dest/$app (is it running?)."
+fi
+ditto "$src" "$dest/$app" || die "could not install to $dest."
+
+# --- clear quarantine so it opens without a Gatekeeper detour ---------------
+xattr -dr com.apple.quarantine "$dest/$app" 2>/dev/null || true
+
+say "Installed $app to $dest."
+say "Opening Signet…"
+open "$dest/$app" || say "Open it from $dest/$app whenever you're ready."


### PR DESCRIPTION
## What

Installing Signet is now a single command:

```sh
curl -fsSL https://raw.githubusercontent.com/zig-nostr/signet/main/scripts/install-macos.sh | bash
```

[`scripts/install-macos.sh`](scripts/install-macos.sh) resolves the latest release via the GitHub API, **verifies the asset's published SHA-256**, installs `Signet.app` to `/Applications` (falls back to `~/Applications`), **clears the download-quarantine flag** so it opens without a Gatekeeper detour, and launches it. It refuses non-arm64 / non-macOS with a clear message and is `set -euo pipefail` throughout.

This replaces the old manual **download → unzip → `xattr` → Finder/'Open Anyway'** walkthrough in the README and release notes with just the one-liner plus a one-sentence note on why Signet is ad-hoc signed (and links to read the installer and build from source). Reduces the multiple, easy-to-confuse install paths down to one. Fixes the now-stale `#download` anchors.

## Verification
- `shellcheck` clean; `bash -n` clean.
- Ran the full script end-to-end against the live v0.1.1 release (install target redirected to a temp dir, `open` stubbed): resolved `v0.1.1`, downloaded, **SHA-256 matched**, unpacked, installed `Signet.app`, and **0 quarantine attrs** remained on the installed bundle.

Notarization stays deliberately out of scope (the reproducible-build trust anchor is the point); the installer clearing quarantine is the friendly path a `curl | bash` the user runs themselves makes safe.