### PR TITLE
chore: bump Native SDK CLI to 0.4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: 22
 
       - name: Install the Native SDK CLI
-        run: npm install -g @native-sdk/cli@0.4.1
+        run: npm install -g @native-sdk/cli@0.4.4
 
       - name: Check markup and manifest
         run: native check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: 22
 
       - name: Install the Native SDK CLI
-        run: npm install -g @native-sdk/cli@0.4.1
+        run: npm install -g @native-sdk/cli@0.4.4
 
       - name: Build the daemon (ReleaseFast)
         run: cd daemon && zig build -Doptimize=ReleaseFast


### PR DESCRIPTION
Bumps the pinned Native SDK CLI in both workflows from `0.4.1` to `0.4.4` (`ci.yml`, `release.yml`).

### Why
0.4.2–0.4.4 land purely additive/quality changes relevant to a macOS native-canvas app:
- **0.4.2** — crisper hairline borders (device-pixel snapping) and continuous-coverage rounded-rect AA.
- **0.4.3** — linear-light edge blending (removes dark rims on curved geometry) and single-line field overflow handling.
- **0.4.4** — Windows/Linux native-only host builds (our app already declares no web use — `native check` now reports `web layer: none`) and a new `native skills get zig` Zig-0.16 reference.

No breaking API changes for our app, so **no source changes** are needed — only the CI pin.

### Verification (local, on 0.4.4)
- `native check` — passes (`app.zon is valid`, `web layer: none`).
- `native test` — **20/20 pass**.
- `native build` — succeeds (ReleaseFast).
- Live render via the automation harness — the first-run setup screen renders correctly (Create/Import toggle, passphrase field, buttons) with clean, dark-rim-free rounded borders.