### PR TITLE
Notary is 0.5.0

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,18 +1,18 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
-### What's new in v0.4.0
+### What's new in v0.5.0
 
-- **A relay that goes quiet is noticed.** Each relay thread waits inside `receive` until its relay says something, so a peer that went away without closing left that thread waiting forever. For a signer that is the worst kind of failure: remote signing simply stops, the approval window never opens, the client's request times out, and the daemon still reports the relay as connected.
+**Clients can invite Notary now, not just the other way round.** Until now the only way to connect was to copy Notary's `bunker://` URL and paste it into your client. Most clients offer the opposite: they show a `nostrconnect://` link and wait. Paste one into Notary and it adopts that client.
 
-  A keeper thread now watches every connection, pings after thirty seconds of silence and half-closes the socket after ninety, which returns the blocked read and lets the relay thread reconnect. It has to be a separate thread, because a thread waiting on a dead peer is the last thing able to notice that it is waiting.
+**Three relays instead of one.** Notary served on a single relay, which means it stops signing the moment that relay does, and from your client's side that failure is silent: the request goes out, nothing ever answers, and the app just sits there. It now serves three, run by three different operators, so one going down is one connection reconnecting rather than a signer that has quietly stopped.
 
-- **Relays have a fourth state, `quiet`.** The socket is open, nothing has come down it for a while, and a keepalive is out unanswered. Not disconnected, because nothing has failed; not plainly connected either, because the last evidence of that is a minute old. The GUI shows it in amber, and `/info` reports it.
+Serving several relays needed more than a longer list. Your client publishes each request to every relay in the token, so one thing you asked for arrives several times. Notary used to treat those as separate: two approval windows for one question, and two signatures published for one intent. It also meant a client that connected over one relay and then asked over another was told it had never connected. Both are fixed.
 
-- **A request cannot get past the staleness check by choosing an absurd timestamp.** Notary refuses a NIP-46 request older than two minutes, which is what stops a request captured off the relay from being replayed later. That age was a plain subtraction on a `created_at` the sender picked, and a request stamped with the smallest number an `i64` holds made the difference too wide to fit, so it wrapped to a *negative* age. A negative age is not greater than two minutes, so the check waved it through.
+**Signing out.** There was no way out of an account: once a key was unlocked, Notary served it until the process died. Signing out locks the signer and asks for your passphrase again.
 
-  The arithmetic saturates now: a timestamp that far away reads as stale, which is what the check meant all along. This is a guard rather than the lock, since a request still has to be sealed to your bunker and authorized before anything is signed, but a replay window you can open by choosing a number is not one worth leaving open in the thing that holds your key.
+Using a different key is a separate button, because it is a different thing: it removes the key from this Mac, and that is the only copy here. It asks you to type a phrase to confirm, and the button does nothing until you do. Have your nsec written down before you use it.
 
-Full history in the [CHANGELOG](https://github.com/zig-nostr/notary/blob/main/CHANGELOG.md). **Your key never leaves the daemon.**
+**Under it:** the release you are reading was built by CI and its tests ran before it was published. That was not true of previous releases, which went from build straight to publish with nothing checking them.
 
 ### Install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-15
+
+### Added
+- **`nostrconnect://`.** Notary could only be connected one way round: copy its
+  `bunker://` URL and paste it into a client. The other direction is what most
+  clients actually offer, a link they show and wait on. Paste one in and Notary
+  adopts that client.
+
+  The reply carries the link's own secret as its result, in place of `"ack"`,
+  which is how the client knows the signer that answered is the one it invited.
+  Answering `"ack"` is ignored by every client and the connection never
+  completes, with nothing to see on either side.
+
+  The answer goes to the relays the client named, which are not necessarily
+  ours, so this is the one place the daemon dials an address it did not choose:
+  `wss://` only, no control characters, and at most four relays tried.
+
+- **Signing out, and using another key.** Two things, deliberately separate.
+  Signing out locks the signer and is a restart, which is the honest
+  implementation: the relay threads were handed the key by value when serving
+  began, so nothing short of ending the process takes it back. Using another key
+  removes the key file, sits behind a typed phrase matched exactly, and ends the
+  process, because the relay threads still hold the key that was just deleted.
+
+  Sessions do not outlive the key they were granted against, and anything
+  waiting for a decision is rejected rather than dropped: a relay thread is
+  parked on each of those and freeing the slot would strand it.
+
+### Changed
+- **Three relays by default, not one.** The GUI served on `wss://relay.damus.io`
+  and nothing else. A signer on a single relay stops signing when that relay
+  does, and from the client's side the failure is silent: the request is
+  published, nothing answers, and the app sits there. The three are Amber's
+  verbatim, three separate operators. Deliberately not `relay.nsec.app`, which
+  is the obvious pick and belongs to a project that looks unmaintained.
+
+- Serving several relays was already possible and was not correct. One intent
+  arrives as the same event id on every relay thread, and two things were held
+  per thread that had to be shared: the record of answered requests, so each
+  relay answered its own copy (two approval prompts, two signatures for one
+  intent), and the set of connected clients, so a client that connected over one
+  relay and asked over another was told "not connected". Both are now created
+  once and shared. Takes nostr v0.11.0, which is what changed those signatures.
+
+### Fixed
+- The release workflow went from build straight to package to publish, running
+  **no tests at all**, on the one artifact nobody gets to re-check. Both suites
+  gate it now, the publish step is idempotent so a re-run is not a red X on work
+  that succeeded, and the tag has to agree with `gui/app.zon` so a release
+  cannot tell people they are running the previous version.
+
 ## [0.4.0] - 2026-08-12
 
 ### Fixed

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.4.0",
+    .version = "0.5.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command", "clipboard" },


### PR DESCRIPTION
Version bump, changelog and release notes for v0.5.0: nostrconnect support (#55), three relays instead of one with the shared state that makes multi-relay correct (#54), signing out and switching keys (#56), and a release workflow that actually runs the tests before publishing (#53). On nostr v0.11.0.