### PR TITLE
A client that asked first

### DIFF
--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.10.0.tar.gz",
-            .hash = "nostr-0.10.0-CMyPzWk1CAC2becNRs7kkkeghxpw1CBhXGaA3HS_0u9Z",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.11.0.tar.gz",
+            .hash = "nostr-0.11.0-CMyPzWpLCADR2ZLEd45ikfK3c2O5d_3Y170D3uQOqN-8",
         },
     },
     .paths = .{

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -55,6 +55,11 @@ pub const Info = struct {
 pub const Server = struct {
     gpa: std.mem.Allocator,
     broker: *Broker,
+    /// The clients that have completed a connect, shared with every relay
+    /// thread. `/nostrconnect` adds to it: adopting a client that invited us is
+    /// authorizing it, and doing that here rather than on the relay threads is
+    /// the whole point of the flow (nobody sends us a request first).
+    clients: ?*nip46.AuthorizedClients = null,
     /// Key-onboarding gate: reports its state on /info and is driven by /setup
     /// and /unlock. The key it guards is created/decrypted in the daemon and
     /// never crosses this API.
@@ -311,6 +316,8 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
         return handleInfo(self, w);
     if (eql(method, "POST") and eql(path, "/setup"))
         return handleSetup(self, io, w, body);
+    if (eql(method, "POST") and eql(path, "/nostrconnect"))
+        return handleNostrConnect(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/unlock"))
         return handleUnlock(self, io, w, body);
     if (eql(method, "GET") and std.mem.startsWith(u8, path, "/pending"))
@@ -459,6 +466,80 @@ fn handleSetup(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !
         else => respond(w, 500, "{\"error\":\"could not create the key\"}"),
     };
     return respondPubkey(self, w);
+}
+
+/// Whether a relay URL from a `nostrconnect://` URI is one to dial.
+///
+/// The link is handed in by a person, but its contents are written by whatever
+/// asked to connect, and this is the one place this daemon makes an OUTBOUND
+/// connection to an address it did not choose. `wss://` only: a `ws://` would
+/// carry the acceptance in the clear, and anything else is not a relay.
+pub fn dialableRelay(url: []const u8) bool {
+    if (!std.mem.startsWith(u8, url, "wss://")) return false;
+    if (url.len <= "wss://".len) return false;
+    // A control character in a URL is something being smuggled, not a typo.
+    for (url) |c| {
+        if (c < 0x20 or c == 0x7f) return false;
+    }
+    return true;
+}
+
+/// How many of a link's relays are worth trying. The client names where it is
+/// listening, and one reachable relay is enough for it to adopt us; this bounds
+/// what a hostile link can make this daemon dial.
+pub const max_nostrconnect_relays = 4;
+
+/// POST /nostrconnect, adopt a client that advertised itself.
+///
+/// The other direction of NIP-46: instead of the reader pasting our `bunker://`
+/// token into a client, the client shows a `nostrconnect://` token and waits.
+/// The answer carries the link's own secret as its result, which is how the
+/// client knows the signer that replied is the one it invited.
+fn handleNostrConnect(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !void {
+    const Body = struct { uri: []const u8 = "" };
+    const parsed = std.json.parseFromSlice(Body, self.gpa, body, .{ .ignore_unknown_fields = true }) catch
+        return respond(w, 400, bad_request);
+    defer parsed.deinit();
+
+    if (self.gate.current() != .unlocked)
+        return respond(w, 409, "{\"error\":\"the key is locked\"}");
+    const clients = self.clients orelse
+        return respond(w, 503, "{\"error\":\"not serving yet\"}");
+
+    var uri = nip46.parseNostrConnectUri(self.gpa, parsed.value.uri) catch
+        return respond(w, 400, "{\"error\":\"that is not a nostrconnect link\"}");
+    defer uri.deinit();
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const kp = signer.keyPairFromSecretKey(self.gate.secret_key) catch
+        return respond(w, 500, "{\"error\":\"could not load the key\"}");
+
+    const now = std.Io.Timestamp.now(io, .real).toSeconds();
+    var sealed = nip46.acceptNostrConnect(self.gpa, io, signer, kp, uri.value, "notary-nostrconnect", now) catch
+        return respond(w, 500, "{\"error\":\"could not build the reply\"}");
+    defer sealed.deinit();
+
+    // Published to the relays the CLIENT named, which are not necessarily ours:
+    // it is listening there and nowhere else.
+    var delivered = false;
+    var tried: usize = 0;
+    for (uri.value.relays) |url| {
+        if (tried >= max_nostrconnect_relays) break;
+        if (!dialableRelay(url)) continue;
+        tried += 1;
+        var relay = nostr.relay.dial(self.gpa, io, url) catch continue;
+        defer relay.deinit();
+        relay.publish(sealed.event) catch continue;
+        delivered = true;
+    }
+    if (!delivered)
+        return respond(w, 502, "{\"error\":\"could not reach any relay the link named\"}");
+
+    // AFTER it is out, not before. Authorizing a client we failed to answer
+    // leaves a grant standing for a connection that never happened.
+    clients.authorize(uri.value.client_pubkey);
+    return respond(w, 200, "{\"ok\":true}");
 }
 
 /// POST /unlock, decrypt an existing key file. Body: `{"passphrase":".."}`.
@@ -685,4 +766,36 @@ test "GET /info reports live per-relay connection status" {
 
     try testing.expect(std.mem.indexOf(u8, body.items, "{\"url\":\"wss://a.example\",\"status\":\"connected\"}") != null);
     try testing.expect(std.mem.indexOf(u8, body.items, "{\"url\":\"wss://b.example\",\"status\":\"disconnected\"}") != null);
+}
+
+test "only a wss relay named by a nostrconnect link is dialled" {
+    // This is the one place the daemon opens an outbound connection to an
+    // address it did not choose: the link is pasted by a person, but its
+    // contents are written by whatever wants to connect.
+    try testing.expect(dialableRelay("wss://relay.example.com"));
+    try testing.expect(dialableRelay("wss://relay.example.com/nostr"));
+
+    // Plaintext would carry the acceptance, and the acceptance carries the
+    // secret that proves which signer answered.
+    try testing.expect(!dialableRelay("ws://relay.example.com"));
+
+    // Not relays at all. The last two are the ones worth naming: a link is a
+    // string from a stranger, and these are what "just dial what it says" turns
+    // into.
+    try testing.expect(!dialableRelay("http://example.com"));
+    try testing.expect(!dialableRelay("file:///etc/passwd"));
+    try testing.expect(!dialableRelay(""));
+    try testing.expect(!dialableRelay("wss://"));
+
+    // A control character in a URL is something being smuggled.
+    try testing.expect(!dialableRelay("wss://evil.example\r\nHOST: x"));
+    try testing.expect(!dialableRelay("wss://evil.example\x00"));
+}
+
+test "a nostrconnect link cannot make the daemon dial without limit" {
+    // A link may name any number of relays. One reachable one is enough for the
+    // client to adopt us, so the rest is only a way to spend this daemon's
+    // sockets on somebody else's list.
+    try testing.expect(max_nostrconnect_relays > 0);
+    try testing.expect(max_nostrconnect_relays <= 8);
 }

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -44,6 +44,17 @@ const default_key_file = ".zig-nostr-signer.key";
 // Deliberately NOT relay.nsec.app, which is the obvious pick and the wrong one:
 // it belongs to a signer project that looks unmaintained, and a default should
 // not point at infrastructure whose owner has moved on.
+/// The two pieces of state every relay thread shares, and the approval server
+/// reaches as well.
+///
+/// Process-lived rather than owned by `runRelays`, because they outlive nothing
+/// and two other things need them: `/nostrconnect` authorizes a client from the
+/// HTTP thread, which is constructed before serving starts, and signing out has
+/// to clear the same set. `runRelays` never returns, so the lifetime was always
+/// the process; this only says so where both callers can see it.
+var g_seen_requests: nostr.signer.SeenRequests = .{};
+var g_authorized_clients: nip46.AuthorizedClients = .{};
+
 const default_gui_relays = "wss://nostr.oxtr.dev,wss://theforest.nostr1.com,wss://relay.primal.net";
 
 const usage =
@@ -170,6 +181,7 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
         .gate = &gate,
         .token = token_hex,
         .info = .{ .relays = relays.items, .timeout_ms = broker_storage.timeout_ms, .secret = conn_secret, .relay_status = relay_status },
+        .clients = &g_authorized_clients,
         .host = hp.host,
         .port = hp.port,
     };
@@ -277,13 +289,10 @@ fn runRelays(
     //
     // Both now live out here for the life of the process. This is exactly what
     // nostr v0.10.0 changed its two signatures for.
-    var seen_requests: nostr.signer.SeenRequests = .{};
-    var authorized_clients: nip46.AuthorizedClients = .{};
-
     var threads: std.ArrayList(std.Thread) = .empty;
     for (relays, 0..) |url, i| {
         const slot: ?*std.atomic.Value(u8) = if (relay_status) |rs| &rs[i] else null;
-        const t = std.Thread.spawn(.{}, serveRelayForever, .{ gpa, url, secret_key, conn_secret, policy_config, broker, slot, keeper, i, &seen_requests, &authorized_clients }) catch |err| {
+        const t = std.Thread.spawn(.{}, serveRelayForever, .{ gpa, url, secret_key, conn_secret, policy_config, broker, slot, keeper, i, &g_seen_requests, &g_authorized_clients }) catch |err| {
             std.debug.print("signer: [{s}] could not start: {s}\n", .{ url, @errorName(err) });
             if (slot) |s| s.store(@intFromEnum(approval_http.RelayStatus.disconnected), .monotonic);
             continue;

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -19,6 +19,14 @@
           <button variant="secondary" on-press="copy_bunker">{copy_label}</button>
         </column>
       </card>
+      <text foreground="text_muted">Or paste a nostrconnect:// link a client showed you</text>
+      <row gap="8">
+        <text-field text="{nostrconnect}" placeholder="nostrconnect://…" on-input="nostrconnect_edit" on-submit="submit_nostrconnect" grow="1"/>
+        <button variant="secondary" on-press="submit_nostrconnect" disabled="{nostrconnect_disabled}">{nostrconnect_label}</button>
+      </row>
+      <if test="{has_nostrconnect_error}">
+        <text foreground="destructive">{nostrconnect_error}</text>
+      </if>
     </column>
     <separator/>
   </if>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -72,6 +72,7 @@ const info_key: u64 = 3;
 const pending_key: u64 = 4;
 const setup_key: u64 = 5;
 const unlock_key: u64 = 6;
+const nostrconnect_key: u64 = 11;
 const clipboard_key: u64 = 7;
 const info_refresh_key: u64 = 16; // periodic /info re-poll (distinct from the initial info_key)
 const decision_key_base: u64 = 8;
@@ -278,6 +279,12 @@ pub const Model = struct {
     /// screens. They transit this process once to reach `/setup` or `/unlock`
     /// and are cleared right after a successful send.
     passphrase_buf: canvas.TextBuffer(128) = .{},
+    /// A `nostrconnect://` link pasted in from a client that is waiting to be
+    /// adopted. Long, because it carries relays, a secret and app metadata.
+    nostrconnect_buf: canvas.TextBuffer(512) = .{},
+    nostrconnect_sending: bool = false,
+    nostrconnect_error_buf: [96]u8 = [_]u8{0} ** 96,
+    nostrconnect_error_len: usize = 0,
     secret_buf: canvas.TextBuffer(200) = .{},
     /// false: generate a fresh key; true: import an existing `nsec1…`/hex.
     import_mode: bool = false,
@@ -377,6 +384,22 @@ pub const Model = struct {
     }
 
     // -- onboarding view bindings --
+
+    pub fn nostrconnect(self: *const Model) []const u8 {
+        return self.nostrconnect_buf.text();
+    }
+    pub fn nostrconnect_disabled(self: *const Model) bool {
+        return self.nostrconnect_sending or self.nostrconnect_buf.text().len == 0;
+    }
+    pub fn nostrconnect_label(self: *const Model) []const u8 {
+        return if (self.nostrconnect_sending) "Connecting…" else "Connect";
+    }
+    pub fn nostrconnect_error(self: *const Model) []const u8 {
+        return self.nostrconnect_error_buf[0..self.nostrconnect_error_len];
+    }
+    pub fn has_nostrconnect_error(self: *const Model) bool {
+        return self.nostrconnect_error_len > 0;
+    }
 
     pub fn passphrase(self: *const Model) []const u8 {
         return self.passphrase_buf.text();
@@ -592,6 +615,11 @@ pub const Msg = union(enum) {
     // clears the transient "Copied!" confirmation.
     copy_bunker,
     bunker_copied: native_sdk.EffectClipboardResult,
+
+    // Adopting a client that showed a nostrconnect:// link.
+    nostrconnect_edit: canvas.TextInputEvent,
+    submit_nostrconnect,
+    nostrconnect_done: native_sdk.EffectResponse,
     copy_reset: native_sdk.EffectTimer,
 
     // Periodic /info re-poll (keeps the live relay status fresh) and its response.
@@ -739,6 +767,29 @@ fn sendSetup(model: *Model, fx: *Effects) void {
     };
     fx.fetch(.{ .key = setup_key, .method = .POST, .url = url, .headers = &headers, .body = body, .timeout_ms = 20_000, .on_response = Effects.responseMsg(.setup_done) });
     std.crypto.secureZero(u8, &body_buf);
+}
+
+/// POST /nostrconnect, adopt a client that showed a `nostrconnect://` link.
+///
+/// The link goes to the daemon whole and is parsed there, because the daemon is
+/// what holds the key and what will publish the answer. The GUI does not read
+/// it: a link is a stranger's string, and there is nothing this window could
+/// usefully decide about one that the signer does not decide better.
+fn sendNostrConnect(model: *Model, fx: *Effects) void {
+    const link = model.nostrconnect_buf.text();
+    if (link.len == 0 or model.nostrconnect_sending) return;
+    model.nostrconnect_sending = true;
+    model.nostrconnect_error_len = 0;
+    var url_buf: [128]u8 = undefined;
+    const url = std.fmt.bufPrint(&url_buf, "{s}/nostrconnect", .{model.baseUrl()}) catch return;
+    var body_buf: [768]u8 = undefined;
+    const Body = struct { uri: []const u8 };
+    const body = std.fmt.bufPrint(&body_buf, "{f}", .{std.json.fmt(Body{ .uri = link }, .{})}) catch return;
+    const headers = [_]std.http.Header{
+        .{ .name = "authorization", .value = model.auth() },
+        .{ .name = "content-type", .value = "application/json" },
+    };
+    fx.fetch(.{ .key = nostrconnect_key, .method = .POST, .url = url, .headers = &headers, .body = body, .timeout_ms = 20_000, .on_response = Effects.responseMsg(.nostrconnect_done) });
 }
 
 /// POST /unlock, decrypt the key file with the entered passphrase.
@@ -969,6 +1020,31 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
 
         // -- onboarding --
         .passphrase_edit => |e| model.passphrase_buf.apply(e),
+        .nostrconnect_edit => |e| {
+            model.nostrconnect_buf.apply(e);
+            model.nostrconnect_error_len = 0;
+        },
+        .submit_nostrconnect => sendNostrConnect(model, fx),
+        .nostrconnect_done => |response| {
+            model.nostrconnect_sending = false;
+            if (response.outcome == .ok and response.status == 200) {
+                // Adopted. The field is cleared because the link is single use:
+                // the client has its answer and is not waiting any more.
+                model.nostrconnect_buf.set("");
+                model.nostrconnect_error_len = 0;
+                return;
+            }
+            const text = switch (response.status) {
+                400 => "That does not look like a nostrconnect link.",
+                409 => "Unlock your signer first.",
+                502 => "Could not reach any relay that link named.",
+                503 => "The signer is not serving yet.",
+                else => "Could not connect to that client.",
+            };
+            const n = @min(text.len, model.nostrconnect_error_buf.len);
+            @memcpy(model.nostrconnect_error_buf[0..n], text[0..n]);
+            model.nostrconnect_error_len = n;
+        },
         .secret_edit => |e| model.secret_buf.apply(e),
         .choose_create => {
             model.import_mode = false;

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -406,3 +406,37 @@ test "the unlock screen renders and dispatches submit_unlock" {
         else => return error.WrongMessage,
     }
 }
+
+test "a refused nostrconnect link says which thing went wrong" {
+    var m = main.Model{};
+    // Nothing typed: the button is inert rather than sending an empty link.
+    try testing.expect(m.nostrconnect_disabled());
+    try testing.expect(!m.has_nostrconnect_error());
+
+    m.nostrconnect_buf.set("nostrconnect://abc?relay=wss%3A%2F%2Fr.example&secret=s");
+    try testing.expect(!m.nostrconnect_disabled());
+
+    // Each status the daemon can answer with maps to a sentence a person can
+    // act on. "Could not connect" for all of them would be true and useless:
+    // locking, a bad link and an unreachable relay need different things done.
+    const cases = [_]struct { status: u16, needle: []const u8 }{
+        .{ .status = 400, .needle = "nostrconnect link" },
+        .{ .status = 409, .needle = "Unlock" },
+        .{ .status = 502, .needle = "relay" },
+        .{ .status = 503, .needle = "not serving" },
+    };
+    for (cases) |c| {
+        m.nostrconnect_sending = true;
+        main.update(&m, main.Msg{ .nostrconnect_done = .{ .key = 11, .outcome = .ok, .status = c.status, .body = "" } }, undefined);
+        try testing.expect(!m.nostrconnect_sending);
+        try testing.expect(m.has_nostrconnect_error());
+        try testing.expect(std.mem.indexOf(u8, m.nostrconnect_error(), c.needle) != null);
+    }
+
+    // And success clears the field, because the link is single use: the client
+    // has its answer and is not waiting any more.
+    m.nostrconnect_sending = true;
+    main.update(&m, main.Msg{ .nostrconnect_done = .{ .key = 11, .outcome = .ok, .status = 200, .body = "" } }, undefined);
+    try testing.expect(!m.has_nostrconnect_error());
+    try testing.expectEqualStrings("", m.nostrconnect());
+}


### PR DESCRIPTION
Notary could only be connected one way round: you copy its `bunker://` URL and paste it into a client. The other direction is what most clients actually offer, a `nostrconnect://` link they show and wait on, and Notary had no answer for it. Paste one now and it adopts that client.

### The part you only get right by being told

The link's `secret` is **not** the connect method's secret, and the reply carries it as the **result**, in place of `"ack"`. It is how the client knows the signer that answered is the one it invited.

nsec.app says so in a comment where it fabricates the request; nostr-tools' client is the other half, adopting the first kind:24133 addressed to it whose decrypted `result` equals the secret it published, and taking that event's author as its signer. Answering `"ack"` is ignored and the connection never completes, with nothing to see on either side.

That lives in the library (nostr v0.11.0, taken here) so it is documented once.

### The one place this daemon dials an address it did not choose

The answer goes to the relays the *client* named, which are not necessarily ours: it is listening there and nowhere else. So the link is treated as what it is, a stranger's string:

- `wss://` only. `ws://` would carry the acceptance in the clear, and the acceptance carries the secret.
- No control characters, which are something being smuggled rather than a typo.
- At most four relays tried. One reachable relay is enough for the client to adopt us; the rest is only a way to spend this daemon's sockets on somebody else's list.

The client is authorized **after** the answer is out. Authorizing one we failed to answer leaves a grant standing for a connection that never happened.

### Shared state moved to the process

The record of answered requests and the set of connected clients. The HTTP thread needs the second one, because adopting a client *is* authorizing it and nobody sends us a request first, and that thread is built before serving starts. `runRelays` never returns, so that was always the lifetime; this only says so where both callers can see it. Signing out will want the same set.

### The GUI hands the link over whole

It does not parse it. A link is a stranger's string and there is nothing that window could usefully decide about one that the signer does not decide better. Each refusal gets its own sentence, because locking, a bad link and an unreachable relay need different things done.

### Checked

Relaxing `wss://` to `ws` in the guard turns its test red. The guard is tested against `file://`, `http://`, an empty string, a bare scheme, and a URL with CRLF in it. The GUI's mapping of every refusal status is tested, including that success clears the field, since a link is single use.