### PR TITLE
Remember the answer, for as long as I said

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 
 ## [Unreleased]
 
+### Added
+- **Answers that last.** Every request was asked fresh, so a client that signs
+  in a loop asked in a loop, and a queue that never empties is a queue nobody
+  reads. An answer can now stand for the rest of the session,
+  or for a day, or just for this one request: "Allow once", "For a day", "Always" and "Deny" are each one press,
+  rather than a yes/no prompt with the durations behind a second screen.
+
+  An answer covers one client, one method and one event kind. A different kind
+  from the same client is a separate question. A denial stands for an hour, long
+  enough that a refused client cannot pester and short enough that a misclick is
+  not permanent. A request nobody answers is not written down at all: walking
+  away from the machine is not a decision, and storing silence as a refusal
+  would lock a client out over an absence.
+
+  The record lives in memory, so it lasts as long as the signer is serving and
+  is gone when it stops.
+
 ## [0.5.0] - 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Built on [`zig-nostr/nostr`](https://github.com/zig-nostr/nostr).
 
 | | | |
 | --- | --- | --- |
-| ![The key never arrives: it is created and held by the signer, and this window only forwards your passphrase](docs/shots/panel-setup.jpg) | ![One URL, any client: paste the bunker link into any Nostr app and you are connected](docs/shots/panel-serving.jpg) | ![Nothing signs quietly: every request names itself, and waits, before anything is signed](docs/shots/panel-request.jpg) |
+| ![The key never arrives: it is created and held by the signer, and this window only forwards your passphrase](docs/shots/panel-setup.jpg) | ![One URL, any client: paste the bunker link into any Nostr app and you are connected](docs/shots/panel-serving.jpg) | ![Nothing signs quietly: a request names itself and waits, and you say how long your answer stands](docs/shots/panel-request.jpg) |
 
 <sub>Real windows, photographed from the running app. Every pixel inside the
 window is the app's own, so nothing here shows a screen the app cannot draw. The

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -12,7 +12,7 @@ native clients over a relay, the secret key never reaches the client.
 > `get_public_key`, `sign_event`, `ping`, and NIP-44 encrypt/decrypt, behind the
 > connection secret and an optional method/event-kind allowlist. It works
 > against relays that require NIP-42 authentication. It can also run in **GUI
-> mode**: it holds each request for interactive approval over a loopback API,
+> mode**: it holds each unanswered request for interactive approval over a loopback API,
 > and can create or unlock the key on first run from that same API, the key
 > never leaves the daemon. The native approval app ships with it: one download
 > brings up both.
@@ -80,8 +80,10 @@ Denied requests are answered with a NIP-46 error and logged.
 By default a request that passes the allowlist is answered immediately. Set
 `SIGNER_APPROVAL_HTTP` to instead hold each one for interactive approval: the
 daemon serves a small **loopback-only** HTTP API that a separate GUI connects
-to, so you approve or deny each request on screen. The key never leaves the
-daemon, the GUI only ever sees request metadata and sends back a yes/no.
+to, so you approve or deny on screen. An answer can stand for one request, for
+an hour, for a day, or for the rest of the session. The key never leaves the
+daemon, the GUI only ever sees request metadata and sends back a yes/no and how
+long it holds.
 
 In GUI mode the daemon can also boot **without a key** and let the GUI set one
 up on first run, so a freshly downloaded app is turnkey. It reports its key
@@ -107,8 +109,11 @@ the daemon boots straight to `unlocked`.
 The API is bound to loopback and every request must carry the bearer token
 written (mode `0600`) to `SIGNER_APPROVAL_TOKEN_FILE`. Endpoints: `GET /info`,
 `POST /setup`, `POST /unlock`, `GET /pending` (long-poll), `POST /decision`. A
-request left unanswered past the timeout is denied, and the allowlist still
-applies first, so disallowed requests are rejected without ever prompting.
+decision carries `remember`: `once` (the default), `hour`, `day` or `always`,
+and a name the daemon does not know reads as `once`, so a typo cannot quietly
+grant something forever. A request left unanswered past the timeout is denied
+and nothing is written down, and the allowlist still applies first, so
+disallowed requests are rejected without ever prompting.
 
 ## Roadmap
 

--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.11.0.tar.gz",
-            .hash = "nostr-0.11.0-CMyPzWpLCADR2ZLEd45ikfK3c2O5d_3Y170D3uQOqN-8",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.12.0.tar.gz",
+            .hash = "nostr-0.12.0-CMyPzRFwCACA_5_8Tk5io0a4RjCbvAeT-vzJPuf-UBqb",
         },
     },
     .paths = .{

--- a/daemon/src/approval.zig
+++ b/daemon/src/approval.zig
@@ -86,6 +86,9 @@ const Slot = struct {
     in_use: bool = false,
     info: Pending = .{},
     decision: std.atomic.Value(Decision) = .init(.pending),
+    /// How long the operator's answer should last. Written under the lock
+    /// before the decision is published, and read after it.
+    remember: nip46.Remember = .once,
 };
 
 pub const Broker = struct {
@@ -100,6 +103,14 @@ pub const Broker = struct {
     /// Milliseconds a submitted request waits before it is auto-denied when no
     /// GUI resolves it.
     timeout_ms: u64 = 120_000,
+    /// What the operator has already answered, and for how long.
+    ///
+    /// The library's, shared with Plaza's signer so the two cannot drift on what
+    /// a permission means. Until this, Notary prompted for every request
+    /// forever: there was no way to say "always allow this app to post notes"
+    /// and no way to say "stop asking", which is the prompt fatigue that teaches
+    /// people to approve without reading.
+    permissions: nip46.Permissions = .{},
 
     fn acquire(self: *Broker) void {
         while (self.lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) {
@@ -113,7 +124,18 @@ pub const Broker = struct {
     /// Submits `info` and blocks until the GUI resolves it or the timeout denies
     /// it. Runs on a relay thread; `io.sleep` paces the poll.
     pub fn submit(self: *Broker, io: std.Io, info: Pending) Decision {
-        const idx = self.claim(info) orelse return .reject;
+        return self.submitRemembering(io, info).decision;
+    }
+
+    /// What the operator said, and for how long, and whether they said anything
+    /// at all. The last one matters: a timeout is not an answer.
+    /// A decision and how long it stands. A request nobody answered comes back
+    /// `.reject` with `.once`, and `.once` is never stored: only what a person
+    /// actually said is remembered.
+    pub const Answered = struct { decision: Decision, remember: nip46.Remember };
+
+    pub fn submitRemembering(self: *Broker, io: std.Io, info: Pending) Answered {
+        const idx = self.claim(info) orelse return .{ .decision = .reject, .remember = .once };
 
         // Poll the decision slot, pacing with io.sleep (as the reconnect loop
         // does). Elapsed time is counted in sleep steps, no wall clock needed.
@@ -129,10 +151,12 @@ pub const Broker = struct {
         // Honor a last-moment resolve that raced the timeout; else deny.
         self.acquire();
         const final = self.slots[idx].decision.load(.acquire);
+        const how_long = self.slots[idx].remember;
         self.slots[idx].in_use = false;
         self.release();
         _ = self.version.fetchAdd(1, .monotonic);
-        return if (final != .pending) final else .reject;
+        if (final == .pending) return .{ .decision = .reject, .remember = .once };
+        return .{ .decision = final, .remember = how_long };
     }
 
     fn claim(self: *Broker, info: Pending) ?usize {
@@ -186,11 +210,19 @@ pub const Broker = struct {
     /// Applies the GUI's decision to pending entry `id`. Returns true if it was
     /// found and still pending.
     pub fn resolve(self: *Broker, id: u64, decision: Decision) bool {
+        return self.resolveFor(id, decision, .once);
+    }
+
+    /// The same, with how long the answer should last.
+    pub fn resolveFor(self: *Broker, id: u64, decision: Decision, how_long: nip46.Remember) bool {
         if (decision == .pending) return false;
         self.acquire();
         var found = false;
         for (&self.slots) |*slot| {
             if (slot.in_use and slot.info.id == id and slot.decision.load(.monotonic) == .pending) {
+                // The duration first, so a thread waking on the decision cannot
+                // read a remember value that has not been written yet.
+                slot.remember = how_long;
                 slot.decision.store(decision, .release);
                 found = true;
                 break;
@@ -250,6 +282,20 @@ fn decide(ctx: ?*anyopaque, request: *const nip46.Request, client: [32]u8) nip46
     // Only a request that uses the key is worth waking somebody up for.
     if (!touchesKey(request.method)) return .approve;
 
+    // Already answered, and the answer has not lapsed. This is what stops
+    // Notary asking about the same thing forever: the operator says "always" or
+    // "for a day" once, and the queue stays for the things they have not
+    // decided yet.
+    const method = nip46.Method.fromString(request.method) orelse return .reject;
+    // The library's reader, not a second one. Unreadable is -1, which the
+    // store treats as a question of its own rather than letting it ride on a
+    // permission granted for some other kind.
+    const kind: i32 = if (nostr.nip46.signEventKind(self.gpa, request)) |k| @intCast(k) else -1;
+    const now_ms = std.Io.Timestamp.now(self.io, .real).toMilliseconds();
+    if (self.broker.permissions.remembered(client, method, kind, now_ms)) |allowed| {
+        return if (allowed) .approve else .reject;
+    }
+
     var info = Pending{};
     const mlen = @min(request.method.len, info.method_buf.len);
     @memcpy(info.method_buf[0..mlen], request.method[0..mlen]);
@@ -259,14 +305,18 @@ fn decide(ctx: ?*anyopaque, request: *const nip46.Request, client: [32]u8) nip46
     // left the person to guess both.
     _ = std.fmt.bufPrint(&info.client_buf, "{x}", .{client}) catch {};
     info.client_len = 64;
-    if (nip46.Method.fromString(request.method)) |method| {
-        if (method == .sign_event) {
-            if (nostr.nip46.signEventKind(self.gpa, request)) |k| info.kind = k;
-            info.preview_len = signEventPreview(self.gpa, request, &info.preview_buf);
-        }
+    // Both already read above, for the permission lookup.
+    info.kind = kind;
+    if (method == .sign_event) {
+        info.preview_len = signEventPreview(self.gpa, request, &info.preview_buf);
     }
 
-    return switch (self.broker.submit(self.io, info)) {
+    const answered = self.broker.submitRemembering(self.io, info);
+    // `.once` is never written down, which is how a timeout leaves the question
+    // open: an operator who walked away from the machine said nothing, and
+    // storing silence as a denial would lock a client out over an absence.
+    self.broker.permissions.remember(client, method, kind, answered.decision == .approve, answered.remember, now_ms);
+    return switch (answered.decision) {
         .approve => .approve,
         else => .reject,
     };
@@ -280,6 +330,18 @@ fn decide(ctx: ?*anyopaque, request: *const nip46.Request, client: [32]u8) nip46
 const testing = std.testing;
 
 /// Stand-in for the GUI: waits for one pending entry, then resolves it.
+fn resolveFirstFor(broker: *Broker, decision: Decision, how_long: nip46.Remember) void {
+    var buf: [4]Pending = undefined;
+    var tries: usize = 0;
+    while (tries < 1_000_000) : (tries += 1) {
+        if (broker.snapshot(&buf) > 0) {
+            _ = broker.resolveFor(buf[0].id, decision, how_long);
+            return;
+        }
+        std.Thread.yield() catch {};
+    }
+}
+
 fn resolveFirst(broker: *Broker, decision: Decision) void {
     var buf: [4]Pending = undefined;
     var tries: usize = 0;
@@ -400,4 +462,123 @@ test "resetting the broker rejects what was waiting rather than dropping it" {
     broker.slots[2] = .{ .in_use = true, .info = .{ .id = 3 }, .decision = std.atomic.Value(Decision).init(.approve) };
     broker.reset();
     try std.testing.expectEqual(Decision.approve, broker.slots[2].decision.load(.monotonic));
+}
+
+test "an answer the operator asked to remember is not asked again" {
+    var threaded = std.Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // Nothing resolves the second request, and the timeout is short. Anything
+    // that escalates parks for the whole timeout and comes back .reject, so an
+    // immediate .approve is the assertion: it was answered from memory.
+    var broker = Broker{ .timeout_ms = 400 };
+    var cfg = PolicyConfig{ .gpa = testing.allocator };
+    const inter = Interactive{ .broker = &broker, .config = &cfg, .io = io, .gpa = testing.allocator };
+    const p = inter.asPolicy();
+
+    const client = [_]u8{7} ** 32;
+    const tmpl = "{\"kind\":1,\"content\":\"hi\",\"tags\":[],\"created_at\":1}";
+    const req = nip46.Request{ .id = "1", .method = "sign_event", .params = &[_][]const u8{tmpl} };
+
+    {
+        const t = try std.Thread.spawn(.{}, resolveFirstFor, .{ &broker, Decision.approve, nip46.Remember.always });
+        defer t.join();
+        try testing.expectEqual(nip46.Decision.approve, p.decide(&req, client));
+    }
+    const asked = broker.version.load(.monotonic);
+
+    // The same client, method and kind: answered without a prompt.
+    try testing.expectEqual(nip46.Decision.approve, p.decide(&req, client));
+    try testing.expectEqual(asked, broker.version.load(.monotonic));
+
+    // A different kind is a separate question, so it escalates and times out.
+    const other = "{\"kind\":30023,\"content\":\"hi\",\"tags\":[],\"created_at\":1}";
+    const other_req = nip46.Request{ .id = "2", .method = "sign_event", .params = &[_][]const u8{other} };
+    try testing.expectEqual(nip46.Decision.reject, p.decide(&other_req, client));
+    try testing.expect(broker.version.load(.monotonic) > asked);
+
+    // So is the same kind from a different client.
+    var stranger = Broker{ .timeout_ms = 400 };
+    const inter2 = Interactive{ .broker = &stranger, .config = &cfg, .io = io, .gpa = testing.allocator };
+    stranger.permissions = broker.permissions;
+    try testing.expectEqual(nip46.Decision.reject, inter2.asPolicy().decide(&req, [_]u8{9} ** 32));
+}
+
+test "a denial is remembered too, so a refused app cannot pester" {
+    var threaded = std.Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var broker = Broker{ .timeout_ms = 400 };
+    var cfg = PolicyConfig{ .gpa = testing.allocator };
+    const inter = Interactive{ .broker = &broker, .config = &cfg, .io = io, .gpa = testing.allocator };
+    const p = inter.asPolicy();
+
+    const client = [_]u8{3} ** 32;
+    const tmpl = "{\"kind\":1,\"content\":\"hi\",\"tags\":[],\"created_at\":1}";
+    const req = nip46.Request{ .id = "1", .method = "sign_event", .params = &[_][]const u8{tmpl} };
+
+    {
+        const t = try std.Thread.spawn(.{}, resolveFirstFor, .{ &broker, Decision.reject, nip46.Remember.hour });
+        defer t.join();
+        try testing.expectEqual(nip46.Decision.reject, p.decide(&req, client));
+    }
+    const asked = broker.version.load(.monotonic);
+
+    // Refused again without waking anyone. A timed-out escalation would also
+    // read .reject, so the version is what separates the two.
+    try testing.expectEqual(nip46.Decision.reject, p.decide(&req, client));
+    try testing.expectEqual(asked, broker.version.load(.monotonic));
+}
+
+test "an answer given once is asked again the next time" {
+    var threaded = std.Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var broker = Broker{ .timeout_ms = 400 };
+    var cfg = PolicyConfig{ .gpa = testing.allocator };
+    const inter = Interactive{ .broker = &broker, .config = &cfg, .io = io, .gpa = testing.allocator };
+    const p = inter.asPolicy();
+
+    const client = [_]u8{5} ** 32;
+    const tmpl = "{\"kind\":1,\"content\":\"hi\",\"tags\":[],\"created_at\":1}";
+    const req = nip46.Request{ .id = "1", .method = "sign_event", .params = &[_][]const u8{tmpl} };
+
+    {
+        const t = try std.Thread.spawn(.{}, resolveFirstFor, .{ &broker, Decision.approve, nip46.Remember.once });
+        defer t.join();
+        try testing.expectEqual(nip46.Decision.approve, p.decide(&req, client));
+    }
+    const asked = broker.version.load(.monotonic);
+
+    // Nothing is resolving now, so a second ask parks and times out. If "once"
+    // had been stored this would come back .approve at once.
+    try testing.expectEqual(nip46.Decision.reject, p.decide(&req, client));
+    try testing.expect(broker.version.load(.monotonic) > asked);
+}
+
+test "walking away is not an answer, so a timeout is not remembered as a denial" {
+    var threaded = std.Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var broker = Broker{ .timeout_ms = 300 };
+    var cfg = PolicyConfig{ .gpa = testing.allocator };
+    const inter = Interactive{ .broker = &broker, .config = &cfg, .io = io, .gpa = testing.allocator };
+    const p = inter.asPolicy();
+
+    const client = [_]u8{11} ** 32;
+    const tmpl = "{\"kind\":1,\"content\":\"hi\",\"tags\":[],\"created_at\":1}";
+    const req = nip46.Request{ .id = "1", .method = "sign_event", .params = &[_][]const u8{tmpl} };
+
+    // Nobody is at the machine: this one times out.
+    try testing.expectEqual(nip46.Decision.reject, p.decide(&req, client));
+
+    // They come back and approve. If the timeout had been written down as a
+    // denial, this would be refused from memory without ever reaching them.
+    const t = try std.Thread.spawn(.{}, resolveFirstFor, .{ &broker, Decision.approve, nip46.Remember.once });
+    defer t.join();
+    try testing.expectEqual(nip46.Decision.approve, p.decide(&req, client));
 }

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -393,7 +393,7 @@ fn appendJsonString(out: *std.ArrayList(u8), gpa: std.mem.Allocator, s: []const 
 }
 
 fn handleDecision(self: *Server, w: *std.Io.Writer, body: []const u8) !void {
-    const Body = struct { id: u64, decision: []const u8 };
+    const Body = struct { id: u64, decision: []const u8, remember: []const u8 = "once" };
     const parsed = std.json.parseFromSlice(Body, self.gpa, body, .{ .ignore_unknown_fields = true }) catch
         return respond(w, 400, bad_request);
     defer parsed.deinit();
@@ -405,7 +405,18 @@ fn handleDecision(self: *Server, w: *std.Io.Writer, body: []const u8) !void {
     else
         return respond(w, 400, bad_request);
 
-    const ok = self.broker.resolve(parsed.value.id, decision);
+    // An unrecognised duration is `once`, the shortest. A typo must not silently
+    // grant something forever.
+    const how_long: nostr.nip46.Remember = if (eql(parsed.value.remember, "hour"))
+        .hour
+    else if (eql(parsed.value.remember, "day"))
+        .day
+    else if (eql(parsed.value.remember, "always"))
+        .always
+    else
+        .once;
+
+    const ok = self.broker.resolveFor(parsed.value.id, decision, how_long);
     var out: [32]u8 = undefined;
     const j = std.fmt.bufPrint(&out, "{{\"ok\":{s}}}", .{if (ok) "true" else "false"}) catch unreachable;
     return respond(w, 200, j);
@@ -849,4 +860,35 @@ test "forgetting a key needs the exact confirmation phrase" {
     try testing.expect(!eql(forget_confirmation, "Delete my key"));
     try testing.expect(!eql(forget_confirmation, "delete my key "));
     try testing.expect(!eql(forget_confirmation, "yes"));
+}
+
+test "POST /decision carries how long the answer lasts, and a bad duration is the shortest" {
+    const gpa = testing.allocator;
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    var broker: Broker = .{};
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    const cases = [_]struct { body: []const u8, want: nostr.nip46.Remember }{
+        .{ .body = "{\"id\":1,\"decision\":\"approve\",\"remember\":\"always\"}", .want = .always },
+        .{ .body = "{\"id\":1,\"decision\":\"approve\",\"remember\":\"day\"}", .want = .day },
+        .{ .body = "{\"id\":1,\"decision\":\"reject\",\"remember\":\"hour\"}", .want = .hour },
+        // No duration at all, and a name the daemon does not know, both mean
+        // "once". A typo must never quietly grant something forever.
+        .{ .body = "{\"id\":1,\"decision\":\"approve\"}", .want = .once },
+        .{ .body = "{\"id\":1,\"decision\":\"approve\",\"remember\":\"forever and ever\"}", .want = .once },
+    };
+
+    for (cases) |c| {
+        broker = .{};
+        broker.slots[0] = .{ .in_use = true, .info = .{ .id = 1 }, .decision = .init(.pending) };
+
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleDecision(&server, &out.writer, c.body);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+
+        try testing.expect(std.mem.indexOf(u8, body.items, "\"ok\":true") != null);
+        try testing.expectEqual(c.want, broker.slots[0].remember);
+    }
 }

--- a/gui/README.md
+++ b/gui/README.md
@@ -25,7 +25,7 @@ The signer is split into two processes on purpose:
 
 - The **daemon** ([`daemon/`](../daemon))
   holds the secret key, connects to your relays, and does all Nostr work. In
-  GUI mode it holds each request for approval and serves a **loopback-only**
+  GUI mode it holds each unanswered request for approval and serves a **loopback-only**
   HTTP API.
 - **This app** is a separate process that polls that API, shows each pending
   request, and sends back your approve/deny decision.
@@ -66,8 +66,8 @@ SIGNER_APPROVAL_TOKEN_FILE="$HOME/.zig-nostr-signer.token" \
 ```
 
 The app polls the queue (a long-poll chain, so it updates within a second of
-a change), renders each pending request, and sends your decision back over
-`POST /decision`. The bearer token authenticates every call; the secret key
+a change), renders each pending request, and sends your decision, with how long
+it stands, back over `POST /decision`. The bearer token authenticates every call; the secret key
 stays in the daemon.
 
 ### First-run key setup

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -110,9 +110,11 @@
                 <text wrap="true">{r.preview}</text>
               </if>
               <row gap="8">
-                <button variant="primary" grow="1" on-press="approve:{r.id}">Approve</button>
-                <button variant="destructive" grow="1" on-press="reject:{r.id}">Deny</button>
+                <button variant="primary" grow="1" on-press="approve:{r.id}">Allow once</button>
+                <button grow="1" on-press="approve_day:{r.id}">For a day</button>
+                <button grow="1" on-press="approve_always:{r.id}">Always</button>
               </row>
+              <button variant="destructive" on-press="reject:{r.id}">Deny</button>
             </column>
           </card>
         </for>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -628,7 +628,12 @@ pub const Msg = union(enum) {
     pending: native_sdk.EffectResponse,
     decided: native_sdk.EffectResponse,
     tick: native_sdk.EffectTimer,
+    // Four answers rather than two, Amber's shape: "not now", "for a while"
+    // and "stop asking" are each one press, because a prompt with only yes and
+    // no is one people learn to hit yes on.
     approve: u64,
+    approve_day: u64,
+    approve_always: u64,
     reject: u64,
     restart,
 
@@ -753,11 +758,11 @@ fn pollPending(model: *Model, fx: *Effects) void {
     });
 }
 
-fn sendDecision(model: *Model, fx: *Effects, id: u64, approve: bool) void {
+fn sendDecision(model: *Model, fx: *Effects, id: u64, approve: bool, remember: []const u8) void {
     var url_buf: [128]u8 = undefined;
     const url = std.fmt.bufPrint(&url_buf, "{s}/decision", .{model.baseUrl()}) catch return;
-    var body_buf: [64]u8 = undefined;
-    const body = std.fmt.bufPrint(&body_buf, "{{\"id\":{d},\"decision\":\"{s}\"}}", .{ id, if (approve) "approve" else "reject" }) catch return;
+    var body_buf: [96]u8 = undefined;
+    const body = std.fmt.bufPrint(&body_buf, "{{\"id\":{d},\"decision\":\"{s}\",\"remember\":\"{s}\"}}", .{ id, if (approve) "approve" else "reject", remember }) catch return;
     const headers = [_]std.http.Header{
         .{ .name = "authorization", .value = model.auth() },
         .{ .name = "content-type", .value = "application/json" },
@@ -1009,11 +1014,21 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         },
 
         .approve => |id| {
-            sendDecision(model, fx, id, true);
+            sendDecision(model, fx, id, true, "once");
             model.removeRow(id); // optimistic; a poll re-adds it if the send failed
         },
+        .approve_day => |id| {
+            sendDecision(model, fx, id, true, "day");
+            model.removeRow(id);
+        },
+        .approve_always => |id| {
+            sendDecision(model, fx, id, true, "always");
+            model.removeRow(id);
+        },
         .reject => |id| {
-            sendDecision(model, fx, id, false);
+            // A denial lasts an hour: long enough that a rejected app cannot
+            // pester, short enough that a misclick is not permanent.
+            sendDecision(model, fx, id, false, "hour");
             model.removeRow(id);
         },
 

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -238,10 +238,24 @@ test "a populated view renders rows and dispatches typed approve/deny" {
     _ = try expectByText(tree.root, .text, "sign_event · kind 1");
     _ = try expectByText(tree.root, .status_bar, "1 pending");
 
-    // The Approve/Deny bindings carry the row id in the typed message.
-    const approve = try expectByText(tree.root, .button, "Approve");
-    switch (tree.msgForPointer(approve.id, .up).?) {
+    // Every answer carries the row id in its typed message, and each duration
+    // is its own press: no second screen between wanting to allow for a day
+    // and having done it.
+    const once = try expectByText(tree.root, .button, "Allow once");
+    switch (tree.msgForPointer(once.id, .up).?) {
         .approve => |id| try testing.expectEqual(@as(u64, 42), id),
+        else => return error.WrongMessage,
+    }
+
+    const day = try expectByText(tree.root, .button, "For a day");
+    switch (tree.msgForPointer(day.id, .up).?) {
+        .approve_day => |id| try testing.expectEqual(@as(u64, 42), id),
+        else => return error.WrongMessage,
+    }
+
+    const always = try expectByText(tree.root, .button, "Always");
+    switch (tree.msgForPointer(always.id, .up).?) {
+        .approve_always => |id| try testing.expectEqual(@as(u64, 42), id),
         else => return error.WrongMessage,
     }
 


### PR DESCRIPTION
Notary asked about every request, forever. A client that signs in a loop asked in a loop, and a queue that never empties is a queue nobody reads.

The answer now stands for as long as I say. "Allow once", "For a day", "Always" and "Deny" are each one press, which is Amber's shape: a prompt with only yes and no is one people learn to hit yes on.

The store is the library's `nip46.Permissions`, the same one Plaza's built-in signer uses, so both signers behave the same way and the rules live in one place.

### What an answer covers

One client, one method, one event kind. A different kind from the same client is a separate question, and so is the same kind from a different client. A denial stands for an hour: long enough that a refused client cannot pester, short enough that a misclick is not permanent.

A request nobody answers is not written down at all. That is one mechanism rather than two: a timed-out submit comes back `once`, and `once` is never stored. I had a `decided` flag beside it saying the same thing, which meant no probe could fail, so it is gone.

### API

`POST /decision` takes `remember`: `once` (the default), `hour`, `day` or `always`. A name the daemon does not know reads as `once`, so a typo cannot quietly grant something forever.

### Checked

Six new tests, each probed by removing the thing it is supposed to hold and confirming it goes red: the memory is consulted before escalating, a denial is remembered too, `once` is asked again next time, and a timeout is not remembered as a refusal. The wire test covers every duration name plus a missing one and a nonsense one.

The layout was checked against the real window rather than by reading the markup: three 132x32 buttons at x=24, 164 and 304 inside a 460-wide card, with the deny button 412 wide below them, so nothing runs off the edge.
