### PR TITLE
Take nostr 0.6.0

### DIFF
--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.5.0.tar.gz",
-            .hash = "nostr-0.5.0-CMyPzU9SBwCvl6326rBTDgiSWnsBhDVaGiD1QmH1hO2l",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.6.0.tar.gz",
+            .hash = "nostr-0.6.0-CMyPzYFyBwDLe1r65g4GV6ZeKcGJUwHPqQH7oyxUQezB",
         },
     },
     .paths = .{


### PR DESCRIPTION
Picks up the signer hardening: a captured request cannot be replayed, one that has been sitting around for more than two minutes is refused, the websocket receive buffer is bounded while a frame is still arriving, and the audit line no longer prints the attacker's method string to the terminal.

These are all in the relay serve loop the daemon runs, so the daemon gets them by taking the release. Full detail in zig-nostr/nostr#76.