### PR TITLE
chore: release v0.2.0

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 **Signet** — a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
+### What's new in v0.2.0
+
+- **Bunker URL in the app** — the serving screen now shows the `bunker://` connection URL with a Copy button, so you can connect a client without touching the logs.
+- **Live relay status** — watch each relay connect in real time on the serving screen.
+- **One-line install** — the `curl … | bash` command below is new: it verifies the download's checksum and clears quarantine, so the app opens cleanly with no Gatekeeper detour.
+
+Full history in the [CHANGELOG](https://github.com/zig-nostr/signet/blob/main/CHANGELOG.md). **Your key never leaves the daemon.**
+
 ### Install
 
 ```sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to **Signet** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+While pre-1.0, minor versions add capability and patch versions are fixes.
+
+## [0.2.0] — 2026-07-13
+
+### Added
+- The `bunker://` connection URL now appears on the serving screen with a **Copy**
+  button, after both creating a new key and unlocking or importing an existing one
+  — so you can hand a client the connection string without reading the daemon's
+  logs. The URL (and its connection secret) is assembled inside the daemon and
+  never leaves it (#23).
+- **Connected relay status**: the serving screen lists each configured relay with a
+  live indicator — connecting…, connected, or offline — refreshed periodically
+  (#24).
+- A **one-line macOS installer**:
+  `curl -fsSL …/scripts/install-macos.sh | bash` resolves the latest release,
+  verifies its SHA-256, installs `Signet.app` to `/Applications`, clears the
+  download quarantine, and opens it (#25).
+
+### Changed
+- Install docs reduced to the single installer command, leading with the
+  quarantine-clear step instead of a multi-path download/unzip walkthrough
+  (#22, #25).
+- Bumped the Native SDK CLI to 0.4.4 — crisper rendering (device-pixel-snapped
+  borders, linear-light edge blending), no source changes (#26).
+
+## [0.1.1] — 2026-07-12
+
+### Fixed
+- A Finder/LaunchServices launch no longer quits with "signer exited code 1". A
+  double-click hands the app a minimal environment (no `SIGNER_*` variables), so
+  the GUI now passes the approval address to the daemon over `argv` and the daemon
+  still reaches GUI mode (#21).
+
+## [0.1.0] — 2026-07-12
+
+### Added
+- Initial ad-hoc-signed macOS release: a single `.app` bundling the signer daemon
+  and the native approval GUI, first-run key onboarding (create or import,
+  encrypted at rest via NIP-49), and the approval queue over the daemon's
+  loopback-only API. Superseded by 0.1.1.

--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .signer,
-    .version = "0.1.1",
+    .version = "0.2.0",
     .fingerprint = 0xea6f6d92d62e08e5,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "signet",
     .display_name = "Signet",
     .description = "Signet — approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.1.1",
+    .version = "0.2.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command", "clipboard" },


### PR DESCRIPTION
Cuts **v0.2.0** — the first release since the bugfix-only v0.1.1, gathering the user-facing work that's landed on `main`.

### Highlights
- **`bunker://` URL in the GUI** with a Copy button, after create *and* import/unlock — a client can finally be connected without reading the daemon logs; the URL + secret stay in the daemon (#23).
- **Connected relay status** on the serving screen, refreshed live (#24).
- **One-line macOS installer** — checksum-verified, clears quarantine, opens cleanly (#25).
- Native SDK CLI bumped to **0.4.4** (#26).

### Changes in this PR
- `gui/app.zon` + `daemon/build.zig.zon` → `0.2.0`.
- New `CHANGELOG.md` (0.2.0, 0.1.1, 0.1.0).
- `What's new in v0.2.0` prepended to `.github/RELEASE_NOTES.md` (the body `release.yml` publishes).

Merging this does **not** release — pushing the `v0.2.0` tag afterward triggers `release.yml` to build the ad-hoc `.app` and publish the GitHub release.