### PR TITLE
Let the daemon choose its own port

### DIFF
--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -58,6 +58,9 @@ pub const Server = struct {
     port: u16,
 
     active: std.atomic.Value(u32) = .init(0),
+    /// Filled once the listener is up. With `port` 0 this is the only place the
+    /// real port exists.
+    bound_port: std.atomic.Value(u16) = .init(0),
     in_flight: [max_conns]InFlight = [_]InFlight{.{}} ** max_conns,
     in_flight_lock: std.atomic.Value(bool) = .init(false),
 
@@ -159,6 +162,22 @@ pub const Server = struct {
         const reaper = std.Thread.spawn(.{}, runReaper, .{self}) catch
             return error.CouldNotStartConnectionReaper;
         reaper.detach();
+
+        // Say which port we got. Asking for port 0 is how the GUI stops
+        // anything else from being there first: a port nobody has chosen yet
+        // cannot be squatted, and this line is the only way the GUI can learn
+        // which one it turned out to be.
+        //
+        // STDOUT, and that matters. The SDK's line-mode spawn ignores the
+        // child's stderr outright (`.stderr = ... else .ignore`), so the
+        // ordinary `std.debug.print` banner below would be dropped on the
+        // floor and the GUI would wait forever for a port it was never told.
+        self.bound_port.store(boundPort(server), .release);
+        var out_buf: [64]u8 = undefined;
+        var stdout = std.Io.File.stdout().writer(io, &out_buf);
+        stdout.interface.print("{s} {d}\n", .{ port_line_prefix, self.bound_port.load(.acquire) }) catch {};
+        stdout.interface.flush() catch {};
+
         while (true) {
             const stream = server.accept(io) catch continue;
             if (self.active.load(.monotonic) >= max_conns) {
@@ -175,6 +194,21 @@ pub const Server = struct {
         }
     }
 };
+
+/// The one line the GUI parses out of the daemon's stdout. Anything else the
+/// daemon prints is for a human reading a terminal.
+pub const port_line_prefix = "notary-approval-port";
+
+/// The port the listener actually bound, which is the entire point of asking
+/// for zero. `net.Server` carries no bound address (checked), so this asks the
+/// kernel. A pure query with no io involvement, unlike the socket-timeout
+/// route, which panicked this io model.
+fn boundPort(server: net.Server) u16 {
+    var sa: std.c.sockaddr.in = undefined;
+    var len: std.c.socklen_t = @sizeOf(std.c.sockaddr.in);
+    if (std.c.getsockname(server.socket.handle, @ptrCast(&sa), &len) != 0) return 0;
+    return std.mem.bigToNative(u16, sa.port);
+}
 
 /// Wakes once a second and cuts off connections that have stopped progressing.
 fn runReaper(self: *Server) void {

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -62,6 +62,10 @@ const default_token_file = ".zig-nostr-signer.token";
 // long-lived daemon spawn holds one slot for the process's lifetime. Timer
 // keys are their own namespace. Decisions use a small pool so several can be
 // in flight at once (a fast double-approve never collides on one key).
+/// The one daemon stdout line the GUI parses. Must match
+/// `approval_http.port_line_prefix` in the daemon.
+const daemon_port_prefix = "notary-approval-port";
+
 const daemon_key: u64 = 1;
 const token_key: u64 = 2;
 const info_key: u64 = 3;
@@ -267,6 +271,18 @@ pub const Model = struct {
     secret_buf: canvas.TextBuffer(200) = .{},
     /// false: generate a fresh key; true: import an existing `nsec1…`/hex.
     import_mode: bool = false,
+    /// Managed mode: whether the daemon has told us which port it bound.
+    ///
+    /// It binds port 0 and reports what the kernel gave it, because a fixed
+    /// port can be taken before the daemon starts. Anything that got there
+    /// first would receive the unlock passphrase, or an imported nsec, from a
+    /// GUI with no way to tell the difference. A port nobody has chosen yet
+    /// cannot be squatted.
+    ///
+    /// Until this is true there is nothing to talk to, so no poll is sent.
+    /// Attached mode sets it at boot: the address came from the environment and
+    /// is the operator's business.
+    port_known: bool = false,
     /// A `/setup` or `/unlock` POST is in flight (disables the submit button).
     submitting: bool = false,
     onboard_error_buf: [96]u8 = [_]u8{0} ** 96,
@@ -280,13 +296,6 @@ pub const Model = struct {
     }
     pub fn baseUrl(self: *const Model) []const u8 {
         return self.base_url_buf[0..self.base_url_len];
-    }
-    /// The bare `host:port` we poll, passed to the spawned daemon as
-    /// `--approval-http` so it serves the API there (a Finder-launched `.app`
-    /// carries no `SIGNER_APPROVAL_HTTP` env for the child to inherit).
-    pub fn approvalAddress(self: *const Model) []const u8 {
-        const url = self.baseUrl();
-        return if (std.mem.startsWith(u8, url, "http://")) url["http://".len..] else url;
     }
     pub fn setTokenPath(self: *Model, path: []const u8) void {
         const n = @min(path.len, self.token_path_buf.len);
@@ -596,11 +605,17 @@ pub const app_markup = @embedFile("app.native");
 const NotaryApp = native_sdk.UiApp(Model, Msg);
 const Effects = NotaryApp.Effects;
 
+/// What we ask the daemon to bind in managed mode: loopback, port chosen by the
+/// kernel. See `Model.port_known` for why.
+const managed_bind_address = "127.0.0.1:0";
+
 fn spawnDaemon(model: *Model, fx: *Effects) void {
     model.phase = .starting;
+    // A restarted daemon gets a different port, so anything we knew is stale.
+    model.port_known = false;
     fx.spawn(.{
         .key = daemon_key,
-        .argv = &.{ model.daemonBin(), "--approval-http", model.approvalAddress() },
+        .argv = &.{ model.daemonBin(), "--approval-http", managed_bind_address },
         .on_line = Effects.lineMsg(.daemon_line),
         .on_exit = Effects.exitMsg(.daemon_exited),
     });
@@ -610,6 +625,10 @@ fn spawnDaemon(model: *Model, fx: *Effects) void {
 /// every attempt means a freshly (re)started daemon's new token is always
 /// picked up, healing both the initial startup race and a restart.
 fn attemptConnect(model: *Model, fx: *Effects) void {
+    // Nothing to connect to until the daemon says where it landed. Staying in
+    // `.starting` is the honest state, and it is what the retry tick already
+    // knows how to leave.
+    if (!model.port_known) return;
     if (model.tokenPath().len == 0) {
         // No token file configured at all: nothing to authenticate with.
         model.phase = .unauthorized;
@@ -778,7 +797,22 @@ pub fn boot(model: *Model, fx: *Effects) void {
 
 pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
     switch (msg) {
-        .daemon_line => {}, // daemon stdout; the connection state is the signal we surface
+        .daemon_line => |line| {
+            // One line out of the daemon's stdout matters: the port it bound.
+            // Everything else it prints is for a human reading a terminal.
+            const text = std.mem.trim(u8, line.line, " \t\r\n");
+            if (!std.mem.startsWith(u8, text, daemon_port_prefix)) return;
+            const rest = std.mem.trim(u8, text[daemon_port_prefix.len..], " \t");
+            const port = std.fmt.parseInt(u16, rest, 10) catch return;
+            if (port == 0) return;
+            var buf: [32]u8 = undefined;
+            const host_port = std.fmt.bufPrint(&buf, "127.0.0.1:{d}", .{port}) catch return;
+            model.setBaseUrl(host_port);
+            model.port_known = true;
+            // The daemon is listening by the time it prints this, so there is
+            // no reason to wait for the retry tick.
+            attemptConnect(model, fx);
+        },
 
         .daemon_exited => |exit| {
             // A cancel we initiated (restart / app quit) reports `.cancelled`.
@@ -1082,6 +1116,9 @@ fn loadConfig(model: *Model, io: std.Io, environ: *const std.process.Environ.Map
         model.setDaemonBin(bin);
         model.managed = true;
     }
+    // Attached mode talks to whatever the operator pointed us at, so the
+    // address above is already the answer. Managed mode waits to be told.
+    model.port_known = !model.managed;
 
     if (environ.get("SIGNER_APPROVAL_TOKEN_FILE")) |path| {
         model.setTokenPath(path);


### PR DESCRIPTION
The approval API was on a fixed `127.0.0.1:8787`, and the GUI concluded it was talking to its own daemon because something answered there. Anything that reached the port first would be handed the unlock passphrase, or an imported nsec, by a GUI with no way to tell the difference.

The daemon now binds port 0 in managed mode and reports what the kernel gave it. A port nobody has chosen yet cannot be taken in advance, and it differs on every start.

**It reports it on stdout, and that is not incidental.** The SDK's line-mode spawn ignores a child's stderr outright (`.stderr = if (output_mode == .collect) .pipe else .ignore`), so the ordinary `std.debug.print` banner would have been dropped on the floor and the GUI would have waited forever for a port it was never told. Read out of the SDK rather than assumed.

The GUI sends nothing until it has been told where to send it. Until the port line arrives it stays in `starting`, which is the honest state and one the retry tick already knows how to leave. A restart clears it, since a restarted daemon gets a different port. Attached mode is unchanged: the address comes from the environment and is the operator's business.

### What this does not do

It does not help against a process running as this user, which can read the token file as easily as the GUI can. It closes the case where something is simply sitting on a known port, waiting.

### Verified by running it

- the daemon reports a real ephemeral port and the API answers there
- the port differs across restarts (60693, then 60715)
- the GUI launched in managed mode reaches first-run setup, which it can only reach after an authenticated `/info` round trip to the port it was told about; its child daemon was listening on 61235, not 8787