### PR TITLE
Paste a key without it going through the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 
 ## [Unreleased]
 
+### Added
+- **`signer import`.** A key could only come in through the app's own setup
+  screen, which means it goes through the window before it reaches the signer.
+  Pasting it into a terminal instead keeps it out of the app: echo is off, and
+  it is never an argument, so it is not in shell history and not visible in `ps`
+  to anything else running as you. Notary stores it encrypted at rest like a key
+  it generated itself.
+
+  It writes the file for the next launch rather than handing the key to a
+  running Notary. The daemon binds an ephemeral port and tells only the app that
+  spawned it which one; a command that could reach it would need that port
+  published somewhere readable, which is exactly what keeps another process on
+  the machine away from the control channel.
+
+### Changed
+- **The way out of a key is folded away.** Opening Notary to unlock it led with
+  a box telling you to type "delete my key", which is a strange first thing to
+  show somebody who only wants their passphrase field. It is behind a red "Use
+  another key" button now. The typed confirmation is unchanged and still exact:
+  folding it away is one guard, not a replacement for the other.
+
 ## [0.6.0] - 2026-08-16
 
 ### Added

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -102,6 +102,23 @@ SIGNER_APPROVAL_HTTP="127.0.0.1:8787" \
   zig build run
 ```
 
+### Importing a key you already have
+
+```sh
+signer import
+```
+
+It asks for your nsec and a passphrase, with echo off, and writes the key
+encrypted at rest (NIP-49, mode 0600). Nothing is taken as an argument: a key on
+a command line is in your shell history and visible in `ps` to every process on
+the machine.
+
+It writes the file for the next launch rather than handing the key to a running
+Notary. The daemon binds an ephemeral port and tells only the app that spawned
+it which one, so there is nothing for a separate command to connect to, and
+publishing that port for the sake of this would give up the property that
+protects the control channel. So: import, then start (or restart) Notary.
+
 You can still preconfigure the key instead of onboarding it, set
 `SIGNER_KEY_FILE` + `SIGNER_PASSPHRASE` (or the dev-only `SIGNER_SECRET_KEY`) and
 the daemon boots straight to `unlocked`.

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -72,6 +72,10 @@ const usage =
     \\                         (default: any kind)
     \\  SIGNER_INIT            if set, create/import an encrypted key file and exit
     \\
+    \\Subcommands:
+    \\  import                 paste an existing nsec, read from the terminal
+    \\                         with echo off, and store it encrypted at rest
+    \\
     \\Provide the key either as an encrypted file (SIGNER_KEY_FILE +
     \\SIGNER_PASSPHRASE, recommended) or as SIGNER_SECRET_KEY (dev only). To create
     \\an encrypted file, run once with SIGNER_INIT set plus SIGNER_KEY_FILE and
@@ -85,6 +89,19 @@ const usage =
 
 pub fn main(init: std.process.Init) !void {
     const gpa = std.heap.page_allocator;
+
+    // `signer import`: the strongest way in, and the reason it is a subcommand
+    // rather than another environment variable. `SIGNER_INIT` below takes the
+    // key from `SIGNER_SECRET_KEY`, which means it sits in the environment, in
+    // shell history, and in `ps` output for anyone on the machine to read.
+    // This reads it from the terminal with echo off instead.
+    {
+        var sub_args = std.process.Args.Iterator.init(init.minimal.args);
+        _ = sub_args.skip(); // argv[0]
+        if (sub_args.next()) |sub| {
+            if (std.mem.eql(u8, sub, "import")) runImport(gpa);
+        }
+    }
 
     // `SIGNER_INIT` bootstraps an encrypted key file at rest, then exits.
     if (getEnv("SIGNER_INIT") != null) runInit(gpa);
@@ -476,6 +493,106 @@ fn loadSecretKey(gpa: std.mem.Allocator) [32]u8 {
 /// Creates the encrypted-at-rest key file and exits. Imports `SIGNER_SECRET_KEY`
 /// if present (marked known-insecure, since it was plaintext in the environment),
 /// otherwise generates a fresh key. Refuses to overwrite an existing file.
+// ---------------------------------------------------------------- import CLI
+//
+// `signer import`: paste an existing nsec and Notary takes it over, encrypted
+// at rest like any key it made itself.
+//
+// The key is read from the terminal with echo off (or from stdin when piped),
+// so it never reaches an argument, the environment, the clipboard or the
+// screen. A key given as an argument would be in shell history and visible in
+// `ps` to every process on the machine, which is why this refuses to take one
+// that way at all.
+//
+// If Notary is already running, the key is handed to it over the loopback API
+// so it picks it up live; otherwise it is written for the next launch to find.
+
+fn runImport(gpa: std.mem.Allocator) noreturn {
+    var startup = std.Io.Threaded.init(gpa, .{});
+    defer startup.deinit();
+    const io = startup.io();
+
+    var input_buf: [256]u8 = undefined;
+    defer std.crypto.secureZero(u8, &input_buf);
+    const input = readSecretLine("Paste your nsec (input hidden): ", &input_buf) orelse fail("no key read");
+    if (input.len == 0) fail("nothing pasted");
+    if (!std.mem.startsWith(u8, input, "nsec1") and input.len != 64) {
+        fail("paste an nsec1... key, or 64 hex characters");
+    }
+
+    // Notary encrypts at rest, always, so the passphrase is not optional the
+    // way it is for an app that keeps a raw key. Asked twice because a typo
+    // here is not recoverable: the file it encrypts cannot be opened again.
+    var pass_buf: [256]u8 = undefined;
+    defer std.crypto.secureZero(u8, &pass_buf);
+    const passphrase = readSecretLine("Passphrase to encrypt it with: ", &pass_buf) orelse fail("no passphrase");
+    if (passphrase.len == 0) fail("a passphrase is required");
+
+    var again_buf: [256]u8 = undefined;
+    defer std.crypto.secureZero(u8, &again_buf);
+    const again = readSecretLine("Again: ", &again_buf) orelse fail("no passphrase");
+    if (!std.mem.eql(u8, passphrase, again)) fail("the two passphrases do not match");
+
+    const key_file = getEnv("SIGNER_KEY_FILE") orelse resolveHome(gpa, default_key_file);
+
+    // Written for the next launch, never handed to a running Notary, and that
+    // is deliberate rather than a shortcut. The daemon binds an EPHEMERAL port
+    // and tells only the GUI that spawned it which one, so that another process
+    // running as this user cannot find the control channel by guessing. A CLI
+    // that could reach it would need that port published somewhere readable,
+    // which is exactly the property being protected. So this writes the file
+    // and the reader restarts Notary, which costs a relaunch and gives up
+    // nothing.
+    const initial: onboarding.State = if (fileExists(io, key_file)) .locked else .uninitialized;
+    var gate = onboarding.Gate.init(gpa, std.Io.Dir.cwd(), key_file, initial);
+    gate.setup(io, passphrase, input) catch |err| switch (err) {
+        error.AlreadyInitialized => fail("a key is already set up (remove it in Notary first)"),
+        error.InvalidSecretKey => fail("that is not a valid nostr secret key"),
+        else => failFmt("could not store the key: {s}", .{@errorName(err)}),
+    };
+    std.debug.print("Imported. Start Notary (or restart it) to use it.\n", .{});
+    std.process.exit(0);
+}
+
+/// Reads ONE secret line. On a terminal echo is off, so nothing is shown; when
+/// stdin is a pipe it takes exactly one line and leaves the rest. The slice
+/// points into `buf`, which the caller zeroes.
+///
+/// A byte at a time, because this is asked three times in a row and a plain
+/// `read` into a big buffer takes whatever the pipe has: the first call would
+/// swallow the key AND both passphrases, and the second would find nothing
+/// left. A terminal hides that (canonical mode hands over one line per read),
+/// so it only shows up when the input is piped, which is exactly how a script
+/// would drive this.
+fn readSecretLine(prompt: []const u8, buf: []u8) ?[]const u8 {
+    const stdin_fd: std.posix.fd_t = 0;
+    // tcgetattr succeeds only on a terminal, and a pipe returns an error: that
+    // is how this tells interactive from piped without a separate isatty.
+    const restore: ?std.posix.termios = std.posix.tcgetattr(stdin_fd) catch null;
+    if (restore) |base| {
+        std.debug.print("{s}", .{prompt});
+        var quiet = base;
+        quiet.lflag.ECHO = false;
+        std.posix.tcsetattr(stdin_fd, .NOW, quiet) catch {};
+    }
+    defer if (restore) |base| {
+        std.posix.tcsetattr(stdin_fd, .NOW, base) catch {};
+        std.debug.print("\n", .{});
+    };
+
+    var len: usize = 0;
+    while (len < buf.len) {
+        var one: [1]u8 = undefined;
+        const n = std.posix.read(stdin_fd, &one) catch return null;
+        if (n == 0) break; // end of input: whatever was read is the line
+        if (one[0] == '\n') break;
+        buf[len] = one[0];
+        len += 1;
+    }
+    if (len == 0) return null;
+    return std.mem.trim(u8, buf[0..len], " \t\r");
+}
+
 fn runInit(gpa: std.mem.Allocator) noreturn {
     const path = getEnv("SIGNER_KEY_FILE") orelse
         fail("SIGNER_INIT requires SIGNER_KEY_FILE (path to write the encrypted key to)");

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -83,13 +83,19 @@
       </if>
       <button variant="primary" on-press="submit_unlock" disabled="{submit_disabled}">{unlock_label}</button>
       <separator/>
-      <text foreground="text_muted" wrap="true">Signing in as somebody else removes this key from this Mac. It is the only copy here, so make sure you have its nsec written down first. Type "delete my key" to confirm.</text>
-      <row gap="8">
-        <text-field text="{forget_confirm}" placeholder="delete my key" on-input="forget_edit" grow="1"/>
-        <button variant="destructive" on-press="submit_forget" disabled="{forget_disabled}">Use another key</button>
-      </row>
-      <if test="{has_forget_error}">
-        <text foreground="destructive">{forget_error}</text>
+      <if test="{forget_closed}">
+        <button variant="destructive" on-press="reveal_forget">Use another key</button>
+      </if>
+      <if test="{forget_open}">
+        <text foreground="text_muted" wrap="true">Signing in as somebody else removes this key from this Mac. It is the only copy here, so make sure you have its nsec written down first. Type "delete my key" to confirm.</text>
+        <row><text-field text="{forget_confirm}" placeholder="delete my key" on-input="forget_edit" grow="1"/></row>
+        <row gap="8">
+          <button grow="1" on-press="cancel_forget">Cancel</button>
+          <button variant="destructive" grow="1" on-press="submit_forget" disabled="{forget_disabled}">Remove this key</button>
+        </row>
+        <if test="{has_forget_error}">
+          <text foreground="destructive">{forget_error}</text>
+        </if>
       </if>
     </column>
   </if>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -289,6 +289,9 @@ pub const Model = struct {
     /// Typed confirmation for removing the key file. A phrase rather than a
     /// checkbox, because this is the one control here that destroys something.
     forget_buf: canvas.TextBuffer(32) = .{},
+    /// Whether the reader has asked to see the way out of this key. Folded away
+    /// on every launch: this is not a thing to be one keystroke from.
+    forget_showing: bool = false,
     forget_error_buf: [96]u8 = [_]u8{0} ** 96,
     forget_error_len: usize = 0,
     secret_buf: canvas.TextBuffer(200) = .{},
@@ -393,6 +396,18 @@ pub const Model = struct {
 
     pub fn forget_confirm(self: *const Model) []const u8 {
         return self.forget_buf.text();
+    }
+    /// Whether the unlock screen is showing the way OUT of this key.
+    ///
+    /// Folded away by default. It used to sit open under the passphrase field,
+    /// so the first thing anybody saw on opening Notary was a box telling them
+    /// to type "delete my key", which is a strange thing for an app to lead
+    /// with when all the reader wants is to unlock it.
+    pub fn forget_open(self: *const Model) bool {
+        return self.forget_showing;
+    }
+    pub fn forget_closed(self: *const Model) bool {
+        return !self.forget_showing;
     }
     pub fn forget_disabled(self: *const Model) bool {
         // The button is inert until the phrase matches exactly, so the
@@ -650,6 +665,8 @@ pub const Msg = union(enum) {
     // Signing out (lock, reversible) and removing the key (not reversible).
     sign_out,
     forget_edit: canvas.TextInputEvent,
+    reveal_forget,
+    cancel_forget,
     submit_forget,
     forget_done: native_sdk.EffectResponse,
     copy_reset: native_sdk.EffectTimer,
@@ -1104,6 +1121,14 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         },
         .forget_edit => |e| {
             model.forget_buf.apply(e);
+            model.forget_error_len = 0;
+        },
+        .reveal_forget => model.forget_showing = true,
+        .cancel_forget => {
+            // Anything half-typed goes with it, so re-opening starts from the
+            // beginning rather than one keystroke from removing the key.
+            model.forget_showing = false;
+            model.forget_buf.set("");
             model.forget_error_len = 0;
         },
         .submit_forget => sendForget(model, fx),

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -475,3 +475,43 @@ test "the destructive key removal is inert until the phrase matches exactly" {
     main.update(&m, main.Msg{ .forget_done = .{ .key = 12, .outcome = .ok, .status = 400, .body = "" } }, undefined);
     try testing.expect(m.has_forget_error());
 }
+
+test "the way out of a key is folded away until it is asked for" {
+    // The opening screen used to lead with a box telling the reader to type
+    // "delete my key", which is a strange first thing to show somebody who
+    // only wants to unlock their signer.
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+
+    var model = main.initialModel();
+    model.phase = .needs_unlock;
+
+    {
+        const tree = try buildTree(arena_state.allocator(), &model);
+        // One red button, and none of the machinery behind it.
+        const opener = try expectByText(tree.root, .button, "Use another key");
+        switch (tree.msgForPointer(opener.id, .up).?) {
+            .reveal_forget => {},
+            else => return error.WrongMessage,
+        }
+        try testing.expect(findByText(tree.root, .button, "Remove this key") == null);
+    }
+
+    // Asked for: the warning, the phrase to type, and a way back out.
+    model.forget_showing = true;
+    {
+        const tree = try buildTree(arena_state.allocator(), &model);
+        _ = try expectByText(tree.root, .button, "Remove this key");
+        const cancel = try expectByText(tree.root, .button, "Cancel");
+        switch (tree.msgForPointer(cancel.id, .up).?) {
+            .cancel_forget => {},
+            else => return error.WrongMessage,
+        }
+    }
+
+    // The button stays inert until the phrase is exact, revealed or not:
+    // folding it away is the first of two guards, not a replacement for one.
+    try testing.expect(model.forget_disabled());
+    model.forget_buf.set("delete my key");
+    try testing.expect(!model.forget_disabled());
+}


### PR DESCRIPTION
Two things about a key that already exists.

### `signer import`

Notary could only take a key through the app's own setup screen, which means it goes through the window and usually the clipboard first. Plaza has had a terminal path for a while and this is the same one: it asks for the nsec with echo off, asks for a passphrase twice, and stores the key encrypted at rest (NIP-49, mode 0600) exactly as it stores one it generated.

Nothing is taken as an argument. A key on a command line is in shell history and visible in `ps` to every other process running as you, so this refuses to accept one that way at all.

It writes the file for the next launch rather than handing the key to a running Notary, and that is the design rather than a shortcut. The daemon binds an **ephemeral** port and tells only the app that spawned it which one, so a separate command has nothing to connect to. Publishing that port for the sake of this would give up the property that keeps another process on the machine away from the control channel. So: import, then start or restart Notary.

**The line reader takes one line, a byte at a time.** A plain `read` into a big buffer takes whatever the pipe has, so the first of the three prompts swallowed the key and both passphrases and the second found nothing. A terminal hides this, because canonical mode hands over one line per read, so it only appears when the input is piped, which is exactly how a script would drive it. (Plaza's copy has the same shape and is fixed on its own branch.)

### The unlock screen no longer leads with "delete my key"

Opening Notary showed a box asking you to type that phrase, under the passphrase field, every time. It is behind a red **Use another key** button now, with a Cancel beside the confirm.

The typed confirmation is unchanged and still exact. Folding it away is one guard, not a replacement for the other, and the test says so in both directions. Cancelling clears what was typed, so re-opening does not start one keystroke from the end.

### Checked

Driven, not reasoned about. The import was run end to end against the NIP-19 test-vector nsec: the file comes out `ncryptsec1…` at mode 0600, and starting the daemon on it reports pubkey `7e7e9c42…86addf4e`, which is that vector's public key. Every refusal was driven too, each one producing its own message and no file: mismatched passphrases, an empty passphrase, something that is not a key, and a key file that already exists.

Two probes on the folded UI, both caught: unfolding the block permanently, and letting the confirmation phrase stop guarding.
