### PR TITLE
Notary is 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 
 ## [Unreleased]
 
+## [0.3.0]
+
+### Changed
+- The app is called **Notary**. It was Signet, which already meant a Bitcoin test
+  network, and a signer that shares a name with a testnet is a signer people
+  misread. Every surface says Notary now.
+- A copy pass over everything a reader sees: the setup screen, the serving
+  screen, the approval prompts and both READMEs.
+
 ### Fixed
+- **The installer works again.** It looks for `Notary.app`, and the newest release
+  still carried `Signet.app` from before the rename, so every install failed with
+  "the download did not contain Notary.app". Nothing was wrong with the script:
+  there had been no release since the app was renamed.
 - The first-run setup screen no longer truncates its explanation. "Create a new
   key, or import one you already have…" was cut off mid-sentence at the window's
   width; it now wraps and reads in full.

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.2.0",
+    .version = "0.3.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command", "clipboard" },


### PR DESCRIPTION
Fixes the install failure you hit:

```
error: the download did not contain Notary.app.
```

## What was wrong

Nothing in the installer. It looks for `Notary.app`, which is correct.

The app was renamed from Signet to Notary in #35, and **no release was cut
afterwards**. So the newest release is still `Signet v0.2.0`, shipping
`Signet-v0.2.0-macos.zip`, and inside it is `Signet.app`. The installer downloads
the newest release, does not find `Notary.app` in it, and stops.

Confirmed by downloading the current release and listing it:

```
Archive:  Signet-v0.2.0-macos.zip
        0  Signet.app/
        0  Signet.app/Contents/
```

The release pipeline was already correct: `gui/app.zon` declares
`display_name = "Notary"` and the workflow zips `gui/dist/Notary.app` into
`Notary-<tag>-macos.zip`. It only ever needed a tag.

## What this ships

Ten commits have been sitting behind that tag:

- the rename itself
- a copy pass over the setup screen, serving screen, approval prompts and both
  READMEs
- the first-run setup screen no longer cutting its own explanation in half
- the four screens in the README
- the library's signer core, and Native SDK 0.7.2

After this merges I will tag `v0.3.0`, then download the artifact and check it
actually contains `Notary.app` before saying it works.
