### PR TITLE
Do not let anything else answer for the daemon

### DIFF
--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -61,9 +61,21 @@ pub const Server = struct {
     const max_conns = 8;
 
     /// Binds loopback and serves forever on the calling thread.
+    ///
+    /// The bind is EXCLUSIVE, deliberately. `reuse_address` reads like the
+    /// ordinary "let me restart without waiting out TIME_WAIT" flag, and on
+    /// POSIX it also sets SO_REUSEPORT: a second process may then bind the same
+    /// address, and on this platform the newer socket takes the new
+    /// connections. Any process running as this user could therefore quietly
+    /// become the approval API without disturbing this one, and the GUI, which
+    /// has no way to tell one from the other, would hand it the unlock
+    /// passphrase or an imported nsec. That is measured behaviour, not theory.
+    ///
+    /// Without the flag a duplicate bind fails, this listener refuses to start,
+    /// and the daemon exits instead of leaving a hole open.
     pub fn run(self: *Server, io: std.Io) !void {
         const addr = try net.IpAddress.parseIp4(self.host, self.port);
-        var server = try addr.listen(io, .{ .reuse_address = true });
+        var server = try addr.listen(io, .{});
         while (true) {
             const stream = server.accept(io) catch continue;
             if (self.active.load(.monotonic) >= max_conns) {

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -512,12 +512,25 @@ fn makeAndWriteToken(gpa: std.mem.Allocator, path: []const u8) []u8 {
 }
 
 /// Runs the approval HTTP server on its own thread with its own io.
+///
+/// A listener that cannot come up KILLS the daemon. It used to print and let
+/// the thread die, and the consequence was not a missing feature: the daemon
+/// went on running with no listener, blocked forever waiting to be unlocked,
+/// while whatever was already holding that port answered the GUI instead. The
+/// GUI has no way to tell the difference, so it would read the token file, find
+/// something answering, and post the unlock passphrase, or an imported nsec,
+/// straight to it. Dying loudly is what turns that into a startup failure the
+/// GUI's supervision already knows how to show.
 fn runApprovalServer(server: *approval_http.Server) void {
     var threaded = std.Io.Threaded.init(server.gpa, .{});
     defer threaded.deinit();
     server.run(threaded.io()) catch |err| {
         std.debug.print("signer: approval server stopped: {s}\n", .{@errorName(err)});
+        std.process.exit(1);
     };
+    // `run` loops forever, so reaching here at all means the listener is gone.
+    std.debug.print("signer: approval server exited\n", .{});
+    std.process.exit(1);
 }
 
 fn getEnv(name: [*:0]const u8) ?[]const u8 {


### PR DESCRIPTION
The GUI sends the unlock passphrase, and on the import path an `nsec`, to a local HTTP endpoint on a fixed port. It has no way to check that the thing answering is the daemon it spawned, so whatever holds that port receives them. Two separate ways something else could hold it, both closed here.

**The listener asked for `reuse_address`.** That reads like the ordinary "let me restart without waiting out TIME_WAIT" flag, and on POSIX it also sets `SO_REUSEPORT`: a second process may then bind the same address, and on this platform the newer socket takes the new connections. Any process running as this user could become the approval API without disturbing the real daemon at all. This is measured on macOS rather than assumed: with the option set on both sides the duplicate bind succeeds, and the second binder receives every new connection while the first receives none. The bind is exclusive now, so a duplicate fails.

**A listener that could not come up was printed and forgotten.** The thread died, the daemon carried on and blocked forever waiting to be unlocked, and whatever was already holding the port answered the GUI instead. So the flag above was not even necessary: bind the port before Notary launches, with no special options, and the daemon hands the conversation over by itself while the user sees a normal-looking first-run screen. A listener that cannot bind is now fatal, which turns it into a startup failure the GUI's supervision already knows how to display, instead of a silent hole.

**What this does not fix, and I want it on the record rather than implied.** The GUI still infers "this is my daemon" from the fact that something answered on a fixed port. The bearer token authenticates the client to the server and nothing authenticates the server to the client. The right shape is a socket the daemon creates exclusively, with the GUI checking the peer, or a challenge the daemon answers with the token before the GUI sends any secret. That is a larger change and it is next.