### PR TITLE
Notary is 0.4.0, on nostr v0.9.0

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,11 +1,16 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
-### What's new in v0.3.0
+### What's new in v0.4.0
 
-- **The install command works again.** It looks for `Notary.app`, and the previous release still carried `Signet.app` from before the app was renamed, so every install stopped with "the download did not contain Notary.app". Nothing was wrong with the script: there had been no release since the rename.
-- **The app is called Notary.** It was Signet, which already meant a Bitcoin test network, and a signer sharing a name with a testnet is a signer people misread.
-- **The setup screen reads in full.** "Create a new key, or import one you already have..." was cut off mid-sentence at the window's width.
-- **A copy pass** over every screen and both READMEs, and the four screens are now in the README so you can see the app before installing it.
+- **A relay that goes quiet is noticed.** Each relay thread waits inside `receive` until its relay says something, so a peer that went away without closing left that thread waiting forever. For a signer that is the worst kind of failure: remote signing simply stops, the approval window never opens, the client's request times out, and the daemon still reports the relay as connected.
+
+  A keeper thread now watches every connection, pings after thirty seconds of silence and half-closes the socket after ninety, which returns the blocked read and lets the relay thread reconnect. It has to be a separate thread, because a thread waiting on a dead peer is the last thing able to notice that it is waiting.
+
+- **Relays have a fourth state, `quiet`.** The socket is open, nothing has come down it for a while, and a keepalive is out unanswered. Not disconnected, because nothing has failed; not plainly connected either, because the last evidence of that is a minute old. The GUI shows it in amber, and `/info` reports it.
+
+- **A request cannot get past the staleness check by choosing an absurd timestamp.** Notary refuses a NIP-46 request older than two minutes, which is what stops a request captured off the relay from being replayed later. That age was a plain subtraction on a `created_at` the sender picked, and a request stamped with the smallest number an `i64` holds made the difference too wide to fit, so it wrapped to a *negative* age. A negative age is not greater than two minutes, so the check waved it through.
+
+  The arithmetic saturates now: a timestamp that far away reads as stale, which is what the check meant all along. This is a guard rather than the lock, since a request still has to be sealed to your bunker and authorized before anything is signed, but a replay window you can open by choosing a number is not one worth leaving open in the thing that holds your key.
 
 Full history in the [CHANGELOG](https://github.com/zig-nostr/notary/blob/main/CHANGELOG.md). **Your key never leaves the daemon.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-12
+
 ### Fixed
 - **A relay that goes quiet is noticed.** Each relay thread blocks in `receive`
   until its relay says something, so a peer that went away without closing left
@@ -34,10 +36,23 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
   evidence of that is a minute old. The GUI shows it in amber.
 
 ### Changed
-- Takes nostr v0.8.0 (from v0.6.0), which is where `ping`, `idleMs` and
-  `shutdown` live, and which serializes writes on a connection: a connection
-  being kept alive has two users on two threads, and over TLS half a record
-  from each is a session that cannot be decrypted again.
+- Takes nostr v0.9.0 (from v0.6.0). v0.8.0 is where `ping`, `idleMs` and
+  `shutdown` live, and where writes on a connection became serialized: a
+  connection being kept alive has two users on two threads, and over TLS half a
+  record from each is a session that cannot be decrypted again.
+
+  v0.9.0 carries a fix on this daemon's own request path. `worthAnswering`
+  measured a request's age with a plain subtraction on a `created_at` the
+  sender chose. A request stamped `minInt(i64)` makes the difference wider than
+  an i64 holds, so it wrapped to a NEGATIVE age, and a negative age is not
+  greater than the limit: the staleness guard accepted the one timestamp most
+  obviously worth refusing. The arithmetic saturates now, so a timestamp that
+  far away reads as stale, which is what both branches were reaching for.
+
+  It is a guard rather than the lock: a request still has to be sealed to this
+  bunker and authorized before anything is signed. But a replay window that can
+  be opened by choosing a number is not a window anybody should have to argue
+  about, and this daemon is the one thing here holding a key.
 
 ## [0.3.0]
 

--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.8.0.tar.gz",
-            .hash = "nostr-0.8.0-CMyPzSvKBwB5m-OAu6yiR64TldCUCDLA7uZrXRdGVi0y",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.9.0.tar.gz",
+            .hash = "nostr-0.9.0-CMyPzSwJCADUCTmnflqImGCCKSa2EFRqSjlIWAsO8pIj",
         },
     },
     .paths = .{

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.3.0",
+    .version = "0.4.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command", "clipboard" },


### PR DESCRIPTION
Cuts the release that the relay keeper (#51) has been waiting for, and takes nostr v0.9.0 on the way.

## Why the bump matters here, specifically

v0.9.0 fixes something on **this daemon's own request path**, not just somewhere in the library.

`nostr.signer.worthAnswering` runs on every NIP-46 request Notary receives (`daemon/src/main.zig:400` calls `nostr.signer.serve`). It refuses requests older than two minutes, which is what stops a request captured off a public relay from being replayed later. That age was a plain subtraction on a `created_at` the sender chose:

- stamped `minInt(i64)`, the true difference is wider than an `i64` holds
- so it wrapped to a **negative** age
- a negative age is not greater than two minutes
- so the staleness check accepted it

Saturating arithmetic now, so a timestamp that far away reads as stale.

Worth being precise about the severity: this is a guard, not the lock. A request still has to be sealed to your bunker and pass authorization before anything is signed, so this is not a signing bypass. But it is a replay window that opens by choosing a number, in the one component here that holds a key.

## The other half of v0.9.0 does not reach this repo

v0.9.0's breaking change is `bip39.mnemonicToSeed` returning an error union. Nothing here derives a key from a mnemonic, so there is no call site to update. Checked rather than assumed.

## Checked

- `zig build` and `zig build test` green in `daemon/`.
- `zig fmt --check` clean in `daemon/` and `gui/src`.
- GUI build left to CI, which runs `native check`, `native test` and `native build`.