### PR TITLE
Say who is asking, and what they want signed

### DIFF
--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.4.0.tar.gz",
-            .hash = "nostr-0.4.0-CMyPzXlPBwDw4otFrsg9a_ylzJh96rroHhyu4VeVUqKf",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.5.0.tar.gz",
+            .hash = "nostr-0.5.0-CMyPzU9SBwCvl6326rBTDgiSWnsBhDVaGiD1QmH1hO2l",
         },
     },
     .paths = .{

--- a/daemon/src/approval.zig
+++ b/daemon/src/approval.zig
@@ -34,11 +34,53 @@ pub const Pending = struct {
     /// Event kind for `sign_event`, else -1.
     kind: i32 = -1,
     created_at: i64 = 0,
+    /// Who is asking: the pubkey of the event that carried the request, hex.
+    ///
+    /// A row that says "sign_event, kind 1" and nothing else asks a person to
+    /// authorize a signature without telling them whose request it is. It reads
+    /// identically whether it came from their own client or from somebody who
+    /// read the connection token, and the second one is the whole reason this
+    /// queue exists.
+    client_buf: [64]u8 = [_]u8{0} ** 64,
+    client_len: u8 = 0,
+    /// What is being signed: the start of the event's content, for `sign_event`.
+    ///
+    /// The kind number says what SHAPE it is, never what it says. Approving a
+    /// kind:1 without seeing its text is approving a sentence published under
+    /// your name, sight unseen.
+    preview_buf: [160]u8 = [_]u8{0} ** 160,
+    preview_len: u8 = 0,
 
     pub fn method(self: *const Pending) []const u8 {
         return self.method_buf[0..self.method_len];
     }
+    pub fn client(self: *const Pending) []const u8 {
+        return self.client_buf[0..self.client_len];
+    }
+    pub fn preview(self: *const Pending) []const u8 {
+        return self.preview_buf[0..self.preview_len];
+    }
 };
+
+/// The `content` of a `sign_event` template, clipped to fit a `Pending`.
+///
+/// Clipped on a UTF-8 boundary, because half a character is not a character and
+/// this string goes straight into a JSON response and then onto a screen.
+fn signEventPreview(gpa: std.mem.Allocator, request: *const nip46.Request, out: *[160]u8) u8 {
+    if (request.params.len < 1) return 0;
+    const parsed = std.json.parseFromSlice(
+        struct { content: []const u8 = "" },
+        gpa,
+        request.params[0],
+        .{ .ignore_unknown_fields = true },
+    ) catch return 0;
+    defer parsed.deinit();
+    const text = std.mem.trim(u8, parsed.value.content, " \t\r\n");
+    var n = @min(text.len, out.len);
+    while (n > 0 and n < text.len and (text[n] & 0xc0) == 0x80) n -= 1;
+    @memcpy(out[0..n], text[0..n]);
+    return @intCast(n);
+}
 
 const Slot = struct {
     in_use: bool = false,
@@ -156,21 +198,26 @@ pub const Interactive = struct {
     }
 };
 
-fn decide(ctx: ?*anyopaque, request: *const nip46.Request) nip46.Decision {
+fn decide(ctx: ?*anyopaque, request: *const nip46.Request, client: [32]u8) nip46.Decision {
     const self: *const Interactive = @ptrCast(@alignCast(ctx.?));
 
     // The static allowlist is the first gate: a disallowed request is denied
     // outright and never bothers the human.
-    if (self.config.policy().decide(request) == .reject) return .reject;
+    if (self.config.policy().decide(request, client) == .reject) return .reject;
 
     var info = Pending{};
     const mlen = @min(request.method.len, info.method_buf.len);
     @memcpy(info.method_buf[0..mlen], request.method[0..mlen]);
     info.method_len = @intCast(mlen);
     info.created_at = std.Io.Timestamp.now(self.io, .real).toSeconds();
+    // Who, and what. Neither was here, so the row said "sign_event, kind 1" and
+    // left the person to guess both.
+    _ = std.fmt.bufPrint(&info.client_buf, "{x}", .{client}) catch {};
+    info.client_len = 64;
     if (nip46.Method.fromString(request.method)) |method| {
         if (method == .sign_event) {
             if (nostr.nip46.signEventKind(self.gpa, request)) |k| info.kind = k;
+            info.preview_len = signEventPreview(self.gpa, request, &info.preview_buf);
         }
     }
 
@@ -237,7 +284,7 @@ test "interactive policy denies allowlist-disallowed requests without prompting"
 
     const tmpl = "{\"kind\":1,\"content\":\"x\",\"tags\":[],\"created_at\":1}";
     const req = nip46.Request{ .id = "1", .method = "sign_event", .params = &[_][]const u8{tmpl} };
-    try testing.expectEqual(nip46.Decision.reject, p.decide(&req));
+    try testing.expectEqual(nip46.Decision.reject, p.decide(&req, [_]u8{0} ** 32));
     // Never enqueued: a disallowed request must not reach the GUI.
     var buf: [1]Pending = undefined;
     try testing.expectEqual(@as(usize, 0), broker.snapshot(&buf));
@@ -257,5 +304,5 @@ test "interactive policy escalates an allowed request and returns the GUI decisi
     defer t.join();
 
     const req = nip46.Request{ .id = "1", .method = "get_public_key", .params = &.{} };
-    try testing.expectEqual(nip46.Decision.reject, p.decide(&req));
+    try testing.expectEqual(nip46.Decision.reject, p.decide(&req, [_]u8{0} ** 32));
 }

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -198,12 +198,46 @@ fn handlePending(self: *Server, io: std.Io, w: *std.Io.Writer, path: []const u8)
     try json.appendSlice(self.gpa, head);
     for (pending[0..n], 0..) |p, i| {
         if (i != 0) try json.append(self.gpa, ',');
-        const item = try std.fmt.allocPrint(self.gpa, "{{\"id\":{d},\"method\":\"{s}\",\"kind\":{d},\"created_at\":{d}}}", .{ p.id, p.method(), p.kind, p.created_at });
+        // `method` and `client` are safe to interpolate: a request only reaches
+        // the policy once its method has parsed as one of seven fixed names,
+        // and the client is hex. `preview` is the requester's own text and is
+        // escaped, or a quote in a note would end the string and the rest of it
+        // would be read as fields of this object.
+        const item = try std.fmt.allocPrint(
+            self.gpa,
+            "{{\"id\":{d},\"method\":\"{s}\",\"kind\":{d},\"created_at\":{d},\"client\":\"{s}\",\"preview\":",
+            .{ p.id, p.method(), p.kind, p.created_at, p.client() },
+        );
         defer self.gpa.free(item);
         try json.appendSlice(self.gpa, item);
+        try appendJsonString(&json, self.gpa, p.preview());
+        try json.append(self.gpa, '}');
     }
     try json.appendSlice(self.gpa, "]}");
     return respond(w, 200, json.items);
+}
+
+/// Appends `s` as a JSON string literal, quotes included.
+///
+/// Everything a control character or a backslash or a quote could otherwise do
+/// to the surrounding document, it cannot do here. The one string in this API
+/// that the requester writes goes through this.
+fn appendJsonString(out: *std.ArrayList(u8), gpa: std.mem.Allocator, s: []const u8) !void {
+    try out.append(gpa, '"');
+    for (s) |c| switch (c) {
+        '"' => try out.appendSlice(gpa, "\\\""),
+        '\\' => try out.appendSlice(gpa, "\\\\"),
+        '\n' => try out.appendSlice(gpa, "\\n"),
+        '\r' => try out.appendSlice(gpa, "\\r"),
+        '\t' => try out.appendSlice(gpa, "\\t"),
+        0x00...0x08, 0x0b, 0x0c, 0x0e...0x1f => {
+            var esc: [6]u8 = undefined;
+            _ = std.fmt.bufPrint(&esc, "\\u{x:0>4}", .{c}) catch unreachable;
+            try out.appendSlice(gpa, &esc);
+        },
+        else => try out.append(gpa, c),
+    };
+    try out.append(gpa, '"');
 }
 
 fn handleDecision(self: *Server, w: *std.Io.Writer, body: []const u8) !void {
@@ -367,6 +401,37 @@ fn eql(a: []const u8, b: []const u8) bool {
 // --- Tests ---------------------------------------------------------------
 
 const testing = std.testing;
+
+test "a note cannot write JSON into the approval listing" {
+    // The preview is the requester's own text, and the requester is whoever got
+    // past the connect secret. If it went in raw, a quote would end the string
+    // and everything after it would be read as fields of this object: an
+    // attacker could give their own request a different method, a different
+    // kind, or somebody else's pubkey, on the very screen a human is using to
+    // decide whether to sign it.
+    const gpa = std.testing.allocator;
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(gpa);
+
+    try appendJsonString(&out, gpa, "\",\"kind\":1,\"client\":\"ffff");
+    try std.testing.expectEqualStrings(
+        "\"\\\",\\\"kind\\\":1,\\\"client\\\":\\\"ffff\"",
+        out.items,
+    );
+
+    // It has to survive a round trip as one string, not merely look escaped.
+    const parsed = try std.json.parseFromSlice([]const u8, gpa, out.items, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("\",\"kind\":1,\"client\":\"ffff", parsed.value);
+
+    // Newlines, tabs and control bytes are all legal in event content and all
+    // illegal raw inside a JSON string.
+    out.clearRetainingCapacity();
+    try appendJsonString(&out, gpa, "line\none\ttwo\x01\\end");
+    const parsed2 = try std.json.parseFromSlice([]const u8, gpa, out.items, .{});
+    defer parsed2.deinit();
+    try std.testing.expectEqualStrings("line\none\ttwo\x01\\end", parsed2.value);
+}
 
 test "headerValue parses case-insensitively and trims" {
     try testing.expectEqualStrings("Bearer abc", headerValue("Authorization: Bearer abc", "authorization").?);

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -83,6 +83,10 @@
           <card padding="12">
             <column gap="10">
               <text>{r.label}</text>
+              <text foreground="text_muted">{r.asker}</text>
+              <if test="{r.has_preview}">
+                <text wrap="true">{r.preview}</text>
+              </if>
               <row gap="8">
                 <button variant="primary" grow="1" on-press="approve:{r.id}">Approve</button>
                 <button variant="destructive" grow="1" on-press="reject:{r.id}">Deny</button>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -92,6 +92,12 @@ pub const Row = struct {
     /// Event kind for `sign_event`, else -1.
     kind: i32 = -1,
     created_at: i64 = 0,
+    /// The requesting client's pubkey, hex.
+    client_buf: [64]u8 = [_]u8{0} ** 64,
+    client_len: u8 = 0,
+    /// The start of what would be signed.
+    preview_buf: [160]u8 = [_]u8{0} ** 160,
+    preview_len: u8 = 0,
 
     pub fn method(self: *const Row) []const u8 {
         return self.method_buf[0..self.method_len];
@@ -103,6 +109,30 @@ pub const Row = struct {
         self.method_len = @intCast(n);
     }
 
+    pub fn client(self: *const Row) []const u8 {
+        return self.client_buf[0..self.client_len];
+    }
+
+    pub fn setClient(self: *Row, c: []const u8) void {
+        const n = @min(c.len, self.client_buf.len);
+        @memcpy(self.client_buf[0..n], c[0..n]);
+        self.client_len = @intCast(n);
+    }
+
+    pub fn preview(self: *const Row) []const u8 {
+        return self.preview_buf[0..self.preview_len];
+    }
+
+    pub fn has_preview(self: *const Row) bool {
+        return self.preview_len > 0;
+    }
+
+    pub fn setPreview(self: *Row, p: []const u8) void {
+        const n = @min(p.len, self.preview_buf.len);
+        @memcpy(self.preview_buf[0..n], p[0..n]);
+        self.preview_len = @intCast(n);
+    }
+
     /// One-line label for the row, e.g. "sign_event · kind 1" or
     /// "get_public_key". Formats into the build arena.
     pub fn label(self: *const Row, arena: std.mem.Allocator) []const u8 {
@@ -110,6 +140,17 @@ pub const Row = struct {
             return std.fmt.allocPrint(arena, "{s} · kind {d}", .{ self.method(), self.kind }) catch self.method();
         }
         return self.method();
+    }
+
+    /// Who is asking, short enough to read: the first and last of the pubkey.
+    ///
+    /// The whole point of putting it on the row is that a person can tell one
+    /// requester from another, and sixty-four hex characters is not something
+    /// anybody compares. Eight and eight is.
+    pub fn asker(self: *const Row, arena: std.mem.Allocator) []const u8 {
+        const c = self.client();
+        if (c.len < 20) return if (c.len == 0) "unknown client" else c;
+        return std.fmt.allocPrint(arena, "from {s}…{s}", .{ c[0..8], c[c.len - 8 ..] }) catch c;
     }
 };
 
@@ -971,6 +1012,8 @@ pub fn parsePending(model: *Model, body: []const u8) void {
             method: []const u8 = "",
             kind: i32 = -1,
             created_at: i64 = 0,
+            client: []const u8 = "",
+            preview: []const u8 = "",
         } = &.{},
     };
     const parsed = std.json.parseFromSliceLeaky(Pending, fba.allocator(), body, .{ .ignore_unknown_fields = true }) catch return;
@@ -981,6 +1024,8 @@ pub fn parsePending(model: *Model, body: []const u8) void {
         if (n >= max_pending) break;
         var row = Row{ .id = p.id, .kind = p.kind, .created_at = p.created_at };
         row.setMethod(p.method);
+        row.setClient(p.client);
+        row.setPreview(p.preview);
         model.rows[n] = row;
         n += 1;
     }

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -185,6 +185,46 @@ test "the empty view shows the connection status and a zero count" {
     _ = try expectByText(tree.root, .status_bar, "0 pending");
 }
 
+test "an approval row says who is asking and what would be signed" {
+    // A row that reads "sign_event · kind 1" and nothing else asks somebody to
+    // authorize a signature without telling them whose request it is or what it
+    // says. It looks identical whether it came from their own client or from
+    // anyone else who reached the signer, and telling those apart is the only
+    // reason a human is in this loop at all.
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+
+    var model = Model{};
+    model.phase = .connected;
+    main.parsePending(&model,
+        \\{"version":1,"pending":[{"id":7,"method":"sign_event","kind":1,"created_at":0,
+        \\"client":"ab12cd34ef56ab78cd90ef12ab34cd56ef78ab90cd12ef34ab56cd78ef90ab12",
+        \\"preview":"gm from a stranger"}]}
+    );
+
+    const tree = try buildTree(arena_state.allocator(), &model);
+    _ = try expectByText(tree.root, .text, "from ab12cd34…ef90ab12");
+    _ = try expectByText(tree.root, .text, "gm from a stranger");
+
+    // A method with nothing to preview does not draw an empty line.
+    var quiet = Model{};
+    quiet.phase = .connected;
+    main.parsePending(&quiet,
+        \\{"version":1,"pending":[{"id":8,"method":"get_public_key","kind":-1,"created_at":0,
+        \\"client":"ab12cd34ef56ab78cd90ef12ab34cd56ef78ab90cd12ef34ab56cd78ef90ab12","preview":""}]}
+    );
+    const quiet_tree = try buildTree(arena_state.allocator(), &quiet);
+    _ = try expectByText(quiet_tree.root, .text, "from ab12cd34…ef90ab12");
+    try testing.expect(!quiet.rows[0].has_preview());
+
+    // A daemon that sent no client at all must not print a misleading identity.
+    var old = Model{};
+    old.phase = .connected;
+    main.parsePending(&old, "{\"version\":1,\"pending\":[{\"id\":9,\"method\":\"sign_event\",\"kind\":1,\"created_at\":0}]}");
+    const old_tree = try buildTree(arena_state.allocator(), &old);
+    _ = try expectByText(old_tree.root, .text, "unknown client");
+}
+
 test "a populated view renders rows and dispatches typed approve/deny" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();


### PR DESCRIPTION
An approval row read `sign_event · kind 1` and stopped there. It looked exactly the same whether the request came from the user's own client or from anyone else who reached the signer, and telling those two apart is the only reason a person is in this loop at all.

**Who.** The row names the requester, first and last eight of their pubkey. Not the whole thing: sixty-four hex characters is not something anybody compares, and a row nobody reads is the same as no row.

**What.** For a `sign_event`, the row shows the start of the content. The kind number says what *shape* the event is and never what it says; approving a kind:1 without seeing its text is approving a sentence published under your name, sight unseen.

**The preview is the requester's own text, so it is escaped on the way into the listing.** Raw, a quote would end the JSON string and everything after it would be read as fields of that same object, which means the requester could give their own row a different method, a different kind, or somebody else's pubkey, on the very screen being used to decide about them. The client pubkey and the method need no escaping and I checked rather than assumed: one is hex, and the other has already parsed as one of seven fixed names before a policy ever sees it.

Needs `nostr` v0.5.0, where a policy is told which client is asking. Bumped here.

**Tests.** Daemon 18, GUI 21. The escaping test asserts a round trip through a real JSON parser rather than a string comparison, so it fails if the output merely looks escaped. The GUI test covers the three cases that matter: a full row, a method with nothing to preview (which must not draw an empty line), and a daemon that sent no client at all, which must say "unknown client" rather than print a misleading identity.