### PR TITLE
Signet is Notary

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-**Signet** — a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
+**Notary** — a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
 ### What's new in v0.2.0
 
@@ -6,14 +6,14 @@
 - **Live relay status** — watch each relay connect in real time on the serving screen.
 - **One-line install** — the `curl … | bash` command below is new: it verifies the download's checksum and clears quarantine, so the app opens cleanly with no Gatekeeper detour.
 
-Full history in the [CHANGELOG](https://github.com/zig-nostr/signet/blob/main/CHANGELOG.md). **Your key never leaves the daemon.**
+Full history in the [CHANGELOG](https://github.com/zig-nostr/notary/blob/main/CHANGELOG.md). **Your key never leaves the daemon.**
 
 ### Install
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/zig-nostr/signet/main/scripts/install-macos.sh | bash
+curl -fsSL https://raw.githubusercontent.com/zig-nostr/notary/main/scripts/install-macos.sh | bash
 ```
 
-The installer downloads the latest release, verifies its SHA-256, installs `Signet.app` to `/Applications`, and opens it — ready to use.
+The installer downloads the latest release, verifies its SHA-256, installs `Notary.app` to `/Applications`, and opens it — ready to use.
 
-Signet is ad-hoc signed, not notarized, on purpose: it holds your keys, so the trust anchor is a build you can reproduce, not an Apple signature. Read the [installer](https://github.com/zig-nostr/signet/blob/main/scripts/install-macos.sh) or [build from source](https://github.com/zig-nostr/signet#build). **Your key never leaves the daemon.**
+Notary is ad-hoc signed, not notarized, on purpose: it holds your keys, so the trust anchor is a build you can reproduce, not an Apple signature. Read the [installer](https://github.com/zig-nostr/notary/blob/main/scripts/install-macos.sh) or [build from source](https://github.com/zig-nostr/notary#build). **Your key never leaves the daemon.**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,13 @@ jobs:
         run: cd gui && scripts/package-macos.sh --signer ../daemon/zig-out/bin/signer
 
       - name: Zip the .app (ditto preserves the signature)
-        run: ditto -c -k --sequesterRsrc --keepParent "gui/dist/Signet.app" "Signet-${{ github.ref_name }}-macos.zip"
+        run: ditto -c -k --sequesterRsrc --keepParent "gui/dist/Notary.app" "Notary-${{ github.ref_name }}-macos.zip"
 
       - name: Publish the release
         env:
           GH_TOKEN: ${{ github.token }}
         run: >
           gh release create "${{ github.ref_name }}"
-          "Signet-${{ github.ref_name }}-macos.zip"
-          --title "Signet ${{ github.ref_name }}"
+          "Notary-${{ github.ref_name }}-macos.zip"
+          --title "Notary ${{ github.ref_name }}"
           --notes-file .github/RELEASE_NOTES.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to **Signet** are documented in this file.
+All notable changes to **Notary** are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 While pre-1.0, minor versions add capability and patch versions are fixes.
@@ -18,7 +18,7 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
   (#24).
 - A **one-line macOS installer**:
   `curl -fsSL …/scripts/install-macos.sh | bash` resolves the latest release,
-  verifies its SHA-256, installs `Signet.app` to `/Applications`, clears the
+  verifies its SHA-256, installs `Notary.app` to `/Applications`, clears the
   download quarantine, and opens it (#25).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Signet
+# Notary
 
-**A native remote signer for [Nostr](https://nostr.com).** Signet keeps your
+**A native remote signer for [Nostr](https://nostr.com).** Notary keeps your
 Nostr secret key on a machine you control and signs for your apps over
 [NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) — the key
 never leaves the signer, and every request waits for your explicit approval.
@@ -11,7 +11,7 @@ Built on [`zig-nostr/nostr`](https://github.com/zig-nostr/nostr).
 > relays, including those that require NIP-42 authentication. Downloads are
 > ad-hoc signed (not notarized) — see [Install](#install).
 
-![Signet: first-run key setup, then approving a live signing request](gui/assets/demo.gif)
+![Notary: first-run key setup, then approving a live signing request](gui/assets/demo.gif)
 
 <sub>First-run key setup, then the serving screen — the `bunker://` connection URL
 to copy into a client, live per-relay status, and approving a real NIP-46 signing
@@ -23,13 +23,13 @@ GUI.</sub>
 **macOS (Apple Silicon):**
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/zig-nostr/signet/main/scripts/install-macos.sh | bash
+curl -fsSL https://raw.githubusercontent.com/zig-nostr/notary/main/scripts/install-macos.sh | bash
 ```
 
-That downloads the latest release, verifies its SHA-256, installs `Signet.app`
+That downloads the latest release, verifies its SHA-256, installs `Notary.app`
 to `/Applications`, and opens it — ready to use.
 
-Signet is **ad-hoc signed, not notarized** — on purpose. It holds your keys, so
+Notary is **ad-hoc signed, not notarized** — on purpose. It holds your keys, so
 the trust anchor is a build you can reproduce, not an Apple signature: every
 release is built by CI from a tagged commit
 ([`.github/workflows/release.yml`](.github/workflows/release.yml)). Prefer to
@@ -38,7 +38,7 @@ trust nothing you didn't run? Read the
 
 ## Two components, one product
 
-Signet is split into two processes on purpose, so the secret key stays isolated
+Notary is split into two processes on purpose, so the secret key stays isolated
 from the user interface:
 
 - **[`daemon/`](daemon)** — the headless NIP-46 signer ("bunker"). It holds the

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,6 +1,6 @@
-# Signet — the GUI
+# Notary — the GUI
 
-**Signet** — a native desktop app that approves or denies Nostr
+**Notary** — a native desktop app that approves or denies Nostr
 signing requests from your [signer daemon](../daemon).
 
 > **Status: early / work in progress.** This is the interactive front end for
@@ -11,7 +11,7 @@ signing requests from your [signer daemon](../daemon).
 > `.app`, shipped as ad-hoc-signed macOS releases (not notarized — see the
 > top-level [Install](../README.md#install)).
 
-![Signet: first-run key setup, then approving a live signing request](assets/demo.gif)
+![Notary: first-run key setup, then approving a live signing request](assets/demo.gif)
 
 <sub>First-run key setup, then the serving screen — the `bunker://` connection URL
 to copy into a client, live per-relay status, and approving a real NIP-46 signing
@@ -106,8 +106,8 @@ in the daemon child.
 ## Packaging
 
 `scripts/package-macos.sh` produces a single, self-contained
-`Signet.app` with both executables side by side in `Contents/MacOS`
-(`signet` and `signer`), so one download brings up both:
+`Notary.app` with both executables side by side in `Contents/MacOS`
+(`notary` and `signer`), so one download brings up both:
 
 ```sh
 # builds the GUI, packages the .app, injects the daemon, and ad-hoc signs it

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -1,8 +1,8 @@
 .{
-    .id = "com.zig-nostr.signet",
-    .name = "signet",
-    .display_name = "Signet",
-    .description = "Signet — approve or deny Nostr signing requests; your key stays in the signer daemon.",
+    .id = "com.zig-nostr.notary",
+    .name = "notary",
+    .display_name = "Notary",
+    .description = "Notary — approve or deny Nostr signing requests; your key stays in the signer daemon.",
     .version = "0.2.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
@@ -12,13 +12,13 @@
         .windows = .{
             .{
                 .label = "main",
-                .title = "Signet",
+                .title = "Notary",
                 .width = 460,
                 .height = 560,
                 .restore_state = false,
                 .restore_policy = "center_on_primary",
                 .views = .{
-                    .{ .label = "main-canvas", .kind = "gpu_surface", .fill = true, .role = "Signet canvas", .accessibility_label = "Signet", .gpu_backend = "metal", .gpu_pixel_format = "bgra8_unorm", .gpu_present_mode = "timer", .gpu_alpha_mode = "opaque", .gpu_color_space = "srgb", .gpu_vsync = true },
+                    .{ .label = "main-canvas", .kind = "gpu_surface", .fill = true, .role = "Notary canvas", .accessibility_label = "Notary", .gpu_backend = "metal", .gpu_pixel_format = "bgra8_unorm", .gpu_present_mode = "timer", .gpu_alpha_mode = "opaque", .gpu_color_space = "srgb", .gpu_vsync = true },
                 },
             },
         },

--- a/gui/scripts/package-macos.sh
+++ b/gui/scripts/package-macos.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Package Signet as a single, self-contained macOS .app.
+# Package Notary as a single, self-contained macOS .app.
 #
 # The bundle carries two executables side by side in Contents/MacOS:
 #
-#   Signet.app/Contents/MacOS/signet   the GUI (CFBundleExecutable)
-#   Signet.app/Contents/MacOS/signer       the daemon it supervises
+#   Notary.app/Contents/MacOS/notary   the GUI (CFBundleExecutable)
+#   Notary.app/Contents/MacOS/signer       the daemon it supervises
 #
 # so one download brings up both: at launch the GUI discovers the `signer`
 # sitting beside it and spawns it (see bundledDaemonPath in src/main.zig). No
@@ -38,7 +38,7 @@ signer_bin="${SIGNER_BIN:-}"
 signing="adhoc"
 identity=""
 outdir="dist"
-app_name="Signet.app"
+app_name="Notary.app"
 
 usage() { sed -n '2,38p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
@@ -76,7 +76,7 @@ signer_bin="$(cd "$(dirname "$signer_bin")" && pwd)/$(basename "$signer_bin")"
 
 echo "==> building the GUI (native build, ReleaseFast)"
 native build
-gui_bin="$root/zig-out/bin/signet"
+gui_bin="$root/zig-out/bin/notary"
 [ -x "$gui_bin" ] || { echo "error: $gui_bin missing after native build" >&2; exit 1; }
 
 app="$outdir/$app_name"

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -1,11 +1,11 @@
-<!-- Signet — the live view. The header shows the connection state
+<!-- Notary — the live view. The header shows the connection state
      and which key you are approving for; the body is one of several mutually
      exclusive states (signer stopped / first-run setup / unlock / no requests /
      the request queue); the status bar counts the queue. Logic is in
      src/main.zig. Validate with: native check -->
 <column gap="0">
   <column gap="4" padding="16">
-    <text size="heading">Signet</text>
+    <text size="heading">Notary</text>
     <text>{status}</text>
     <text>signer {pubkey_short}</text>
   </column>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -1,4 +1,4 @@
-//! Signet — a native desktop approver for the signer daemon.
+//! Notary — a native desktop approver for the signer daemon.
 //!
 //! Architecture: the signer daemon (the daemon/ package in this repo) holds the
 //! secret key and does all Nostr work; this app is a *separate process* that
@@ -41,11 +41,11 @@ const window_height: f32 = 560;
 
 const app_permissions = [_][]const u8{ native_sdk.security.permission_command, native_sdk.security.permission_view, native_sdk.security.permission_clipboard };
 const shell_views = [_]native_sdk.ShellView{
-    .{ .label = canvas_label, .kind = .gpu_surface, .fill = true, .role = "Signet canvas", .accessibility_label = "Signet", .gpu_backend = .metal, .gpu_pixel_format = .bgra8_unorm, .gpu_present_mode = .timer, .gpu_alpha_mode = .@"opaque", .gpu_color_space = .srgb, .gpu_vsync = true },
+    .{ .label = canvas_label, .kind = .gpu_surface, .fill = true, .role = "Notary canvas", .accessibility_label = "Notary", .gpu_backend = .metal, .gpu_pixel_format = .bgra8_unorm, .gpu_present_mode = .timer, .gpu_alpha_mode = .@"opaque", .gpu_color_space = .srgb, .gpu_vsync = true },
 };
 const shell_windows = [_]native_sdk.ShellWindow{.{
     .label = "main",
-    .title = "Signet",
+    .title = "Notary",
     .width = window_width,
     .height = window_height,
     .restore_state = false,
@@ -552,8 +552,8 @@ pub const Msg = union(enum) {
 pub const AppUi = canvas.Ui(Msg);
 pub const app_markup = @embedFile("app.native");
 
-const SignetApp = native_sdk.UiApp(Model, Msg);
-const Effects = SignetApp.Effects;
+const NotaryApp = native_sdk.UiApp(Model, Msg);
+const Effects = NotaryApp.Effects;
 
 fn spawnDaemon(model: *Model, fx: *Effects) void {
     model.phase = .starting;
@@ -1049,8 +1049,8 @@ fn loadConfig(model: *Model, io: std.Io, environ: *const std.process.Environ.Map
 }
 
 pub fn main(init: std.process.Init) !void {
-    const app_state = try SignetApp.create(std.heap.page_allocator, .{
-        .name = "signet",
+    const app_state = try NotaryApp.create(std.heap.page_allocator, .{
+        .name = "notary",
         .scene = shell_scene,
         .canvas_label = canvas_label,
         .init_fx = boot,
@@ -1062,9 +1062,9 @@ pub fn main(init: std.process.Init) !void {
     loadConfig(&app_state.model, init.io, init.environ_map);
 
     try runner.runWithOptions(app_state.app(), .{
-        .app_name = "signet",
-        .window_title = "Signet",
-        .bundle_id = "com.zig-nostr.signet",
+        .app_name = "notary",
+        .window_title = "Notary",
+        .bundle_id = "com.zig-nostr.notary",
         .icon_path = "assets/icon.png",
         .default_frame = geometry.RectF.init(0, 0, window_width, window_height),
         .restore_state = false,

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -180,7 +180,7 @@ test "the empty view shows the connection status and a zero count" {
     var model = main.initialModel(); // .connecting, empty queue
     const tree = try buildTree(arena_state.allocator(), &model);
 
-    _ = try expectByText(tree.root, .text, "Signet");
+    _ = try expectByText(tree.root, .text, "Notary");
     _ = try expectByText(tree.root, .text, "Connecting to the signer…");
     _ = try expectByText(tree.root, .status_bar, "0 pending");
 }

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 #
-# Signet - one-line macOS installer.
+# Notary - one-line macOS installer.
 #
-#   curl -fsSL https://raw.githubusercontent.com/zig-nostr/signet/main/scripts/install-macos.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/zig-nostr/notary/main/scripts/install-macos.sh | bash
 #
-# Downloads the latest release, verifies its SHA-256, installs Signet.app to
+# Downloads the latest release, verifies its SHA-256, installs Notary.app to
 # /Applications (or ~/Applications), clears the download-quarantine flag so it
-# opens without a Gatekeeper detour, and launches it. Signet is ad-hoc signed
+# opens without a Gatekeeper detour, and launches it. Notary is ad-hoc signed
 # (not notarized) on purpose - it holds your keys, so the trust anchor is a build
 # you can reproduce, not an Apple signature. Read this script and build from
-# source (https://github.com/zig-nostr/signet#build) if you'd rather.
+# source (https://github.com/zig-nostr/notary#build) if you'd rather.
 #
 set -euo pipefail
 
@@ -21,12 +21,12 @@ die()  { printf '\033[1;31merror:\033[0m %s\n' "$1" >&2; exit 1; }
 # truncated `curl | bash` (a dropped connection mid-stream) can never execute a
 # half-read script - it just does nothing.
 main() {
-  local repo="zig-nostr/signet"
-  local app="Signet.app"
+  local repo="zig-nostr/notary"
+  local app="Notary.app"
 
   # --- platform checks -----------------------------------------------------
-  [ "$(uname -s)" = "Darwin" ] || die "Signet is a macOS app; this installer is macOS-only."
-  [ "$(uname -m)" = "arm64" ] || die "Signet ships for Apple Silicon (arm64) only. On an Intel Mac, build from source: https://github.com/$repo#build"
+  [ "$(uname -s)" = "Darwin" ] || die "Notary is a macOS app; this installer is macOS-only."
+  [ "$(uname -m)" = "arm64" ] || die "Notary ships for Apple Silicon (arm64) only. On an Intel Mac, build from source: https://github.com/$repo#build"
 
   local tool
   for tool in curl shasum ditto xattr; do
@@ -34,7 +34,7 @@ main() {
   done
 
   # --- find the latest release asset ---------------------------------------
-  say "Finding the latest Signet release..."
+  say "Finding the latest Notary release..."
   local api="https://api.github.com/repos/$repo/releases/latest"
   local json
   json="$(curl -fsSL "$api")" || die "could not reach the GitHub API."
@@ -53,7 +53,7 @@ main() {
   # returns, where a local would be out of scope. ${tmp:-} keeps set -u happy.
   tmp="$(mktemp -d)"
   trap 'rm -rf "${tmp:-}"' EXIT
-  zip="$tmp/signet-macos.zip"
+  zip="$tmp/notary-macos.zip"
 
   say "Downloading $(basename "$url")..."
   curl -fSL --progress-bar -o "$zip" "$url" || die "download failed."
@@ -95,7 +95,7 @@ main() {
   xattr -dr com.apple.quarantine "$dest/$app" 2>/dev/null || true
 
   say "Installed $app to $dest."
-  say "Opening Signet..."
+  say "Opening Notary..."
   open "$dest/$app" || say "Open it from $dest/$app whenever you're ready."
 }
 


### PR DESCRIPTION
The name was always going to change, and this is the last moment it is cheap. The client that pairs with this has no tagged release yet, so nothing published anywhere carries the old name into a bundle, a demo video or a screenshot. After that release it becomes a migration for two apps instead of a rename of one.

## What moves

The repository, the bundle id, the app, the GUI binary, the window title, the installer, the release workflow and the docs. Zero `signet` references remain in the tree.

**The daemon binary keeps its name.** It is called `signer` because that is what it is, not what it is branded as, and renaming it would churn the one file path existing installs depend on, for nothing.

## What this costs

The repository rename leaves a redirect, so the one-line installer URL already published in the existing release notes keeps resolving.

What does **not** carry over is the bundle id. `com.zig-nostr.notary` is a different application to macOS than `com.zig-nostr.signet`, so anyone who installed the old one keeps a working copy that will never update, sitting beside the new one. Two releases old and days into its life is the cheapest that will ever be, which is the argument for doing it now rather than after launch.

## Verified rather than assumed

- both halves build and their tests pass
- `scripts/package-macos.sh` produces `Notary.app` carrying `notary` and `signer`
- `Info.plist` reads `Notary` / `com.zig-nostr.notary` / `notary`
- the ad-hoc signature names `com.zig-nostr.notary`