### PR TITLE
Say what is in 0.3.0

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,10 +1,11 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
-### What's new in v0.2.0
+### What's new in v0.3.0
 
-- **Bunker URL in the app**: the serving screen now shows the `bunker://` connection URL with a Copy button, so you can connect a client without touching the logs.
-- **Live relay status**: watch each relay connect in real time on the serving screen.
-- **One-line install**: the `curl … | bash` command below is new: it verifies the download's checksum and clears quarantine, so the app opens cleanly with no Gatekeeper detour.
+- **The install command works again.** It looks for `Notary.app`, and the previous release still carried `Signet.app` from before the app was renamed, so every install stopped with "the download did not contain Notary.app". Nothing was wrong with the script: there had been no release since the rename.
+- **The app is called Notary.** It was Signet, which already meant a Bitcoin test network, and a signer sharing a name with a testnet is a signer people misread.
+- **The setup screen reads in full.** "Create a new key, or import one you already have..." was cut off mid-sentence at the window's width.
+- **A copy pass** over every screen and both READMEs, and the four screens are now in the README so you can see the app before installing it.
 
 Full history in the [CHANGELOG](https://github.com/zig-nostr/notary/blob/main/CHANGELOG.md). **Your key never leaves the daemon.**
 


### PR DESCRIPTION
The release notes file is used verbatim as the release body, and I tagged 0.3.0 without touching it, so the published release described 0.2.0. I have already corrected the published release; this lands the same text in the repo so the next tag does not repeat it.

The first line is the one that matters to anybody reading it: the install command works again.