### PR TITLE
Native SDK 0.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: 22
 
       - name: Install the Native SDK CLI
-        run: npm install -g @native-sdk/cli@0.9.0
+        run: npm install -g @native-sdk/cli@0.9.2
 
       - name: Check markup and manifest
         run: native check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: 22
 
       - name: Install the Native SDK CLI
-        run: npm install -g @native-sdk/cli@0.9.0
+        run: npm install -g @native-sdk/cli@0.9.2
 
       # The suites run on every pull request, but a tag can be pushed at any
       # commit, and a release is the one artifact nobody gets to re-check. So


### PR DESCRIPTION
Notary's SDK version *is* the CLI, pinned in the two workflows, so this is the whole upgrade: 0.9.0 to 0.9.2 in `ci.yml` and `release.yml` together. Both were on 0.9.0, and leaving release behind would have built published artifacts against a different SDK than CI tested.

Nothing in the GUI moves. The one breaking change in 0.9.2 is that `.dialog`, `.drawer` and `.sheet` are placed and centred by the runtime rather than filling the frame they are given, and this app uses none of the three: the setup, unlock and queue screens are plain columns. (Plaza does use them, and is a separate PR.)

What 0.9.2 brings that Notary benefits from for free: the macOS presentation-cost fix, monotonic GPU timestamps, and automation focus doing a scroll reveal, which helps the GUI's own layout tests.

Daemon suite and GUI suite both green on the new CLI.
