### PR TITLE
Sign out, and use another key

### DIFF
--- a/daemon/src/approval.zig
+++ b/daemon/src/approval.zig
@@ -165,6 +165,24 @@ pub const Broker = struct {
         return n;
     }
 
+    /// Denies everything still waiting and frees the slots.
+    ///
+    /// For signing out: a request that was queued against the key being removed
+    /// must not sit there and be approved against whatever key comes next.
+    /// REJECTED rather than dropped, because a relay thread is blocked waiting on
+    /// each of these and dropping the slot would leave it waiting for a decision
+    /// that can no longer arrive.
+    pub fn reset(self: *Broker) void {
+        self.acquire();
+        for (&self.slots) |*slot| {
+            if (slot.in_use and slot.decision.load(.monotonic) == .pending) {
+                slot.decision.store(.reject, .release);
+            }
+        }
+        self.release();
+        _ = self.version.fetchAdd(1, .monotonic);
+    }
+
     /// Applies the GUI's decision to pending entry `id`. Returns true if it was
     /// found and still pending.
     pub fn resolve(self: *Broker, id: u64, decision: Decision) bool {
@@ -363,4 +381,23 @@ test "housekeeping never reaches the human, so a stranger cannot park the relay 
     // An unrecognised name is not waved through.
     const odd = nip46.Request{ .id = "2", .method = "nip04_decrypt", .params = &.{} };
     try testing.expectEqual(nip46.Decision.reject, p.decide(&odd, [_]u8{0} ** 32));
+}
+
+test "resetting the broker rejects what was waiting rather than dropping it" {
+    var broker = Broker{};
+    broker.slots[0] = .{ .in_use = true, .info = .{ .id = 1 }, .decision = std.atomic.Value(Decision).init(.pending) };
+    broker.slots[1] = .{ .in_use = true, .info = .{ .id = 2 }, .decision = std.atomic.Value(Decision).init(.pending) };
+
+    broker.reset();
+
+    // REJECTED, not cleared. A relay thread is parked waiting on each of these,
+    // and freeing the slot would leave it waiting for an answer that can never
+    // arrive. Signing out has to unblock them, not strand them.
+    try std.testing.expectEqual(Decision.reject, broker.slots[0].decision.load(.monotonic));
+    try std.testing.expectEqual(Decision.reject, broker.slots[1].decision.load(.monotonic));
+
+    // A request already decided keeps its answer.
+    broker.slots[2] = .{ .in_use = true, .info = .{ .id = 3 }, .decision = std.atomic.Value(Decision).init(.approve) };
+    broker.reset();
+    try std.testing.expectEqual(Decision.approve, broker.slots[2].decision.load(.monotonic));
 }

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -316,6 +316,8 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
         return handleInfo(self, w);
     if (eql(method, "POST") and eql(path, "/setup"))
         return handleSetup(self, io, w, body);
+    if (eql(method, "POST") and eql(path, "/forget"))
+        return handleForget(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/nostrconnect"))
         return handleNostrConnect(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/unlock"))
@@ -466,6 +468,44 @@ fn handleSetup(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !
         else => respond(w, 500, "{\"error\":\"could not create the key\"}"),
     };
     return respondPubkey(self, w);
+}
+
+/// What `/forget` requires in its body before it will delete anything. Typed by
+/// the reader, not clicked: this removes the only copy of a key on this Mac.
+pub const forget_confirmation = "delete my key";
+
+/// POST /forget, remove the key file so another account can be set up.
+///
+/// The destructive half of switching accounts, and the reason it is its own
+/// endpoint rather than part of signing out: signing out is reversible and this
+/// is not. The key file is the only copy of that identity here.
+///
+/// It ends the process on success, and that is not tidiness. The relay threads
+/// were handed the key by value when serving began and still hold it, so
+/// deleting the file alone would leave a signer that has lost its key on disk
+/// and is still happily signing with it in memory. Exiting is what retracts it;
+/// the GUI spawns the daemon again and it comes up with nothing to serve.
+fn handleForget(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !void {
+    const Body = struct { confirm: []const u8 = "" };
+    const parsed = std.json.parseFromSlice(Body, self.gpa, body, .{ .ignore_unknown_fields = true }) catch
+        return respond(w, 400, bad_request);
+    defer parsed.deinit();
+
+    if (!eql(parsed.value.confirm, forget_confirmation))
+        return respond(w, 400, "{\"error\":\"confirmation phrase does not match\"}");
+
+    // Sessions granted against the key being removed must not outlive it. A
+    // client still holding an authorization is one that would be recognised by
+    // whatever key is set up next.
+    if (self.clients) |c| c.clear();
+    self.broker.reset();
+    self.gate.forget(io);
+
+    // Answered before exiting, so the GUI is told rather than seeing its
+    // connection drop and guessing why.
+    respond(w, 200, "{\"ok\":true}") catch {};
+    w.flush() catch {};
+    std.process.exit(0);
 }
 
 /// Whether a relay URL from a `nostrconnect://` URI is one to dial.
@@ -798,4 +838,15 @@ test "a nostrconnect link cannot make the daemon dial without limit" {
     // sockets on somebody else's list.
     try testing.expect(max_nostrconnect_relays > 0);
     try testing.expect(max_nostrconnect_relays <= 8);
+}
+
+test "forgetting a key needs the exact confirmation phrase" {
+    // Typed, not clicked. This deletes the only copy of an identity on this
+    // Mac, and there is nothing on the other side of it that can undo it, so
+    // the check is an exact match rather than a truthy flag.
+    try testing.expect(eql(forget_confirmation, "delete my key"));
+    try testing.expect(!eql(forget_confirmation, ""));
+    try testing.expect(!eql(forget_confirmation, "Delete my key"));
+    try testing.expect(!eql(forget_confirmation, "delete my key "));
+    try testing.expect(!eql(forget_confirmation, "yes"));
 }

--- a/daemon/src/onboarding.zig
+++ b/daemon/src/onboarding.zig
@@ -148,6 +148,25 @@ pub const Gate = struct {
         return self.secret_key;
     }
 
+    /// Removes the key file and returns to `uninitialized`, so the next boot
+    /// onboards a fresh key.
+    ///
+    /// This is the destructive half of switching accounts, and the key file is
+    /// the only copy of that identity on this Mac. Callers must have said so to
+    /// the reader FIRST; nothing here can un-delete it.
+    ///
+    /// The in-memory key is zeroed too, but that is not the whole story and the
+    /// caller has to finish it: the relay threads were handed the key by value
+    /// when serving started and still hold it. Ending the process is what
+    /// actually retracts it, which is why the endpoint that calls this exits.
+    pub fn forget(self: *Gate, io: std.Io) void {
+        self.dir.deleteFile(io, self.key_file) catch {};
+        std.crypto.secureZero(u8, &self.secret_key);
+        self.pubkey_bytes = [_]u8{0} ** 32;
+        self.pubkey_len = 0;
+        self.state.store(@intFromEnum(State.uninitialized), .release);
+    }
+
     fn publish(self: *Gate, kp: keys.KeyPair) void {
         self.secret_key = kp.secret_key;
         self.pubkey_bytes = kp.public_key;

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -27,6 +27,10 @@
       <if test="{has_nostrconnect_error}">
         <text foreground="destructive">{nostrconnect_error}</text>
       </if>
+      <row gap="8">
+        <button variant="secondary" on-press="sign_out">Sign out</button>
+        <text grow="1" foreground="text_muted" wrap="true">Locks the signer. Your key stays on this Mac and needs its passphrase again.</text>
+      </row>
     </column>
     <separator/>
   </if>
@@ -78,6 +82,15 @@
         <text foreground="destructive">{onboard_error}</text>
       </if>
       <button variant="primary" on-press="submit_unlock" disabled="{submit_disabled}">{unlock_label}</button>
+      <separator/>
+      <text foreground="text_muted" wrap="true">Signing in as somebody else removes this key from this Mac. It is the only copy here, so make sure you have its nsec written down first. Type "delete my key" to confirm.</text>
+      <row gap="8">
+        <text-field text="{forget_confirm}" placeholder="delete my key" on-input="forget_edit" grow="1"/>
+        <button variant="destructive" on-press="submit_forget" disabled="{forget_disabled}">Use another key</button>
+      </row>
+      <if test="{has_forget_error}">
+        <text foreground="destructive">{forget_error}</text>
+      </if>
     </column>
   </if>
   <if test="{show_empty}">

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -73,6 +73,7 @@ const pending_key: u64 = 4;
 const setup_key: u64 = 5;
 const unlock_key: u64 = 6;
 const nostrconnect_key: u64 = 11;
+const forget_key: u64 = 12;
 const clipboard_key: u64 = 7;
 const info_refresh_key: u64 = 16; // periodic /info re-poll (distinct from the initial info_key)
 const decision_key_base: u64 = 8;
@@ -285,6 +286,11 @@ pub const Model = struct {
     nostrconnect_sending: bool = false,
     nostrconnect_error_buf: [96]u8 = [_]u8{0} ** 96,
     nostrconnect_error_len: usize = 0,
+    /// Typed confirmation for removing the key file. A phrase rather than a
+    /// checkbox, because this is the one control here that destroys something.
+    forget_buf: canvas.TextBuffer(32) = .{},
+    forget_error_buf: [96]u8 = [_]u8{0} ** 96,
+    forget_error_len: usize = 0,
     secret_buf: canvas.TextBuffer(200) = .{},
     /// false: generate a fresh key; true: import an existing `nsec1…`/hex.
     import_mode: bool = false,
@@ -384,6 +390,21 @@ pub const Model = struct {
     }
 
     // -- onboarding view bindings --
+
+    pub fn forget_confirm(self: *const Model) []const u8 {
+        return self.forget_buf.text();
+    }
+    pub fn forget_disabled(self: *const Model) bool {
+        // The button is inert until the phrase matches exactly, so the
+        // destructive press cannot be a mis-click.
+        return !std.mem.eql(u8, self.forget_buf.text(), "delete my key");
+    }
+    pub fn forget_error(self: *const Model) []const u8 {
+        return self.forget_error_buf[0..self.forget_error_len];
+    }
+    pub fn has_forget_error(self: *const Model) bool {
+        return self.forget_error_len > 0;
+    }
 
     pub fn nostrconnect(self: *const Model) []const u8 {
         return self.nostrconnect_buf.text();
@@ -620,6 +641,12 @@ pub const Msg = union(enum) {
     nostrconnect_edit: canvas.TextInputEvent,
     submit_nostrconnect,
     nostrconnect_done: native_sdk.EffectResponse,
+
+    // Signing out (lock, reversible) and removing the key (not reversible).
+    sign_out,
+    forget_edit: canvas.TextInputEvent,
+    submit_forget,
+    forget_done: native_sdk.EffectResponse,
     copy_reset: native_sdk.EffectTimer,
 
     // Periodic /info re-poll (keeps the live relay status fresh) and its response.
@@ -767,6 +794,25 @@ fn sendSetup(model: *Model, fx: *Effects) void {
     };
     fx.fetch(.{ .key = setup_key, .method = .POST, .url = url, .headers = &headers, .body = body, .timeout_ms = 20_000, .on_response = Effects.responseMsg(.setup_done) });
     std.crypto.secureZero(u8, &body_buf);
+}
+
+/// POST /forget, remove the key file so another account can be set up.
+///
+/// The daemon answers and then exits, because its relay threads still hold the
+/// key it just deleted. The response handler spawns it again.
+fn sendForget(model: *Model, fx: *Effects) void {
+    if (model.forget_disabled()) return;
+    model.forget_error_len = 0;
+    var url_buf: [128]u8 = undefined;
+    const url = std.fmt.bufPrint(&url_buf, "{s}/forget", .{model.baseUrl()}) catch return;
+    var body_buf: [128]u8 = undefined;
+    const Body = struct { confirm: []const u8 };
+    const body = std.fmt.bufPrint(&body_buf, "{f}", .{std.json.fmt(Body{ .confirm = model.forget_buf.text() }, .{})}) catch return;
+    const headers = [_]std.http.Header{
+        .{ .name = "authorization", .value = model.auth() },
+        .{ .name = "content-type", .value = "application/json" },
+    };
+    fx.fetch(.{ .key = forget_key, .method = .POST, .url = url, .headers = &headers, .body = body, .timeout_ms = 20_000, .on_response = Effects.responseMsg(.forget_done) });
 }
 
 /// POST /nostrconnect, adopt a client that showed a `nostrconnect://` link.
@@ -1025,6 +1071,49 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             model.nostrconnect_error_len = 0;
         },
         .submit_nostrconnect => sendNostrConnect(model, fx),
+
+        .sign_out => {
+            // A restart IS the sign out. The relay threads were handed the key
+            // by value when serving began, so nothing short of ending the
+            // process takes it back; the daemon then comes up locked and asks
+            // for the passphrase. Doing it any other way would leave a signer
+            // that reports itself signed out and still signs.
+            if (!model.managed) return;
+            model.setAuth("");
+            model.clearRows();
+            model.clearSecrets();
+            model.clearOnboardError();
+            model.submitting = false;
+            spawnDaemon(model, fx);
+            attemptConnect(model, fx);
+        },
+        .forget_edit => |e| {
+            model.forget_buf.apply(e);
+            model.forget_error_len = 0;
+        },
+        .submit_forget => sendForget(model, fx),
+        .forget_done => |response| {
+            if (response.outcome == .ok and response.status == 200) {
+                // The daemon deletes the key and exits, so what follows is a
+                // fresh one with nothing to serve: it will come up asking to
+                // create or import.
+                model.forget_buf.set("");
+                model.forget_error_len = 0;
+                model.setAuth("");
+                model.clearRows();
+                model.clearSecrets();
+                spawnDaemon(model, fx);
+                attemptConnect(model, fx);
+                return;
+            }
+            const text = if (response.status == 400)
+                "Type the phrase exactly to confirm."
+            else
+                "Could not remove the key.";
+            const n = @min(text.len, model.forget_error_buf.len);
+            @memcpy(model.forget_error_buf[0..n], text[0..n]);
+            model.forget_error_len = n;
+        },
         .nostrconnect_done => |response| {
             model.nostrconnect_sending = false;
             if (response.outcome == .ok and response.status == 200) {

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -440,3 +440,24 @@ test "a refused nostrconnect link says which thing went wrong" {
     try testing.expect(!m.has_nostrconnect_error());
     try testing.expectEqualStrings("", m.nostrconnect());
 }
+
+test "the destructive key removal is inert until the phrase matches exactly" {
+    var m = main.Model{};
+    // Disabled by default, so the press that removes somebody's only copy of an
+    // identity on this Mac cannot be a mis-click.
+    try testing.expect(m.forget_disabled());
+
+    m.forget_buf.set("yes");
+    try testing.expect(m.forget_disabled());
+    m.forget_buf.set("Delete my key");
+    try testing.expect(m.forget_disabled());
+    m.forget_buf.set("delete my key ");
+    try testing.expect(m.forget_disabled());
+
+    m.forget_buf.set("delete my key");
+    try testing.expect(!m.forget_disabled());
+
+    // A refusal from the daemon is reported rather than swallowed.
+    main.update(&m, main.Msg{ .forget_done = .{ .key = 12, .outcome = .ok, .status = 400, .body = "" } }, undefined);
+    try testing.expect(m.has_forget_error());
+}


### PR DESCRIPTION
There was no way out of an account. Once a key was unlocked the signer served it until the process died, and switching to a different one meant finding the key file by hand.

Two things, deliberately separate, because one is reversible and the other is not.

### Signing out locks the signer

Implemented as a restart, and that is the honest implementation rather than a lazy one: the relay threads were handed the key **by value** when serving began, so nothing short of ending the process takes it back. A version that flipped a flag would report itself signed out while every relay thread went on signing. The daemon comes back up locked and asks for the passphrase.

### Using another key removes the key file

That deletes the only copy of that identity on this Mac, so it sits behind a typed phrase, `delete my key`, matched exactly. The button is inert until it matches, so the press cannot be a mis-click, and the screen says to have the nsec written down first. `/forget` refuses anything that is not an exact match, including `yes`, a different case, and a trailing space.

`/forget` **ends the process** on success, and that is the point rather than tidiness: the relay threads still hold the key that was just deleted, so returning normally would leave a signer that has lost its key on disk and is happily signing with it in memory. The GUI spawns the daemon again and it comes up with nothing to serve.

### Sessions do not outlive the key they were granted against

Forgetting clears the authorized clients, so a client still holding an authorization cannot be recognised by whatever key is set up next.

Anything waiting for a decision is **rejected** rather than dropped. A relay thread is parked inside `submit` on each of those, and freeing the slot would leave it waiting for an answer that can never arrive; signing out has to unblock them, not strand them.

### Checked

Replacing the rejection with a slot free turns its test red. The confirmation phrase is tested against the near-misses that would otherwise get through, and the GUI's disabled state is tested for each of them.