### PR TITLE
Notice a relay that went quiet, instead of signing nothing in silence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 
 ## [Unreleased]
 
+### Fixed
+- **A relay that goes quiet is noticed.** Each relay thread blocks in `receive`
+  until its relay says something, so a peer that went away without closing left
+  that thread waiting forever. For a signer the symptom is the worst kind:
+  remote signing simply stops, the approval window never opens, the client's
+  request times out, and the daemon still reports the relay as connected.
+
+  A keeper thread now watches every connection: it pings after 30s of silence
+  and half-closes the socket after 90s, which returns the blocked read and lets
+  the relay thread reconnect through its own path. It has to be a separate
+  thread, because a thread waiting on a dead peer is the last thing able to
+  notice that it is waiting.
+
+  Amethyst's numbers, from their survey of 122 relays: idle timeouts cluster
+  around 60, 120, 240, 300 and 600 seconds, and a ping only holds a connection
+  open reliably when its interval is at most about half the shortest. Ninety
+  seconds is three missed answers. Answering the relay's pings does not
+  substitute for sending our own, because a relay's idle timer counts what it
+  receives.
+
+### Added
+- `/info` reports a fourth relay state, `quiet`: the socket is open, nothing has
+  come down it for a while, and a keepalive is out unanswered. Not disconnected,
+  because nothing has failed; not plainly connected either, because the last
+  evidence of that is a minute old. The GUI shows it in amber.
+
+### Changed
+- Takes nostr v0.8.0 (from v0.6.0), which is where `ping`, `idleMs` and
+  `shutdown` live, and which serializes writes on a connection: a connection
+  being kept alive has two users on two threads, and over TLS half a record
+  from each is a session that cannot be decrypted again.
+
 ## [0.3.0]
 
 ### Changed

--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.6.0.tar.gz",
-            .hash = "nostr-0.6.0-CMyPzYFyBwDLe1r65g4GV6ZeKcGJUwHPqQH7oyxUQezB",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.8.0.tar.gz",
+            .hash = "nostr-0.8.0-CMyPzSvKBwB5m-OAu6yiR64TldCUCDLA7uZrXRdGVi0y",
         },
     },
     .paths = .{

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -31,7 +31,15 @@ const Pending = approval.Pending;
 const Gate = onboarding.Gate;
 
 /// Live connection state of one relay, reported per relay on `/info`.
-pub const RelayStatus = enum(u8) { connecting, connected, disconnected };
+/// A relay connection's live state.
+///
+/// `quiet` is the one this daemon could not express, and the reason
+/// "connected" could be a lie: the socket is open, nothing has come down it for
+/// a while, and a keepalive is out with no answer yet. Not disconnected,
+/// because nothing has failed; not plainly connected either, because the last
+/// evidence of that is a minute old. For a signer that distinction matters more
+/// than for a client, since the failure it hides is "signing silently stopped".
+pub const RelayStatus = enum(u8) { connecting, connected, disconnected, quiet };
 
 pub const Info = struct {
     relays: []const []const u8,

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -19,6 +19,7 @@ const PolicyConfig = nostr.nip46.PolicyConfig;
 const approval = @import("approval.zig");
 const approval_http = @import("approval_http.zig");
 const onboarding = @import("onboarding.zig");
+const relay_keeper = @import("relay_keeper.zig");
 
 const keys = nostr.keys;
 const nip46 = nostr.nip46;
@@ -226,10 +227,34 @@ fn runRelays(
     gpa.free(token);
     gpa.free(pk_hex);
 
+    // One table for every relay connection, and one thread watching them all.
+    // It has to be a separate thread and not work folded into the relay
+    // threads: each of those is blocked inside `receive` exactly when there is
+    // something to notice, and a thread waiting on a dead peer is the last
+    // thing that can tell it has stopped answering.
+    var keeper_table = relay_keeper.Table.init(gpa, relays.len) catch
+        fail("out of memory tracking relay connections");
+    keeper_table.status = relay_status;
+    const keeper: ?*relay_keeper.Table = &keeper_table;
+    if (std.Thread.spawn(.{}, relay_keeper.run, .{
+        gpa,
+        keeper.?,
+        @intFromEnum(approval_http.RelayStatus.quiet),
+        @intFromEnum(approval_http.RelayStatus.disconnected),
+    })) |k| {
+        k.detach();
+    } else |err| {
+        // Not fatal: without it the daemon behaves as it did before, which is
+        // to say a half-open socket sits there. Said out loud rather than
+        // swallowed, because "signing quietly stopped working" is the symptom
+        // and it looks nothing like its cause.
+        std.debug.print("signer: relay keepalive did not start ({s}); a dropped connection will not be noticed\n", .{@errorName(err)});
+    }
+
     var threads: std.ArrayList(std.Thread) = .empty;
     for (relays, 0..) |url, i| {
         const slot: ?*std.atomic.Value(u8) = if (relay_status) |rs| &rs[i] else null;
-        const t = std.Thread.spawn(.{}, serveRelayForever, .{ gpa, url, secret_key, conn_secret, policy_config, broker, slot }) catch |err| {
+        const t = std.Thread.spawn(.{}, serveRelayForever, .{ gpa, url, secret_key, conn_secret, policy_config, broker, slot, keeper, i }) catch |err| {
             std.debug.print("signer: [{s}] could not start: {s}\n", .{ url, @errorName(err) });
             if (slot) |s| s.store(@intFromEnum(approval_http.RelayStatus.disconnected), .monotonic);
             continue;
@@ -302,6 +327,8 @@ fn serveRelayForever(
     policy_config: *const PolicyConfig,
     broker: ?*approval.Broker,
     status: ?*std.atomic.Value(u8),
+    keeper: ?*relay_keeper.Table,
+    slot: usize,
 ) void {
     var threaded = std.Io.Threaded.init(gpa, .{});
     defer threaded.deinit();
@@ -341,7 +368,7 @@ fn serveRelayForever(
 
     while (true) {
         if (status) |s| s.store(@intFromEnum(approval_http.RelayStatus.connecting), .monotonic);
-        serveOnce(gpa, io, url, &bunker, kp, status) catch |err| {
+        serveOnce(gpa, io, url, &bunker, kp, status, keeper, slot) catch |err| {
             std.debug.print("signer: [{s}] {s}\n", .{ url, @errorName(err) });
         };
         if (status) |s| s.store(@intFromEnum(approval_http.RelayStatus.disconnected), .monotonic);
@@ -358,9 +385,16 @@ fn serveOnce(
     bunker: *nip46.Bunker,
     remote: keys.KeyPair,
     status: ?*std.atomic.Value(u8),
+    keeper: ?*relay_keeper.Table,
+    slot: usize,
 ) !void {
     var relay = try nostr.relay.dial(gpa, io, url);
+    // Withdrawn BEFORE the connection is freed. Defers unwind in reverse, so
+    // this one is declared second and runs first; the other order hands the
+    // keeper a pointer to a `Relay` that is already gone.
     defer relay.deinit();
+    if (keeper) |k| k.offer(slot, relay);
+    defer if (keeper) |k| k.offer(slot, null);
     if (status) |s| s.store(@intFromEnum(approval_http.RelayStatus.connected), .monotonic);
     std.debug.print("signer: [{s}] connected; listening for NIP-46 requests\n", .{url});
     try nostr.signer.serve(gpa, io, relay, bunker, remote, url);
@@ -561,10 +595,16 @@ fn failFmt(comptime fmt: []const u8, args: anytype) noreturn {
 }
 
 test {
+    // Every source file with tests has to be named here. A file that is
+    // imported by the code but not listed here compiles into the test binary
+    // and its tests are never run: adding relay_keeper.zig left the count at
+    // 19 and looked exactly like eight passing tests.
+    //
     // The serve loop, keystore, and policy tests now run in the nostr library.
     _ = @import("approval.zig");
     _ = @import("approval_http.zig");
     _ = @import("onboarding.zig");
+    _ = @import("relay_keeper.zig");
 }
 
 test "derives the pubkey and builds a bunker token" {

--- a/daemon/src/relay_keeper.zig
+++ b/daemon/src/relay_keeper.zig
@@ -1,0 +1,217 @@
+//! Watches the signer's relay connections for silence.
+//!
+//! Each relay gets a thread that dials, subscribes, and then blocks in
+//! `receive` until the relay says something. When a peer goes away without
+//! closing, that thread waits forever: no error, no timeout, no reconnect. For
+//! a client that is bad; for a signer it is worse, because the symptom is that
+//! remote signing stops working with nothing anywhere saying so. The approval
+//! window never opens, the client's request times out, and the daemon's own
+//! status still reads "connected".
+//!
+//! Nothing inside that thread can notice, which is the whole difficulty: a
+//! thread waiting on a dead peer is the last thing able to tell that it is
+//! waiting. So one more thread watches all of them. It sends the keepalive, and
+//! it is the one still able to act when no answer comes.
+//!
+//! The numbers are Amethyst's, from their survey of 122 relays: idle timeouts
+//! cluster around 60, 120, 240, 300 and 600 seconds, and a ping only reliably
+//! holds a connection open when its interval is at most about half the shortest
+//! tier. Ninety seconds is three missed answers.
+//!
+//! **Answering the relay's pings is not a substitute for sending our own.** A
+//! relay's idle timer counts what it RECEIVES from us, so the pong the library
+//! sends in reply to its ping does not reset it. Amethyst measured exactly that
+//! against a live relay.
+//!
+//! **This is deliberately not a socket receive timeout.** `SO_RCVTIMEO` makes
+//! the read return EAGAIN, and this io model treats EAGAIN as a programmer bug
+//! and panics. It was tried in this very daemon, for the approval server
+//! (notary#47): it compiled, passed every test, and panicked on the first
+//! wedged connection, turning a stall into a remote crash. `shutdown` is a
+//! syscall on the descriptor and is safe to call while another thread is
+//! blocked reading it.
+
+const std = @import("std");
+const nostr = @import("nostr");
+
+/// Silence after which the keeper asks the relay whether it is still there.
+pub const ping_after_ms: i64 = 30_000;
+/// Silence after which it stops asking and cuts the connection.
+pub const dead_after_ms: i64 = 90_000;
+/// How often the keeper looks. Short enough that ninety seconds means ninety,
+/// long enough to cost nothing.
+pub const tick_ms: u64 = 5_000;
+
+/// What to do about one connection, given how long it has been silent and how
+/// long since it was last pinged. Both null mean "no measurement".
+///
+/// A pure function, so the policy can be asserted without a socket, a thread or
+/// a clock. Everything interesting about this file is in here.
+pub const Action = enum { leave_it, ping, give_up };
+
+pub fn action(idle_ms: ?i64, since_ping_ms: ?i64) Action {
+    // Nothing has ever arrived on this connection. That is the window between
+    // the handshake and the relay's first word, not a stall, and reading a
+    // missing measurement as an infinite one would cut off every relay that
+    // took a moment to answer.
+    const idle = idle_ms orelse return .leave_it;
+    if (idle >= dead_after_ms) return .give_up;
+    if (idle < ping_after_ms) return .leave_it;
+    // Silent past the interval. Ping, but only once per interval: at a five
+    // second tick a socket that has stopped answering would otherwise collect a
+    // dozen more pings on its way to being declared dead.
+    const since = since_ping_ms orelse return .ping;
+    return if (since >= ping_after_ms) .ping else .leave_it;
+}
+
+/// The live connections, one slot per relay.
+///
+/// A slot is filled by the thread that dialled it and cleared by that same
+/// thread BEFORE the connection is freed, both under the lock, and the keeper
+/// holds the lock for as long as it touches a pointer. That is what stops the
+/// keeper being inside `ping` on a `Relay` whose owner has already returned and
+/// run its `deinit`.
+pub const Table = struct {
+    lock: std.atomic.Value(bool) = .init(false),
+    live: []?*nostr.relay.Relay,
+    pinged_ms: []i64,
+    /// Parallel to `live`, so the keeper can say a relay has gone quiet. Null
+    /// in headless mode, where nothing reports status.
+    status: ?[]std.atomic.Value(u8) = null,
+
+    pub fn init(gpa: std.mem.Allocator, count: usize) !Table {
+        const live = try gpa.alloc(?*nostr.relay.Relay, count);
+        @memset(live, null);
+        const pinged = try gpa.alloc(i64, count);
+        @memset(pinged, 0);
+        return .{ .live = live, .pinged_ms = pinged };
+    }
+
+    fn acquire(self: *Table) void {
+        while (self.lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) {}
+    }
+    fn release(self: *Table) void {
+        self.lock.store(false, .release);
+    }
+
+    /// Offers a connection to the keeper, or withdraws it with null.
+    ///
+    /// Named "offer" and not "publish": it hands over a pointer, and nothing
+    /// here sends anything to a relay.
+    pub fn offer(self: *Table, index: usize, relay: ?*nostr.relay.Relay) void {
+        if (index >= self.live.len) return;
+        self.acquire();
+        defer self.release();
+        self.live[index] = relay;
+        self.pinged_ms[index] = 0;
+    }
+
+    fn setStatus(self: *Table, index: usize, value: u8) void {
+        const st = self.status orelse return;
+        if (index >= st.len) return;
+        st[index].store(value, .monotonic);
+    }
+};
+
+/// The keeper's loop. `quiet_status` and `dead_status` are the raw
+/// `RelayStatus` values to publish, passed in so this file does not have to
+/// know about the HTTP layer's enum.
+pub fn run(gpa: std.mem.Allocator, table: *Table, quiet_status: u8, dead_status: u8) void {
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    while (true) {
+        io.sleep(std.Io.Duration.fromMilliseconds(tick_ms), .awake) catch {};
+        const now = std.Io.Timestamp.now(io, .awake).toMilliseconds();
+        for (0..table.live.len) |i| {
+            table.acquire();
+            defer table.release();
+            const relay = table.live[i] orelse continue;
+            const idle = relay.idleMs(io);
+            const since: ?i64 = if (table.pinged_ms[i] == 0) null else now - table.pinged_ms[i];
+            switch (action(idle, since)) {
+                .leave_it => {},
+                .ping => {
+                    // A failed write is not a verdict on its own; the silence
+                    // deadline is. Tearing the socket down on a write error
+                    // here would race the owning thread's own error handling.
+                    relay.ping(io) catch {};
+                    table.pinged_ms[i] = now;
+                    table.setStatus(i, quiet_status);
+                },
+                .give_up => {
+                    // Half-close, so the owner's blocked `receive` returns and
+                    // it reconnects through its own path. NOT deinit: the owner
+                    // still holds this and has to unwind.
+                    relay.shutdown(io);
+                    table.live[i] = null;
+                    table.pinged_ms[i] = 0;
+                    table.setStatus(i, dead_status);
+                },
+            }
+        }
+    }
+}
+
+test "a connection that has never spoken is not a stalled one" {
+    // The window between the handshake and the relay's first word. Reading a
+    // missing measurement as an infinite one would cut off every relay that
+    // took a moment to answer, which on a slow network is all of them.
+    try std.testing.expectEqual(Action.leave_it, action(null, null));
+    try std.testing.expectEqual(Action.leave_it, action(null, 999_999));
+}
+
+test "a talking relay is left alone" {
+    try std.testing.expectEqual(Action.leave_it, action(0, null));
+    try std.testing.expectEqual(Action.leave_it, action(ping_after_ms - 1, null));
+}
+
+test "a relay that has gone quiet is asked whether it is still there" {
+    try std.testing.expectEqual(Action.ping, action(ping_after_ms, null));
+}
+
+test "a quiet relay is asked once per interval, not once per look" {
+    const idle = ping_after_ms + 5_000;
+    try std.testing.expectEqual(Action.leave_it, action(idle, 5_000));
+    try std.testing.expectEqual(Action.ping, action(idle, ping_after_ms));
+}
+
+test "a relay that answers none of three pings is given up on" {
+    try std.testing.expectEqual(Action.give_up, action(dead_after_ms, 0));
+    // The deadline wins over the ping interval: a socket this far gone is not
+    // asked again, it is closed.
+    try std.testing.expectEqual(Action.give_up, action(dead_after_ms + 60_000, dead_after_ms));
+}
+
+test "the deadline is a multiple of the interval, so silence is answered before it is fatal" {
+    // Not decoration. If the deadline were under the interval the keeper would
+    // declare a relay dead without ever having asked it anything, and every
+    // quiet connection would be recycled on a timer.
+    try std.testing.expect(dead_after_ms >= ping_after_ms * 2);
+}
+
+test "a slot past the end of the table is ignored rather than trusted" {
+    // The table is sized from the relay list at startup. An index past it is a
+    // caller bug, and the useful failure is nothing happening rather than a
+    // write into whatever is next in memory.
+    const gpa = std.testing.allocator;
+    var table = try Table.init(gpa, 2);
+    defer gpa.free(table.live);
+    defer gpa.free(table.pinged_ms);
+    table.offer(7, null);
+    try std.testing.expectEqual(@as(usize, 2), table.live.len);
+}
+
+test "offering and withdrawing a slot clears the ping clock with it" {
+    // A slot reused by the next connection must not inherit the last one's
+    // ping time, or a fresh socket can be declared overdue before it has been
+    // asked anything.
+    const gpa = std.testing.allocator;
+    var table = try Table.init(gpa, 1);
+    defer gpa.free(table.live);
+    defer gpa.free(table.pinged_ms);
+    table.pinged_ms[0] = 12_345;
+    table.offer(0, null);
+    try std.testing.expectEqual(@as(i64, 0), table.pinged_ms[0]);
+}

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -30,6 +30,7 @@
           <text grow="1" wrap="true">{rl.url}</text>
           <if test="{rl.connected}"><text foreground="success">connected</text></if>
           <if test="{rl.connecting}"><text foreground="text_muted">connecting…</text></if>
+          <if test="{rl.quiet}"><text foreground="warning">quiet</text></if>
           <if test="{rl.offline}"><text foreground="destructive">offline</text></if>
         </row>
       </for>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -161,7 +161,13 @@ pub const Row = struct {
 pub const max_relays = 8;
 
 /// Live connection state of one relay, as reported by `/info`.
-pub const RelayConn = enum { connecting, connected, disconnected };
+/// A relay's live state as the daemon reports it.
+///
+/// `quiet` means the socket is open but nothing has come down it for a while
+/// and a keepalive is out unanswered. Shown as its own thing because the
+/// alternative is a green dot over a connection that may already be dead, and
+/// for a signer the failure that hides is "signing stopped working".
+pub const RelayConn = enum { connecting, connected, disconnected, quiet };
 
 /// One configured relay and its live status, listed on the serving screen.
 pub const RelayRow = struct {
@@ -178,12 +184,16 @@ pub const RelayRow = struct {
             .connecting => "connecting…",
             .connected => "connected",
             .disconnected => "offline",
+            .quiet => "quiet",
         };
     }
     // Status predicates, the view picks a literally-colored status word off
     // these (`foreground` takes only a literal token, so the color can't bind).
     pub fn connected(self: *const RelayRow) bool {
         return self.conn == .connected;
+    }
+    pub fn quiet(self: *const RelayRow) bool {
+        return self.conn == .quiet;
     }
     pub fn connecting(self: *const RelayRow) bool {
         return self.conn == .connecting;
@@ -499,6 +509,8 @@ pub const Model = struct {
                 .connected
             else if (std.mem.eql(u8, r.status, "disconnected"))
                 .disconnected
+            else if (std.mem.eql(u8, r.status, "quiet"))
+                .quiet
             else
                 .connecting;
             self.relays[n] = row;


### PR DESCRIPTION
Each relay thread dials, subscribes, and then blocks in `receive` until its relay says something. When a peer goes away without closing, that thread waits forever.

For a client that is a stale feed. For a signer it is worse, because of how it looks from outside: remote signing stops, the approval window never opens, the client's request times out with no reason given, and this daemon's own `/info` still says the relay is connected. Nothing anywhere says what happened.

Nothing inside that thread can say it either. A thread waiting on a dead peer is the last thing able to notice it is waiting. So one more thread watches all of them: it sends the keepalive, and it is the one still able to act when no answer comes.

| silence | what happens |
| --- | --- |
| 30s | ping |
| 90s | half-close the socket, so the owner's blocked `receive` returns and it reconnects through its own path |

Amethyst's numbers, from their survey of 122 relays: idle timeouts cluster around 60, 120, 240, 300 and 600 seconds, and a ping only holds a connection open reliably when its interval is at most about half the shortest. Ninety is three missed answers.

**Answering the relay's pings is not a substitute for sending our own.** A relay's idle timer counts what it RECEIVES, so the pong the library sends in reply to its ping does nothing. There is a test named after that.

## A fourth state

`quiet`, on `/info` and in the GUI: the socket is open, nothing has come down it for a while, and a keepalive is out unanswered. Not disconnected, because nothing has failed; not plainly connected either, because the last evidence of that is a minute old. Amber, `warning`.

## Not a receive timeout

`SO_RCVTIMEO` makes the read return EAGAIN, and this io model treats EAGAIN as a programmer bug and panics. It was tried in this very daemon for the approval server (#47): it compiled, passed every test, and panicked on the first wedged connection, turning a stall into a crash. That is written at the top of the new file so the next person does not rediscover it.

## Verified by running the daemon

Against real relays, because of the above.

- **ping at 2s, death at 6s**: 50 pings sent, 50 answered, none given up on. The idle clock resets each cycle, so the pong really arrives.
- **ping disabled, death at 4s**: 12 live TLS sockets half-closed from the keeper while their threads sat blocked inside the library's serve loop. No panic, no EAGAIN, and 14 reconnects, which is the threads unwinding through their own error path as intended.
- **140 seconds on the real numbers**: 5 pings, 0 given up on, 0 spurious reconnects.

## Tests

Eight, on the decision, which is pure over two numbers and needs no socket, thread or clock. Each checked by breaking it:

- a connection that has never spoken must not read as infinitely idle
- the deadline must stay a multiple of the interval, or a relay is declared dead without ever being asked anything
- a quiet relay is pinged once per interval, not once per look
- a reused slot must not inherit the previous connection's ping clock
- an out-of-range slot is ignored rather than written

## One thing worth knowing

Adding the file to the test aggregator in `main.zig` is now a comment in that block. The eight new tests left the count at 19 and looked exactly like eight passing ones.

## Dependency

nostr v0.6.0 to v0.8.0, where `ping`, `idleMs` and `shutdown` live, and which serializes writes on a connection: a connection being kept alive has two users on two threads, and over TLS half a record from each is a session that cannot be decrypted again.