### PR TITLE
Say that the terminal path exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 
 ## [Unreleased]
 
+### Added
+- **The terminal import is offered in the window.** `signer import` shipped last
+  release and nothing in the app mentioned it, so the only way in that anybody
+  could see was the one that puts an nsec through a text field and usually the
+  clipboard. The setup screen now shows the command beside the paste field, with
+  a button to copy it, the same way Plaza's key window has always offered it.
+
+### Changed
+- **One status line instead of four.** The window opened with its own name above
+  the phase above the key, and then counted the queue again at the bottom. That
+  is four lines of chrome in a small window, three of which said nothing after
+  the first second, and the app's name was already in the title bar. The body
+  starts at the top now and there is a single status line at the bottom: the
+  phase while onboarding, the key and the queue count once serving.
+
+  The setup screen also scrolls, so a taller state cannot paint underneath the
+  status bar the way the import branch did.
+
 ## [0.7.0] - 2026-08-16
 
 ### Added

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -1,15 +1,9 @@
-<!-- Notary, the live view. The header shows the connection state
-     and which key you are approving for; the body is one of several mutually
-     exclusive states (signer stopped / first-run setup / unlock / no requests /
-     the request queue); the status bar counts the queue. Logic is in
-     src/main.zig. Validate with: native check -->
+<!-- Notary, the live view. The body is one of several mutually exclusive
+     states (signer stopped / first-run setup / unlock / no requests / the
+     request queue) and starts at the top of the window; the ONE status line
+     lives in the status bar and carries the phase, or the key and the queue
+     count once serving. Logic is in src/main.zig. Validate with: native check -->
 <column gap="0">
-  <column gap="4" padding="16">
-    <text size="heading">Notary</text>
-    <text>{status}</text>
-    <text>signer {pubkey_short}</text>
-  </column>
-  <separator/>
   <if test="{show_bunker}">
     <column gap="6" padding="16">
       <text foreground="text_muted">Bunker URL: paste into your Nostr client to connect</text>
@@ -56,6 +50,11 @@
     </column>
   </if>
   <if test="{needs_setup}">
+    <!-- Scrolls, because the import branch is taller than the create branch and
+         a column that overflows still lays its children out and still paints
+         them: the terminal card's last line went under the footer band. Height
+         is not something to keep measuring by hand. -->
+    <scroll grow="1">
     <column gap="12" grow="1" padding="20">
       <text size="heading">Set up your signer</text>
       <text wrap="true">Create a new key, or import one you already have. The key is generated and stored by the signer itself. This app only sends the passphrase.</text>
@@ -71,7 +70,20 @@
         <text foreground="destructive">{onboard_error}</text>
       </if>
       <button variant="primary" on-press="submit_setup" disabled="{submit_disabled}">{setup_label}</button>
+      <if test="{show_terminal_import}">
+        <card padding="12">
+          <column gap="8">
+            <row gap="8" cross="center">
+              <text foreground="text_muted" grow="1" wrap="true">Prefer the terminal? Nothing is pasted anywhere:</text>
+              <button variant="secondary" on-press="copy_command">{command_copy_label}</button>
+            </row>
+            <text wrap="true">{import_command_text}</text>
+            <text foreground="text_muted" wrap="true">Run it, then reopen Notary to pick the key up.</text>
+          </column>
+        </card>
+      </if>
     </column>
+    </scroll>
   </if>
   <if test="{needs_unlock}">
     <column gap="12" grow="1" padding="20">

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -56,6 +56,14 @@ const shell_scene: native_sdk.ShellConfig = .{ .windows = &shell_windows };
 // ------------------------------------------------------------- config
 
 const default_address = "127.0.0.1:8787";
+
+/// The command that takes a key without it passing through this window.
+///
+/// The installed path, not one derived from argv[0]: a reader looking at this
+/// is going to retype or paste it into a terminal, and the answer has to be
+/// right for the app they installed rather than for wherever this binary
+/// happens to be running from during development.
+const import_command = "/Applications/Notary.app/Contents/MacOS/signer import";
 const default_token_file = ".zig-nostr-signer.token";
 
 // Effect keys. Fetch/spawn/file effects share one key space and 16 slots; the
@@ -75,6 +83,9 @@ const unlock_key: u64 = 6;
 const nostrconnect_key: u64 = 11;
 const forget_key: u64 = 12;
 const clipboard_key: u64 = 7;
+/// Its own effect key: two clipboard writes under one key would have the second
+/// rejected while the first is still in flight.
+const command_clipboard_key: u64 = 17;
 const info_refresh_key: u64 = 16; // periodic /info re-poll (distinct from the initial info_key)
 const decision_key_base: u64 = 8;
 const decision_key_slots: u64 = 8;
@@ -297,6 +308,10 @@ pub const Model = struct {
     secret_buf: canvas.TextBuffer(200) = .{},
     /// false: generate a fresh key; true: import an existing `nsec1…`/hex.
     import_mode: bool = false,
+    /// Whether the terminal command is on the clipboard, for the button's own
+    /// confirmation. Separate from `copied`, which belongs to the bunker URL:
+    /// one flag for two buttons would light both.
+    command_copied: bool = false,
     /// Managed mode: whether the daemon has told us which port it bound.
     ///
     /// It binds port 0 and reports what the kernel gave it, because a fixed
@@ -387,12 +402,42 @@ pub const Model = struct {
     }
 
     /// Footer text: the pending count while serving, nothing during onboarding.
+    /// The app's ONE status line.
+    ///
+    /// There used to be a header block carrying the name, the phase and the key
+    /// on three separate lines, above a status bar counting the queue. Four
+    /// lines of chrome in a 460x560 window, three of which said nothing after
+    /// the first second, and the app's own name told the reader nothing the
+    /// title bar had not already said. Now there is one line, at the bottom,
+    /// and the body starts at the top of the window.
     pub fn footer(self: *const Model, arena: std.mem.Allocator) []const u8 {
-        if (self.onboarding_body()) return "";
-        return std.fmt.allocPrint(arena, "{d} pending", .{self.rows_len}) catch "";
+        // While onboarding, the phase IS the whole story and there is no queue
+        // to count: the screen already says what it wants.
+        if (self.onboarding_body()) return self.status();
+        if (self.phase != .connected) return self.status();
+        // No key yet means the daemon has not answered /info; the count alone
+        // is the honest line, rather than "signer not connected" beside a queue.
+        if (self.pubkey_len == 0) return std.fmt.allocPrint(arena, "{d} pending", .{self.rows_len}) catch "";
+        const key = self.pubkey_short(arena);
+        return std.fmt.allocPrint(arena, "signer {s} · {d} pending", .{ key, self.rows_len }) catch "";
     }
 
     // -- onboarding view bindings --
+
+    pub fn import_command_text(self: *const Model) []const u8 {
+        _ = self;
+        return import_command;
+    }
+    /// "Copy", or the confirmation, on the terminal card's own button.
+    pub fn command_copy_label(self: *const Model) []const u8 {
+        return if (self.command_copied) "Copied!" else "Copy";
+    }
+    /// The card belongs to the import branch of setup, not to creating a key:
+    /// there is nothing to bring in from a terminal when the signer is about to
+    /// mint one.
+    pub fn show_terminal_import(self: *const Model) bool {
+        return self.phase == .needs_setup and self.import_mode;
+    }
 
     pub fn forget_confirm(self: *const Model) []const u8 {
         return self.forget_buf.text();
@@ -655,6 +700,8 @@ pub const Msg = union(enum) {
     // Copy the bunker:// URI to the clipboard, its result, and the timer that
     // clears the transient "Copied!" confirmation.
     copy_bunker,
+    copy_command,
+    command_copied_result: native_sdk.EffectClipboardResult,
     bunker_copied: native_sdk.EffectClipboardResult,
 
     // Adopting a client that showed a nostrconnect:// link.
@@ -1060,6 +1107,15 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             attemptConnect(model, fx);
         },
 
+        .copy_command => fx.writeClipboard(.{
+            .key = command_clipboard_key,
+            .text = import_command,
+            .on_result = Effects.clipboardMsg(.command_copied_result),
+        }),
+        .command_copied_result => |result| {
+            if (result.outcome != .ok) return;
+            model.command_copied = true;
+        },
         .copy_bunker => {
             const uri = model.bunker();
             if (uri.len == 0) return;

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -180,9 +180,12 @@ test "the empty view shows the connection status and a zero count" {
     var model = main.initialModel(); // .connecting, empty queue
     const tree = try buildTree(arena_state.allocator(), &model);
 
-    _ = try expectByText(tree.root, .text, "Notary");
-    _ = try expectByText(tree.root, .text, "Connecting to the signer…");
-    _ = try expectByText(tree.root, .status_bar, "0 pending");
+    // ONE status line, and it is the status bar. The header block that used to
+    // repeat the app's name above the phase above the key is gone: four lines
+    // of chrome in a small window, three of them saying nothing after the first
+    // second, and the name was already in the title bar.
+    _ = try expectByText(tree.root, .status_bar, "Connecting to the signer…");
+    try testing.expect(findByText(tree.root, .text, "Notary") == null);
 }
 
 test "an approval row says who is asking and what would be signed" {
@@ -318,7 +321,7 @@ test "the daemon-stopped view offers a restart" {
     model.phase = .daemon_exited; // as set when the daemon child exits
     const tree = try buildTree(arena_state.allocator(), &model);
 
-    _ = try expectByText(tree.root, .text, "Signer stopped");
+    _ = try expectByText(tree.root, .status_bar, "Signer stopped");
     _ = try expectByText(tree.root, .text, "The signer process stopped.");
 
     const restart = try expectByText(tree.root, .button, "Restart signer");
@@ -514,4 +517,62 @@ test "the way out of a key is folded away until it is asked for" {
     try testing.expect(model.forget_disabled());
     model.forget_buf.set("delete my key");
     try testing.expect(!model.forget_disabled());
+}
+
+test "the terminal path is offered beside the paste field, not instead of it" {
+    // The nsec goes through this window and the clipboard when it is pasted
+    // here. The terminal takes it without either, so the command is offered
+    // rather than hidden, exactly as Plaza's own key window offers it.
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+
+    var model = main.initialModel();
+    model.phase = .needs_setup;
+
+    // Creating a key has nothing to bring in, so the card stays away.
+    model.import_mode = false;
+    {
+        const tree = try buildTree(arena_state.allocator(), &model);
+        try testing.expect(findByText(tree.root, .button, "Copy") == null);
+    }
+
+    model.import_mode = true;
+    {
+        const tree = try buildTree(arena_state.allocator(), &model);
+        const copy = try expectByText(tree.root, .button, "Copy");
+        switch (tree.msgForPointer(copy.id, .up).?) {
+            .copy_command => {},
+            else => return error.WrongMessage,
+        }
+        // The command names the INSTALLED binary. A path derived from argv[0]
+        // would be right in development and wrong for everybody else.
+        _ = try expectByText(tree.root, .text, "/Applications/Notary.app/Contents/MacOS/signer import");
+        // And it says to reopen, because the import writes the key for the next
+        // launch rather than handing it to a daemon it cannot reach.
+        _ = try expectByText(tree.root, .text, "Run it, then reopen Notary to pick the key up.");
+    }
+}
+
+test "one status line, and it says the phase before there is a queue to count" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // Onboarding: the phase is the whole story, and there is no queue.
+    var m = Model{};
+    m.phase = .needs_unlock;
+    try testing.expectEqualStrings("Locked", m.footer(arena));
+
+    // Serving: the key and the count, on one line rather than three.
+    m.phase = .connected;
+    main.parseInfo(&m, "{\"state\":\"unlocked\",\"pubkey\":\"aabbccddeeff00112233445566778899\"}");
+    const line = m.footer(arena);
+    try testing.expect(std.mem.startsWith(u8, line, "signer "));
+    try testing.expect(std.mem.endsWith(u8, line, "0 pending"));
+
+    // Serving before the daemon has said who it is: the count alone, never
+    // "signer not connected" sitting beside a live queue.
+    var fresh = Model{};
+    fresh.phase = .connected;
+    try testing.expectEqualStrings("0 pending", fresh.footer(arena));
 }


### PR DESCRIPTION
`signer import` shipped in v0.7.0 and nothing in the app mentioned it, so the only way in that anybody could see was the one that puts an nsec through a text field and usually the clipboard.

The command now sits beside the paste field on the setup screen, with a button to copy it, which is how Plaza's own key window has always offered it. It names the installed binary rather than a path derived from argv[0]: that would be right in development and wrong for everybody who installed the app. The footnote says to reopen Notary, because the import writes the key for the next launch rather than handing it to a daemon it cannot reach.

### The header, while I was in there

The window opened with the app's own name above the phase above the key, then counted the queue again at the bottom. Four lines of chrome in a 460x560 window, three of them saying nothing after the first second, and the name was already in the title bar. There is one status line now, at the bottom: the phase while onboarding, the key and the queue count once serving.

That mattered for more than tidiness. Measured against the real window, the card's last line landed at y=544 under a status band at y=528, which is the trap Plaza's notary-window already documents in a comment: a column that overflows still lays its children out and still paints them. Dropping the header bought 111px, and the setup column scrolls now so the next tall state cannot do it again.

### Checked

Against the real window, not the markup. Before: content ran to y=544 with the band at y=528. After: the body starts at y=20, the card's last line ends at y=450, the scroll reports content exactly fitting its viewport, and the status line has its own band.

Three probes, all caught: showing the card when creating a key rather than importing one, letting the status line read "signer not connected" beside a live queue, and pointing the command at the dev binary.