### PR TITLE
Sign only for clients that connected

### DIFF
--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/930b84f466898a97c79db19093d684fd8dabf8e1.tar.gz",
-            .hash = "nostr-0.3.5-CMyPzaWnBgDVA0NBBSs2eDV3GVmsu5BNEunywzVnc8wm",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.4.0.tar.gz",
+            .hash = "nostr-0.4.0-CMyPzXlPBwDw4otFrsg9a_ylzJh96rroHhyu4VeVUqKf",
         },
     },
     .paths = .{

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -328,10 +328,20 @@ fn serveRelayForever(
 
     var bunker = nip46.Bunker.initSingleKey(signer, kp, request_policy);
     bunker.secret = conn_secret;
+    // The bunker now remembers which clients have connected, and refuses to
+    // sign for one it has not heard of. It lives out here, outside the dial
+    // loop, so a dropped socket does not make every client connect again.
+    //
+    // One consequence worth naming: this bunker belongs to THIS relay thread,
+    // which is how the rest of the state here works, so a client is authorized
+    // per relay. A client that connects over one relay in the token and then
+    // asks over another gets "not connected" and has to connect again. Clients
+    // hold one connection at a time, so that is a reconnect and not a wall, but
+    // a set shared across the threads would be better and is worth doing.
 
     while (true) {
         if (status) |s| s.store(@intFromEnum(approval_http.RelayStatus.connecting), .monotonic);
-        serveOnce(gpa, io, url, bunker, kp, status) catch |err| {
+        serveOnce(gpa, io, url, &bunker, kp, status) catch |err| {
             std.debug.print("signer: [{s}] {s}\n", .{ url, @errorName(err) });
         };
         if (status) |s| s.store(@intFromEnum(approval_http.RelayStatus.disconnected), .monotonic);
@@ -345,7 +355,7 @@ fn serveOnce(
     gpa: std.mem.Allocator,
     io: std.Io,
     url: []const u8,
-    bunker: nip46.Bunker,
+    bunker: *nip46.Bunker,
     remote: keys.KeyPair,
     status: ?*std.atomic.Value(u8),
 ) !void {


### PR DESCRIPTION
Picks up `nostr` v0.4.0, whose whole content is this: a bunker keeps the clients that completed a `connect` and refuses anything key-touching from one it has never heard of.

Until now the connection secret this daemon prints in its `bunker://` token gated exactly one method, `connect`, and nothing remembered who had passed it. Anyone who could read that token, or who watched a relay and saw the pubkey, could send `sign_event` as their first message. In GUI mode that reached the approval queue, where the prompt shows a method name and an event kind and not who is asking, so it is indistinguishable from the user's own client. In headless mode with a method and kind allowlist it was signed outright. The secret was doing no work.

`connect`, `ping` and `get_public_key` stay open to a stranger: the first is how a client becomes known, the second touches nothing, and the third returns a value already printed in the token. `logout` now forgets the client.

The bunker lives outside the dial loop, so a dropped socket does not make every client connect again. It belongs to its relay thread, the way the rest of the per-thread state does, which means authorization is **per relay**: a client that connects over one relay in the token and then asks over another gets `not connected` and has to connect again. Clients hold one connection at a time, so that is a reconnect rather than a wall, and Notary's own GUI and Plaza both use a single relay. A set shared across the relay threads would be better and is worth doing.

**Next, and needed before this is finished:** the approval prompt has to name the requester and show what is being signed. Right now a human approving a request cannot tell their own client from anyone else's, which is the other half of the same problem.