### PR TITLE
Native SDK 0.7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: 22
 
       - name: Install the Native SDK CLI
-        run: npm install -g @native-sdk/cli@0.4.4
+        run: npm install -g @native-sdk/cli@0.7.2
 
       - name: Check markup and manifest
         run: native check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: 22
 
       - name: Install the Native SDK CLI
-        run: npm install -g @native-sdk/cli@0.4.4
+        run: npm install -g @native-sdk/cli@0.7.2
 
       - name: Build the daemon (ReleaseFast)
         run: cd daemon && zig build -Doptimize=ReleaseFast


### PR DESCRIPTION

From 0.4.4. The GUI is a zero-config app, so its framework comes from the CLI
the workflows install and this is the whole change.

Built, tested and run: 20 tests pass, and the window renders and reports
"connecting to the signer" against no daemon, which is the honest state.

The daemon does not depend on the SDK at all, so it is untouched.

Plaza moved to the same version in the same sitting, which matters because the
two ship in one bundle: the GUI here and the ceremony window there both talk to
the same automation protocol, and a mismatch is silent until a live test reads
a snapshot nobody wrote.