### PR TITLE
A copy pass over everything a reader sees

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,10 +1,10 @@
-**Notary** — a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
+**Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
 ### What's new in v0.2.0
 
-- **Bunker URL in the app** — the serving screen now shows the `bunker://` connection URL with a Copy button, so you can connect a client without touching the logs.
-- **Live relay status** — watch each relay connect in real time on the serving screen.
-- **One-line install** — the `curl … | bash` command below is new: it verifies the download's checksum and clears quarantine, so the app opens cleanly with no Gatekeeper detour.
+- **Bunker URL in the app**: the serving screen now shows the `bunker://` connection URL with a Copy button, so you can connect a client without touching the logs.
+- **Live relay status**: watch each relay connect in real time on the serving screen.
+- **One-line install**: the `curl … | bash` command below is new: it verifies the download's checksum and clears quarantine, so the app opens cleanly with no Gatekeeper detour.
 
 Full history in the [CHANGELOG](https://github.com/zig-nostr/notary/blob/main/CHANGELOG.md). **Your key never leaves the daemon.**
 
@@ -14,6 +14,6 @@ Full history in the [CHANGELOG](https://github.com/zig-nostr/notary/blob/main/CH
 curl -fsSL https://raw.githubusercontent.com/zig-nostr/notary/main/scripts/install-macos.sh | bash
 ```
 
-The installer downloads the latest release, verifies its SHA-256, installs `Notary.app` to `/Applications`, and opens it — ready to use.
+The installer downloads the latest release, verifies its SHA-256, installs `Notary.app` to `/Applications`, and opens it, ready to use.
 
 Notary is ad-hoc signed, not notarized, on purpose: it holds your keys, so the trust anchor is a build you can reproduce, not an Apple signature. Read the [installer](https://github.com/zig-nostr/notary/blob/main/scripts/install-macos.sh) or [build from source](https://github.com/zig-nostr/notary#build). **Your key never leaves the daemon.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,15 @@ All notable changes to **Notary** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 While pre-1.0, minor versions add capability and patch versions are fixes.
 
-## [0.2.0] — 2026-07-13
+## [0.2.0] - 2026-07-13
 
 ### Added
 - The `bunker://` connection URL now appears on the serving screen with a **Copy**
-  button, after both creating a new key and unlocking or importing an existing one
-  — so you can hand a client the connection string without reading the daemon's
+  button, after both creating a new key and unlocking or importing an existing one so you can hand a client the connection string without reading the daemon's
   logs. The URL (and its connection secret) is assembled inside the daemon and
   never leaves it (#23).
 - **Connected relay status**: the serving screen lists each configured relay with a
-  live indicator — connecting…, connected, or offline — refreshed periodically
+  live indicator (connecting…, connected, or offline) refreshed periodically
   (#24).
 - A **one-line macOS installer**:
   `curl -fsSL …/scripts/install-macos.sh | bash` resolves the latest release,
@@ -25,10 +24,10 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 - Install docs reduced to the single installer command, leading with the
   quarantine-clear step instead of a multi-path download/unzip walkthrough
   (#22, #25).
-- Bumped the Native SDK CLI to 0.4.4 — crisper rendering (device-pixel-snapped
+- Bumped the Native SDK CLI to 0.4.4: crisper rendering (device-pixel-snapped
   borders, linear-light edge blending), no source changes (#26).
 
-## [0.1.1] — 2026-07-12
+## [0.1.1] - 2026-07-12
 
 ### Fixed
 - A Finder/LaunchServices launch no longer quits with "signer exited code 1". A
@@ -36,7 +35,7 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
   the GUI now passes the approval address to the daemon over `argv` and the daemon
   still reaches GUI mode (#21).
 
-## [0.1.0] — 2026-07-12
+## [0.1.0] - 2026-07-12
 
 ### Added
 - Initial ad-hoc-signed macOS release: a single `.app` bundling the signer daemon

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 **A native remote signer for [Nostr](https://nostr.com).** Notary keeps your
 Nostr secret key on a machine you control and signs for your apps over
-[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) — the key
+[NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md): the key
 never leaves the signer, and every request waits for your explicit approval.
 
 Built on [`zig-nostr/nostr`](https://github.com/zig-nostr/nostr).
 
 > **Status: early / work in progress.** The signer works end-to-end over public
 > relays, including those that require NIP-42 authentication. Downloads are
-> ad-hoc signed (not notarized) — see [Install](#install).
+> ad-hoc signed (not notarized). See [Install](#install).
 
 ![Notary: first-run key setup, then approving a live signing request](gui/assets/demo.gif)
 
-<sub>First-run key setup, then the serving screen — the `bunker://` connection URL
+<sub>First-run key setup, then the serving screen: the `bunker://` connection URL
 to copy into a client, live per-relay status, and approving a real NIP-46 signing
-request. The key is generated and held by the signer daemon — it never enters the
+request. The key is generated and held by the signer daemon. It never enters the
 GUI.</sub>
 
 ## Install
@@ -27,9 +27,9 @@ curl -fsSL https://raw.githubusercontent.com/zig-nostr/notary/main/scripts/insta
 ```
 
 That downloads the latest release, verifies its SHA-256, installs `Notary.app`
-to `/Applications`, and opens it — ready to use.
+to `/Applications`, and opens it, ready to use.
 
-Notary is **ad-hoc signed, not notarized** — on purpose. It holds your keys, so
+Notary is **ad-hoc signed, not notarized**, on purpose. It holds your keys, so
 the trust anchor is a build you can reproduce, not an Apple signature: every
 release is built by CI from a tagged commit
 ([`.github/workflows/release.yml`](.github/workflows/release.yml)). Prefer to
@@ -41,20 +41,20 @@ trust nothing you didn't run? Read the
 Notary is split into two processes on purpose, so the secret key stays isolated
 from the user interface:
 
-- **[`daemon/`](daemon)** — the headless NIP-46 signer ("bunker"). It holds the
+- **[`daemon/`](daemon)**: the headless NIP-46 signer ("bunker"). It holds the
   encrypted key, connects to your relays, and in GUI mode serves a
   **loopback-only** approval API. It runs standalone as a CLI for advanced users,
   or supervised by the GUI.
-- **[`gui/`](gui)** — the native desktop approver, built with the
+- **[`gui/`](gui)**: the native desktop approver, built with the
   [Native SDK](https://github.com/vercel-labs/native) (declarative markup plus
-  Zig, rendered natively — no WebView, no Electron). It shows each pending
+  Zig, rendered natively: no WebView, no Electron). It shows each pending
   request and sends back your approve/deny decision. The key never enters it.
 
 Packaged together, one download brings up both as a single macOS `.app`.
 
 ## Build
 
-Each component builds independently — see its own README for details:
+Each component builds independently. See its own README for details:
 
 ```sh
 # daemon (Zig 0.16)
@@ -64,9 +64,9 @@ cd daemon && zig build -Doptimize=ReleaseFast
 cd gui && native build
 ```
 
-- [`daemon/README.md`](daemon/README.md) — running the signer, key management,
+- [`daemon/README.md`](daemon/README.md): running the signer, key management,
   relays, and the approval API.
-- [`gui/README.md`](gui/README.md) — the approval app and how it connects to (or
+- [`gui/README.md`](gui/README.md): the approval app and how it connects to (or
   supervises) the daemon.
 
 ## License

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -5,15 +5,15 @@ remote signer ("bunker") for Nostr, built on the
 [zig-nostr/nostr](https://github.com/zig-nostr/nostr) library.
 
 It keeps your `nsec` on a machine you control and signs on behalf of web and
-native clients over a relay — the secret key never reaches the client.
+native clients over a relay, the secret key never reaches the client.
 
 > **Status: early / work in progress.** This is Showcase 1 of the zig-nostr
 > roadmap. The current build loads an encrypted (NIP-49) key from disk, connects
-> to your relays, and answers NIP-46 requests — `get_public_key`, `sign_event`,
-> `ping`, and NIP-44 encrypt/decrypt — behind the connection secret and an
+> to your relays, and answers NIP-46 requests, `get_public_key`, `sign_event`,
+> `ping`, and NIP-44 encrypt/decrypt, behind the connection secret and an
 > optional method/event-kind allowlist. It can also run in **GUI mode**: it
 > holds each request for interactive approval over a loopback API, and can
-> create or unlock the key on first run from that same API — the key never
+> create or unlock the key on first run from that same API, the key never
 > leaves the daemon. The native approval app itself is landing next.
 
 ## Build
@@ -27,7 +27,7 @@ zig build
 ## Usage
 
 The signer is configured with environment variables. First create an encrypted
-key file — it is stored `0600` as a NIP-49 `ncryptsec`, so your key is never on
+key file. It is stored `0600` as a NIP-49 `ncryptsec`, so your key is never on
 disk in the clear:
 
 ```sh
@@ -56,7 +56,7 @@ Paste the token into a NIP-46-capable client to sign with a key that never
 leaves this process.
 
 For quick local testing you can skip the key file and pass an unencrypted key
-directly with `SIGNER_SECRET_KEY=<64-char hex>` — but that keeps the key in your
+directly with `SIGNER_SECRET_KEY=<64-char hex>`: but that keeps the key in your
 environment in the clear, so prefer the encrypted file otherwise.
 
 ### Restricting what the signer will do
@@ -64,12 +64,12 @@ environment in the clear, so prefer the encrypted file otherwise.
 By default the signer honors every NIP-46 request behind the connection secret.
 Two optional variables narrow that to least privilege:
 
-- `SIGNER_ALLOWED_METHODS` — comma-separated methods the signer will honor, e.g.
+- `SIGNER_ALLOWED_METHODS`: comma-separated methods the signer will honor, e.g.
   `get_public_key,sign_event`. `connect`, `ping`, and `logout` are always
   allowed so the handshake can't be locked out. Use this to run a **sign-only**
   bunker that refuses `nip44_decrypt`, so a connected client can't read your DMs
   through it.
-- `SIGNER_ALLOWED_KINDS` — comma-separated event kinds `sign_event` may sign,
+- `SIGNER_ALLOWED_KINDS`: comma-separated event kinds `sign_event` may sign,
   e.g. `1,7`. A request to sign any other kind is denied.
 
 Denied requests are answered with a NIP-46 error and logged.
@@ -80,18 +80,18 @@ By default a request that passes the allowlist is answered immediately. Set
 `SIGNER_APPROVAL_HTTP` to instead hold each one for interactive approval: the
 daemon serves a small **loopback-only** HTTP API that a separate GUI connects
 to, so you approve or deny each request on screen. The key never leaves the
-daemon — the GUI only ever sees request metadata and sends back a yes/no.
+daemon, the GUI only ever sees request metadata and sends back a yes/no.
 
 In GUI mode the daemon can also boot **without a key** and let the GUI set one
 up on first run, so a freshly downloaded app is turnkey. It reports its key
 state on `GET /info` (`uninitialized` → `locked` → `unlocked`); the GUI creates
 a key with `POST /setup` (generate a fresh one, or import an existing `nsec1…`
 or 64-char hex) or decrypts an existing key file with `POST /unlock`. The key is
-generated and decrypted inside the daemon — only the passphrase (and, on import,
+generated and decrypted inside the daemon, only the passphrase (and, on import,
 the secret you type) ever crosses the API, never a derived key.
 
 ```sh
-# Turnkey: no key file and no passphrase on the command line — the GUI provides
+# Turnkey: no key file and no passphrase on the command line, the GUI provides
 # them. SIGNER_KEY_FILE ($HOME/.zig-nostr-signer.key), SIGNER_APPROVAL_TOKEN_FILE
 # ($HOME/.zig-nostr-signer.token) and SIGNER_RELAYS all default in this mode, so
 # this alone is enough:
@@ -99,7 +99,7 @@ SIGNER_APPROVAL_HTTP="127.0.0.1:8787" \
   zig build run
 ```
 
-You can still preconfigure the key instead of onboarding it — set
+You can still preconfigure the key instead of onboarding it, set
 `SIGNER_KEY_FILE` + `SIGNER_PASSPHRASE` (or the dev-only `SIGNER_SECRET_KEY`) and
 the daemon boots straight to `unlocked`.
 
@@ -107,7 +107,7 @@ The API is bound to loopback and every request must carry the bearer token
 written (mode `0600`) to `SIGNER_APPROVAL_TOKEN_FILE`. Endpoints: `GET /info`,
 `POST /setup`, `POST /unlock`, `GET /pending` (long-poll), `POST /decision`. A
 request left unanswered past the timeout is denied, and the allowlist still
-applies first — so disallowed requests are rejected without ever prompting.
+applies first, so disallowed requests are rejected without ever prompting.
 
 ## Roadmap
 

--- a/daemon/src/approval.zig
+++ b/daemon/src/approval.zig
@@ -12,7 +12,7 @@
 //!   decisions (`resolve`).
 //!
 //! The broker is deliberately independent of the `std.Io` model: a tiny atomic
-//! spinlock guards the small pending array (contention is near-zero — approvals
+//! spinlock guards the small pending array (contention is near-zero, approvals
 //! are human-paced and rare), and each entry carries an atomic decision slot.
 //! Only the submit poll-wait uses the caller's `io.sleep`, exactly as the relay
 //! reconnect loop already does.
@@ -74,7 +74,7 @@ pub const Broker = struct {
         const idx = self.claim(info) orelse return .reject;
 
         // Poll the decision slot, pacing with io.sleep (as the reconnect loop
-        // does). Elapsed time is counted in sleep steps — no wall clock needed.
+        // does). Elapsed time is counted in sleep steps, no wall clock needed.
         const step_ms = 50;
         var waited_ms: u64 = 0;
         var decision = self.slots[idx].decision.load(.acquire);
@@ -181,7 +181,7 @@ fn decide(ctx: ?*anyopaque, request: *const nip46.Request) nip46.Decision {
 }
 
 // ---------------------------------------------------------------------------
-// Tests — drive the broker across real threads (a resolver thread stands in for
+// Tests, drive the broker across real threads (a resolver thread stands in for
 // the GUI), and check the interactive policy's allowlist pre-filter.
 // ---------------------------------------------------------------------------
 

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -1,6 +1,6 @@
 //! Minimal, hardened loopback HTTP approval API for GUI mode.
 //!
-//! The GUI process drives approvals over this API — it never holds the key.
+//! The GUI process drives approvals over this API. It never holds the key.
 //! Deliberately tiny (fixed routes, no keep-alive, no chunked encoding) to keep
 //! the key-holding daemon's attack surface small:
 //!
@@ -12,7 +12,7 @@
 //!
 //! `/info` reports the key state (`uninitialized`/`locked`/`unlocked`); the GUI
 //! drives first-run key onboarding through `/setup` and `/unlock`. The key is
-//! created and decrypted in the daemon — only the passphrase (and, on import,
+//! created and decrypted in the daemon, only the passphrase (and, on import,
 //! the operator's chosen secret) crosses the API, never a derived key.
 //!
 //! Every request must carry `Authorization: Bearer <token>`; the token is
@@ -103,7 +103,7 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
     // blank line separating headers from the body.
     // Read available bytes until the blank line ends the headers. `readVec`
     // returns after one read (unlike `readSliceShort`, which blocks until it has
-    // filled the whole buffer or hit EOF — a deadlock when the client sends a
+    // filled the whole buffer or hit EOF, a deadlock when the client sends a
     // short request and then waits for our response).
     var buf: [8192]u8 = undefined;
     // A /setup or /unlock body carries a passphrase (and maybe an nsec) in these
@@ -222,7 +222,7 @@ fn handleInfo(self: *Server, w: *std.Io.Writer) !void {
     };
     // The pubkey and the bunker:// connection URI are known only once unlocked;
     // report "" until then. The URI is the string a client needs to connect, so
-    // the GUI shows and copies it — building it here keeps the canonical NIP-46
+    // the GUI shows and copies it, building it here keeps the canonical NIP-46
     // format (and the connection secret) in the daemon.
     const pubkey = if (state == .unlocked) self.gate.pubkeyHex() else "";
     const bunker_uri: ?[]u8 = if (state == .unlocked)
@@ -253,7 +253,7 @@ fn handleInfo(self: *Server, w: *std.Io.Writer) !void {
     return respond(w, 200, json.items);
 }
 
-/// POST /setup — first-run key creation. Body: `{"passphrase":..,"secret":..?}`.
+/// POST /setup, first-run key creation. Body: `{"passphrase":..,"secret":..?}`.
 /// A non-empty `secret` (an `nsec1…` or 64-char hex) imports an existing key;
 /// absent/empty generates a fresh one. The key is created and encrypted in the
 /// daemon; only the derived public key is returned.
@@ -272,7 +272,7 @@ fn handleSetup(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !
     return respondPubkey(self, w);
 }
 
-/// POST /unlock — decrypt an existing key file. Body: `{"passphrase":".."}`.
+/// POST /unlock, decrypt an existing key file. Body: `{"passphrase":".."}`.
 fn handleUnlock(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !void {
     const Body = struct { passphrase: []const u8 = "" };
     const parsed = std.json.parseFromSlice(Body, self.gpa, body, .{ .ignore_unknown_fields = true }) catch
@@ -381,7 +381,7 @@ test "GET /info reports the bunker URI once unlocked" {
 
     var signer = nostr.keys.Signer.init();
     defer signer.deinit();
-    // BIP-340 test vector — the same key/pubkey the main.zig bunker-token test uses.
+    // BIP-340 test vector, the same key/pubkey the main.zig bunker-token test uses.
     const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
     const kp = try signer.keyPairFromSecretKey(secret);
 

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -1,8 +1,8 @@
-//! zig-nostr signer — a headless NIP-46 remote signer ("bunker").
+//! zig-nostr signer, a headless NIP-46 remote signer ("bunker").
 //!
 //! Keeps the user's secret key on a machine they control and signs for remote
-//! clients over a relay. On startup it loads the key — decrypting an encrypted
-//! NIP-49 key file at rest (`nostr.keystore`), or an unencrypted dev key —
+//! clients over a relay. On startup it loads the key, decrypting an encrypted
+//! NIP-49 key file at rest (`nostr.keystore`), or an unencrypted dev key,
 //! prints the `bunker://` connection token, then connects to each configured
 //! relay and serves NIP-46 requests (`nostr.signer.serve`) until stopped.
 //! Requests are authorized by an optional method/event-kind allowlist
@@ -33,7 +33,7 @@ const default_key_file = ".zig-nostr-signer.key";
 const default_gui_relays = "wss://relay.damus.io";
 
 const usage =
-    \\zig-nostr signer — headless NIP-46 remote signer (bunker)
+    \\zig-nostr signer: headless NIP-46 remote signer (bunker)
     \\
     \\Configure via environment variables:
     \\  SIGNER_KEY_FILE        path to an encrypted (NIP-49) key file
@@ -50,8 +50,8 @@ const usage =
     \\Provide the key either as an encrypted file (SIGNER_KEY_FILE +
     \\SIGNER_PASSPHRASE, recommended) or as SIGNER_SECRET_KEY (dev only). To create
     \\an encrypted file, run once with SIGNER_INIT set plus SIGNER_KEY_FILE and
-    \\SIGNER_PASSPHRASE — it imports SIGNER_SECRET_KEY if present, else generates a
-    \\fresh key — then run again without SIGNER_INIT to start serving.
+    \\SIGNER_PASSPHRASE. It imports SIGNER_SECRET_KEY if present, else generates a
+    \\fresh key, then run again without SIGNER_INIT to start serving.
     \\
     \\Prints the signer's public key and the bunker:// token clients connect
     \\with, then serves NIP-46 requests over the relays until stopped.
@@ -74,8 +74,8 @@ pub fn main(init: std.process.Init) !void {
     // GUI create or unlock the key over /setup and /unlock, and only then serves.
     // The key is created/decrypted here; the GUI never receives it (see
     // onboarding.zig + approval_http.zig). The approval address arrives as
-    // `--approval-http <addr>` — how the GUI passes it when it spawns us, since a
-    // Finder-launched app has no environment for the child to inherit — or via
+    // `--approval-http <addr>`: how the GUI passes it when it spawns us, since a
+    // Finder-launched app has no environment for the child to inherit, or via
     // `SIGNER_APPROVAL_HTTP`. Parse argv here so the slice lives for the process
     // (GUI/relay mode never returns).
     var approval_addr = getEnv("SIGNER_APPROVAL_HTTP");
@@ -138,7 +138,7 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
 
     // Honor a preconfigured key (dev SIGNER_SECRET_KEY, or an existing key file
     // plus SIGNER_PASSPHRASE) so an operator can still bring their own; when none
-    // is configured — the turnkey case — the GUI onboards one over the API.
+    // is configured (the turnkey case) the GUI onboards one over the API.
     if (guiPreloadKey(gpa, io, key_file)) |kp| gate.preload(kp);
     const booted = gate.current();
 
@@ -264,8 +264,8 @@ fn fileExists(io: std.Io, path: []const u8) bool {
 }
 
 /// In GUI mode, loads a key straight from the environment when one is fully
-/// specified — `SIGNER_SECRET_KEY` (dev), or an existing key file together with
-/// `SIGNER_PASSPHRASE` — so an operator can still preconfigure the key. Returns
+/// specified, `SIGNER_SECRET_KEY` (dev), or an existing key file together with
+/// `SIGNER_PASSPHRASE`: so an operator can still preconfigure the key. Returns
 /// null (→ the GUI onboards the key) only when nothing is configured; a bad key
 /// or wrong passphrase still fails loudly rather than silently onboarding.
 fn guiPreloadKey(gpa: std.mem.Allocator, io: std.Io, key_file: []const u8) ?keys.KeyPair {

--- a/daemon/src/onboarding.zig
+++ b/daemon/src/onboarding.zig
@@ -1,16 +1,16 @@
 //! First-run key onboarding for GUI mode.
 //!
 //! In GUI mode the daemon may boot without a key. This gate lets the connected
-//! GUI create one — generate a fresh key, or import an existing `nsec1…`/hex —
+//! GUI create one, generate a fresh key, or import an existing `nsec1…`/hex,
 //! or unlock an existing encrypted key file, all over the loopback approval API
 //! (see `approval_http.zig`). The secret key is generated and decrypted HERE,
 //! inside the key-holding daemon; only the passphrase (and, on import, the
 //! secret the operator chose to type) ever crosses the API. The key itself is
-//! never serialized back — the GUI only learns the derived public key.
+//! never serialized back, the GUI only learns the derived public key.
 //!
 //! Once a key is available the gate publishes it to the serving path, which
 //! blocks in `waitUnlocked` until then. The handoff is a single atomic flip
-//! (release/acquire) — the same io-model-independent idiom the broker uses —
+//! (release/acquire): the same io-model-independent idiom the broker uses,
 //! so no key derivation happens on any request path.
 
 const std = @import("std");
@@ -24,9 +24,9 @@ const hex = nostr.hex;
 const Dir = std.Io.Dir;
 
 pub const State = enum(u8) {
-    /// No key file yet — the GUI must `setup` (generate or import) one.
+    /// No key file yet, the GUI must `setup` (generate or import) one.
     uninitialized,
-    /// A key file exists but is still encrypted — the GUI must `unlock` it.
+    /// A key file exists but is still encrypted, the GUI must `unlock` it.
     locked,
     /// The key is loaded and the daemon can serve.
     unlocked,
@@ -131,7 +131,7 @@ pub const Gate = struct {
         self.publish(kp);
     }
 
-    /// Marks the gate `unlocked` with a key loaded outside the API — used in GUI
+    /// Marks the gate `unlocked` with a key loaded outside the API, used in GUI
     /// mode when the operator preconfigured a key in the environment, so the GUI
     /// skips onboarding. `kp` must already be validated.
     pub fn preload(self: *Gate, kp: keys.KeyPair) void {
@@ -171,7 +171,7 @@ fn decodeSecret(gpa: std.mem.Allocator, s: []const u8) ?[32]u8 {
 }
 
 // ---------------------------------------------------------------------------
-// Tests — exercise the gate end to end against a real temp dir: generate,
+// Tests, exercise the gate end to end against a real temp dir: generate,
 // import (nsec + hex), reject bad input, unlock a locked file, and prove the
 // state machine's rails (no double-init, wrong passphrase stays locked).
 // ---------------------------------------------------------------------------

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,21 +1,21 @@
-# Notary — the GUI
+# Notary, the GUI
 
-**Notary** — a native desktop app that approves or denies Nostr
+**Notary**: a native desktop app that approves or denies Nostr
 signing requests from your [signer daemon](../daemon).
 
 > **Status: early / work in progress.** This is the interactive front end for
 > the headless signer daemon. It walks you through first-run key setup (create
 > or import), unlocks the key on later launches, then shows each pending signing
-> request and sends back your approve/deny decision — and spawns and supervises
+> request and sends back your approve/deny decision, and spawns and supervises
 > the daemon itself. `scripts/package-macos.sh` bundles both into a single
-> `.app`, shipped as ad-hoc-signed macOS releases (not notarized — see the
+> `.app`, shipped as ad-hoc-signed macOS releases (not notarized, see the
 > top-level [Install](../README.md#install)).
 
 ![Notary: first-run key setup, then approving a live signing request](assets/demo.gif)
 
-<sub>First-run key setup, then the serving screen — the `bunker://` connection URL
+<sub>First-run key setup, then the serving screen, the `bunker://` connection URL
 to copy into a client, live per-relay status, and approving a real NIP-46 signing
-request. The key is generated and held by the signer daemon — it never enters this
+request. The key is generated and held by the signer daemon. It never enters this
 app.</sub>
 
 ## Architecture
@@ -29,7 +29,7 @@ The signer is split into two processes on purpose:
 - **This app** is a separate process that polls that API, shows each pending
   request, and sends back your approve/deny decision.
 
-The key never enters this process — it only ever sees request metadata and
+The key never enters this process. It only ever sees request metadata and
 returns a yes/no. Built with the
 [Native SDK](https://github.com/vercel-labs/native): declarative markup plus
 Zig, rendered natively (no WebView, no Electron).
@@ -53,9 +53,9 @@ Run the daemon in **GUI mode** (see the signer's
 section) so it serves the loopback approval API, then point this app at it
 with two environment variables:
 
-- `SIGNER_APPROVAL_HTTP` — the daemon's approval address (default
+- `SIGNER_APPROVAL_HTTP`: the daemon's approval address (default
   `127.0.0.1:8787`).
-- `SIGNER_APPROVAL_TOKEN_FILE` — the bearer-token file the daemon wrote
+- `SIGNER_APPROVAL_TOKEN_FILE`: the bearer-token file the daemon wrote
   (default `$HOME/.zig-nostr-signer.token`).
 
 ```sh
@@ -76,20 +76,20 @@ The first time it connects to a daemon that has no key yet, the app shows a
 64-char hex), protected by a passphrase. On later launches the daemon comes up
 locked and the app shows an **unlock screen** for that passphrase. The key is
 generated and decrypted inside the daemon (over `POST /setup` and
-`POST /unlock`) — the app only ever sends the passphrase, and on import the
+`POST /unlock`): the app only ever sends the passphrase, and on import the
 secret you type, never a derived key.
 
 ### Managed mode (the app supervises the daemon)
 
 A packaged app is self-contained: the `.app` ships the `signer` daemon beside
 the GUI in `Contents/MacOS`, and at launch the GUI discovers that sibling and
-spawns it — one launch brings up both, no configuration. In development you get
+spawns it, one launch brings up both, no configuration. In development you get
 the same one-launch behavior without packaging by pointing `SIGNER_BIN` at a
 built daemon (it takes precedence over any bundled one):
 
 ```sh
 SIGNER_BIN="$(which signer)" \
-SIGNER_SECRET_KEY=<64-char hex, dev only — prefer SIGNER_KEY_FILE + SIGNER_PASSPHRASE> \
+SIGNER_SECRET_KEY=<64-char hex, dev only, prefer SIGNER_KEY_FILE + SIGNER_PASSPHRASE> \
 SIGNER_RELAYS="wss://relay.example.com" \
 SIGNER_APPROVAL_HTTP=127.0.0.1:8787 \
 SIGNER_APPROVAL_TOKEN_FILE="$HOME/.zig-nostr-signer.token" \
@@ -139,7 +139,7 @@ scripts/package-macos.sh --signing identity \
 - [x] App scaffold (native window, shell view, logic tests)
 - [x] Approval queue over the daemon's loopback API (poll, approve, deny)
 - [x] Supervise the daemon as a child process (one launch, key stays isolated)
-- [x] Bundle the daemon into the app — one `.app`, discovered and supervised
+- [x] Bundle the daemon into the app, one `.app`, discovered and supervised
 - [x] First-run key onboarding in-app (create / import / unlock)
 - [x] Ad-hoc signed macOS releases + one-line installer (CI on tag; clears quarantine on install)
 

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -2,7 +2,7 @@
     .id = "com.zig-nostr.notary",
     .name = "notary",
     .display_name = "Notary",
-    .description = "Notary — approve or deny Nostr signing requests; your key stays in the signer daemon.",
+    .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
     .version = "0.2.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},

--- a/gui/scripts/package-macos.sh
+++ b/gui/scripts/package-macos.sh
@@ -13,7 +13,7 @@
 # child.
 #
 # The daemon binary is built from the `daemon/` package in this repo; this
-# script does not build it — point --signer at a prebuilt binary (or build it:
+# script does not build it, point --signer at a prebuilt binary (or build it:
 # `cd ../daemon && zig build -Doptimize=ReleaseFast`).
 #
 # Usage:

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -1,4 +1,4 @@
-<!-- Notary — the live view. The header shows the connection state
+<!-- Notary, the live view. The header shows the connection state
      and which key you are approving for; the body is one of several mutually
      exclusive states (signer stopped / first-run setup / unlock / no requests /
      the request queue); the status bar counts the queue. Logic is in
@@ -12,7 +12,7 @@
   <separator/>
   <if test="{show_bunker}">
     <column gap="6" padding="16">
-      <text foreground="text_muted">Bunker URL — paste into your Nostr client to connect</text>
+      <text foreground="text_muted">Bunker URL: paste into your Nostr client to connect</text>
       <card padding="12">
         <column gap="10">
           <text wrap="true">{bunker}</text>
@@ -45,7 +45,7 @@
   <if test="{needs_setup}">
     <column gap="12" grow="1" padding="20">
       <text size="heading">Set up your signer</text>
-      <text>Create a new key, or import one you already have. The key is generated and stored by the signer itself — this app only sends the passphrase.</text>
+      <text>Create a new key, or import one you already have. The key is generated and stored by the signer itself. This app only sends the passphrase.</text>
       <row gap="8">
         <toggle-button selected="{create_selected}" on-press="choose_create" grow="1">Create new</toggle-button>
         <toggle-button selected="{import_selected}" on-press="choose_import" grow="1">Import existing</toggle-button>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -1,4 +1,4 @@
-//! Notary — a native desktop approver for the signer daemon.
+//! Notary, a native desktop approver for the signer daemon.
 //!
 //! Architecture: the signer daemon (the daemon/ package in this repo) holds the
 //! secret key and does all Nostr work; this app is a *separate process* that
@@ -11,7 +11,7 @@
 //!  - **Attached** (default): the daemon is already running; the app connects
 //!    to its approval API at `SIGNER_APPROVAL_HTTP`.
 //!  - **Managed**: the app *spawns and supervises* the daemon binary as a child
-//!    process — one launch brings up both. The daemon is either a `signer`
+//!    process, one launch brings up both. The daemon is either a `signer`
 //!    bundled beside this executable (`…/Contents/MacOS/signer` in a packaged
 //!    app, so a single download is self-contained) or, taking precedence, an
 //!    explicit `SIGNER_BIN` override for development. The child inherits this
@@ -135,7 +135,7 @@ pub const RelayRow = struct {
             .disconnected => "offline",
         };
     }
-    // Status predicates — the view picks a literally-colored status word off
+    // Status predicates, the view picks a literally-colored status word off
     // these (`foreground` takes only a literal token, so the color can't bind).
     pub fn connected(self: *const RelayRow) bool {
         return self.conn == .connected;
@@ -156,7 +156,7 @@ pub const Phase = enum {
     /// Attached mode: trying to reach an already-running daemon.
     connecting,
     connected,
-    /// Was reachable, now failing — retrying.
+    /// Was reachable, now failing, retrying.
     disconnected,
     /// The API rejected our bearer token (attached mode).
     unauthorized,
@@ -240,7 +240,7 @@ pub const Model = struct {
     pub fn baseUrl(self: *const Model) []const u8 {
         return self.base_url_buf[0..self.base_url_len];
     }
-    /// The bare `host:port` we poll — passed to the spawned daemon as
+    /// The bare `host:port` we poll, passed to the spawned daemon as
     /// `--approval-http` so it serves the API there (a Finder-launched `.app`
     /// carries no `SIGNER_APPROVAL_HTTP` env for the child to inherit).
     pub fn approvalAddress(self: *const Model) []const u8 {
@@ -288,7 +288,7 @@ pub const Model = struct {
     pub fn count(self: *const Model) usize {
         return self.rows_len;
     }
-    /// Body states — exactly one is true, so the view renders plain `<if>`
+    /// Body states, exactly one is true, so the view renders plain `<if>`
     /// blocks instead of nested else chains.
     pub fn daemon_down(self: *const Model) bool {
         return self.phase == .daemon_exited;
@@ -355,8 +355,8 @@ pub const Model = struct {
             .starting => "Starting the signer…",
             .connecting => "Connecting to the signer…",
             .connected => "Connected",
-            .disconnected => "Signer unreachable — retrying…",
-            .unauthorized => "Unauthorized — check the token file",
+            .disconnected => "Signer unreachable, retrying…",
+            .unauthorized => "Unauthorized: check the token file",
             .daemon_exited => "Signer stopped",
             .needs_setup => "First-run setup",
             .needs_unlock => "Locked",
@@ -370,8 +370,8 @@ pub const Model = struct {
             .connected => "No pending requests",
             .starting => "Starting the signer…",
             .connecting => "Connecting to the signer…",
-            .disconnected => "Signer unreachable — retrying…",
-            .unauthorized => "Unauthorized — check the token file",
+            .disconnected => "Signer unreachable, retrying…",
+            .unauthorized => "Unauthorized: check the token file",
             .daemon_exited, .needs_setup, .needs_unlock => "",
         };
     }
@@ -462,7 +462,7 @@ pub const Model = struct {
 
     fn setExitNote(self: *Model, exit: native_sdk.EffectExit) void {
         const s = switch (exit.reason) {
-            .spawn_failed, .rejected => std.fmt.bufPrint(&self.exit_note_buf, "The signer failed to start — check SIGNER_BIN.", .{}),
+            .spawn_failed, .rejected => std.fmt.bufPrint(&self.exit_note_buf, "The signer failed to start, check SIGNER_BIN.", .{}),
             .signaled => std.fmt.bufPrint(&self.exit_note_buf, "The signer was terminated (signal).", .{}),
             else => std.fmt.bufPrint(&self.exit_note_buf, "The signer exited (code {d}).", .{exit.code}),
         } catch return;
@@ -595,7 +595,7 @@ fn fetchInfo(model: *Model, fx: *Effects) void {
 }
 
 /// A lightweight /info re-poll that only refreshes the live relay status (and the
-/// bunker URI), decoupled from the initial connect flow — its response never
+/// bunker URI), decoupled from the initial connect flow, its response never
 /// touches the phase or the pending-poll chain, and its failures are ignored (the
 /// pending poll is the real connection-health signal). Runs on its own effect key
 /// so it never collides with the initial `fetchInfo`.
@@ -646,7 +646,7 @@ fn sendDecision(model: *Model, fx: *Effects, id: u64, approve: bool) void {
     });
 }
 
-/// POST /setup — create the key (generate, or import the entered secret) and,
+/// POST /setup, create the key (generate, or import the entered secret) and,
 /// on success, start serving. The daemon's scrypt KDF makes this take a moment,
 /// so the timeout is generous. The body buffer is wiped after the send (fx.fetch
 /// copies it synchronously).
@@ -669,7 +669,7 @@ fn sendSetup(model: *Model, fx: *Effects) void {
     std.crypto.secureZero(u8, &body_buf);
 }
 
-/// POST /unlock — decrypt the key file with the entered passphrase.
+/// POST /unlock, decrypt the key file with the entered passphrase.
 fn sendUnlock(model: *Model, fx: *Effects) void {
     model.submitting = true;
     model.clearOnboardError();
@@ -740,8 +740,8 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         .daemon_line => {}, // daemon stdout; the connection state is the signal we surface
 
         .daemon_exited => |exit| {
-            // A cancel we initiated (restart / app quit) reports `.cancelled` —
-            // that is expected teardown, not a crash to report.
+            // A cancel we initiated (restart / app quit) reports `.cancelled`.
+            // That is expected teardown, not a crash to report.
             if (exit.reason == .cancelled) return;
             model.phase = .daemon_exited;
             model.setExitNote(exit);
@@ -764,7 +764,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
                     if (model.phase != .connected) model.phase = .connecting;
                     fetchInfo(model, fx);
                 } else {
-                    armRetry(fx); // empty file — the daemon has not written it yet
+                    armRetry(fx); // empty file, the daemon has not written it yet
                 }
             },
             // Not there yet (managed daemon still starting) or unreadable: retry.
@@ -994,8 +994,8 @@ pub fn initialModel() Model {
 }
 
 /// Which daemon binary to supervise, or null for attached mode (connect to a
-/// daemon someone else started). An explicit `SIGNER_BIN` always wins — it is
-/// the development / override path — otherwise a `signer` bundled beside this
+/// daemon someone else started). An explicit `SIGNER_BIN` always wins. It is
+/// the development / override path, otherwise a `signer` bundled beside this
 /// executable is used, so a downloaded app needs no configuration. `bundled`
 /// is expected to be null or non-empty (see `bundledDaemonPath`).
 pub fn chooseDaemonBin(env_bin: ?[]const u8, bundled: ?[]const u8) ?[]const u8 {
@@ -1005,7 +1005,7 @@ pub fn chooseDaemonBin(env_bin: ?[]const u8, bundled: ?[]const u8) ?[]const u8 {
     return bundled;
 }
 
-/// Absolute path to a runnable `signer` sitting next to this executable — the
+/// Absolute path to a runnable `signer` sitting next to this executable, the
 /// layout a packaged app has (`…/Contents/MacOS/signer` beside the GUI binary),
 /// so a single download is self-contained. Returns null when there is no
 /// runnable sibling (e.g. under `native dev`, where the binary lives in the


### PR DESCRIPTION
The docs, the release notes, the changelog and the strings in both binaries were written over several months and drifted into a house style that reads like notes to myself: clauses stacked onto clauses, definitions hanging off a dash, asides that never close. Fine in a working file, wrong on the page somebody lands on.

Definitions take a colon, asides take parentheses, and a sentence that can stand on its own gets a full stop instead of being stapled to the one in front of it. The changelog headings now match the format they claim to follow, which uses a plain hyphen between the version and its date.

## Behaviour

None changes. Two user-visible strings read better as statements than as fragments (`Unauthorized: check the token file`, `Bunker URL: paste into your Nostr client to connect`), and the app description in the manifest is now a sentence.

## Worth recording, because it nearly shipped

The first pass was mechanical, and a mechanical pass over source files is a bad idea.

It joined four Zig multiline string literals to the line below them, eating the `\\` terminator and the format arguments with it. The daemon caught it at compile time, which is the only reason it did not go out. It also produced about twenty comma splices where the text after the join was an independent clause.

Both are fixed here, and the audit is the reason: every source change in this diff is a comment or a string literal, checked individually rather than trusted to the pattern.

Both halves build and their tests pass.