### PR TITLE
The approval app has shipped, and name what a signer is asked for next

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -7,14 +7,15 @@ remote signer ("bunker") for Nostr, built on the
 It keeps your `nsec` on a machine you control and signs on behalf of web and
 native clients over a relay, the secret key never reaches the client.
 
-> **Status: early / work in progress.** This is Showcase 1 of the zig-nostr
-> roadmap. The current build loads an encrypted (NIP-49) key from disk, connects
-> to your relays, and answers NIP-46 requests, `get_public_key`, `sign_event`,
-> `ping`, and NIP-44 encrypt/decrypt, behind the connection secret and an
-> optional method/event-kind allowlist. It can also run in **GUI mode**: it
-> holds each request for interactive approval over a loopback API, and can
-> create or unlock the key on first run from that same API, the key never
-> leaves the daemon. The native approval app itself is landing next.
+> **Status: early / work in progress.** The current build loads an encrypted
+> (NIP-49) key from disk, connects to your relays, and answers NIP-46 requests,
+> `get_public_key`, `sign_event`, `ping`, and NIP-44 encrypt/decrypt, behind the
+> connection secret and an optional method/event-kind allowlist. It works
+> against relays that require NIP-42 authentication. It can also run in **GUI
+> mode**: it holds each request for interactive approval over a loopback API,
+> and can create or unlock the key on first run from that same API, the key
+> never leaves the daemon. The native approval app ships with it: one download
+> brings up both.
 
 ## Build
 
@@ -112,12 +113,17 @@ applies first, so disallowed requests are rejected without ever prompting.
 ## Roadmap
 
 - [x] `bunker://` connection token from a key + relays
-- [x] Relay listen/sign loop (answer NIP-46 requests over a relay)
-- [x] Encrypted key storage at rest (NIP-49 `ncryptsec`)
+- [x] Relay listen/sign loop (NIP-46 `kind:24133` requests over a relay)
+- [x] NIP-44 v2 encryption on every request and response (no NIP-04)
+- [x] Encrypted key storage at rest (NIP-49 `ncryptsec`, scrypt + XChaCha20-Poly1305)
 - [x] Per-request approval policy (method + event-kind allowlists)
 - [x] Loopback approval API for interactive GUI approval
 - [x] First-run key onboarding over the approval API (generate / import / unlock)
-- [ ] Native macOS approval app + downloadable build
+- [x] NIP-42 relay auth, so relays that require it still deliver requests
+- [x] Native macOS approval app + downloadable build (one-line installer)
+- [ ] Private messages: `nip44_encrypt`, a `sign_event` for the NIP-59 `kind:13`
+      seal around each NIP-17 `kind:14` message, and `nip44_decrypt` to read one
+- [ ] `nostrconnect://` client-initiated connections (NIP-46)
 
 ## License
 

--- a/gui/README.md
+++ b/gui/README.md
@@ -144,6 +144,14 @@ scripts/package-macos.sh --signing identity \
 - [x] First-run key onboarding in-app (create / import / unlock)
 - [x] Ad-hoc signed macOS releases + one-line installer (CI on tag; clears quarantine on install)
 
+What comes next is set by what clients ask a signer for:
+
+- [ ] Private-message approvals: one NIP-17 message is several requests
+      (`nip44_encrypt`, then a `sign_event` for the NIP-59 `kind:13` seal), and a
+      prompt for each one is unusable. They have to read as a single decision.
+- [ ] `nostrconnect://` connections, so a client can offer a link and this app
+      connects to it, instead of you copying a `bunker://` URL the other way.
+
 ## License
 
 MIT © Sepehr Safari


### PR DESCRIPTION
Both roadmaps were stale. The daemon README still said the native approval app was landing next; it shipped in v0.3.0 with the one-line installer. The status block also still called this Showcase 1 of an old milestone scheme.

Adds the two things clients will ask a signer for next: NIP-17 private messages, which need decrypt and not only signing, and `nostrconnect://`. Names NIP-42 and the NIP-44-only policy, both already true in code.