### PR TITLE
Notary is 0.8.0

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,18 +1,10 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
-### What's new in v0.7.0
+### What's new in v0.8.0
 
-**You can hand Notary a key from the terminal.** Until now the only way in was the setup screen, which means your nsec goes through a window and usually the clipboard on its way. There is a command now:
+**The terminal way in is now visible.** v0.7.0 added a command that takes your nsec from a terminal without it passing through the window or the clipboard, and then nothing in the app told you it existed. The setup screen shows it now, beside the paste field, with a button to copy it. Both ways work; one of them keeps your key out of more places.
 
-```sh
-/Applications/Notary.app/Contents/MacOS/signer import
-```
-
-It asks for your nsec and a passphrase without showing what you type, and stores the key encrypted exactly as it stores one it generated itself. It will not take a key as an argument, on purpose: a key on a command line ends up in your shell history and is visible to every other program running as you.
-
-It writes the key for the next launch rather than handing it to a running Notary, so import first and then open it. That is not a shortcut. Notary's approval channel listens on a port that only the app itself knows, and a command able to reach it would need that port published somewhere anything could read.
-
-**Opening Notary no longer leads with "delete my key".** The unlock screen showed a box asking you to type that phrase, every time, under the passphrase field. It is behind a red **Use another key** button now. Typing the phrase is still required once you get there, and cancelling clears what you typed.
+**One status line instead of four.** Notary used to open with its own name above the current phase above your key, and then count the queue again at the bottom. That is a lot of the window spent telling you things you knew, in an app whose whole job is to show you one question at a time. The screen starts with the actual content now, and there is a single line at the bottom.
 
 ### Install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-16
+
 ### Added
 - **The terminal import is offered in the window.** `signer import` shipped last
   release and nothing in the app mentioned it, so the only way in that anybody

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.7.0",
+    .version = "0.8.0",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command", "clipboard" },


### PR DESCRIPTION
Version bump, changelog and release notes for 0.8.0: the terminal import is offered in the window, and the four-line header becomes one status line.