### PR TITLE
A key does enter the window, on import

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ window: Zig throughout, drawn by the toolkit itself, with no Electron and no
 WebView anywhere. Notary keeps your secret key on a machine you control and
 signs for your apps over
 [NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md). The key
-never leaves the signer, and nothing gets signed quietly: you see what a client
-is asking for before it happens.
+never leaves the signer, and nothing signs on your behalf until you have said
+so: a request shows which client is asking and what it would sign, and your
+answer stands for that one request, for a day, or always for that client and
+that kind.
 
 Built on [`zig-nostr/nostr`](https://github.com/zig-nostr/nostr), and the signer
 behind [Plaza](https://github.com/zig-nostr/plaza), the native client in the same
@@ -23,7 +25,7 @@ client, and Notary neither knows nor cares which one is asking.
 
 | | | |
 | --- | --- | --- |
-| ![The key never arrives: it is created and held by the signer, and this window only forwards your passphrase](docs/shots/panel-setup.jpg) | ![One URL, any client: paste the bunker link into any Nostr app and you are connected](docs/shots/panel-serving.jpg) | ![Nothing signs quietly: a request names itself and waits, and you say how long your answer stands](docs/shots/panel-request.jpg) |
+| ![Your key is created and held by the signer: this window forwards a passphrase, or the nsec you choose to import](docs/shots/panel-setup.jpg) | ![One URL, any client: paste the bunker link into any Nostr app and you are connected](docs/shots/panel-serving.jpg) | ![Nothing signs quietly: a request names itself and waits, and you say how long your answer stands](docs/shots/panel-request.jpg) |
 
 <sub>Real windows, photographed from the running app. Every pixel inside the
 window is the app's own, so nothing here shows a screen the app cannot draw. The
@@ -39,7 +41,9 @@ curl -fsSL https://raw.githubusercontent.com/zig-nostr/notary/main/scripts/insta
 ```
 
 That downloads the latest release, verifies its SHA-256, installs `Notary.app`
-to `/Applications`, and opens it, ready to use.
+to `/Applications` (or `~/Applications` when that is not writable), clears the
+download-quarantine flag so Gatekeeper does not stop an ad-hoc-signed build, and
+opens it.
 
 Notary is **ad-hoc signed, not notarized**, on purpose. It holds your keys, so
 the trust anchor is a build you can reproduce, not an Apple signature: every
@@ -60,7 +64,11 @@ from the user interface:
 - **[`gui/`](gui)**: the native desktop approver, built with the
   [Native SDK](https://github.com/vercel-labs/native) (declarative markup plus
   Zig, rendered natively: no WebView, no Electron). It shows each pending
-  request and sends back your approve/deny decision. The key never enters it.
+  request and sends back your answer: allow once, for a day, always, or deny.
+  The key is generated and decrypted inside the daemon; this app forwards a
+  passphrase, and an nsec only when you import an existing key on the setup
+  screen. `signer import` reads it from the terminal instead, so it never
+  touches the window at all.
 
 Packaged together, one download brings up both as a single macOS `.app`.
 


### PR DESCRIPTION
The README said "The key never enters it" about the approval GUI. That is not true, and the CHANGELOG already said so at 0.7.0. `gui/src/app.native` has an nsec textarea on the setup screen, and `sendSetup` serialises `{ passphrase, secret }` and POSTs it to the daemon's `/setup`. So on the import path the secret goes through the window before it reaches the signer. `gui/README.md` already carries the corrected wording; only the top-level README still claimed the absolute.

What is true, and worth saying instead: the key is generated and decrypted inside the daemon, the GUI normally forwards only a passphrase, and `signer import` reads a key from the terminal so it never touches the window at all.

**"Nothing gets signed quietly" was the same shape of overclaim.** After one "Always", `decide` returns from `permissions.remembered` without queuing anything, which is the entire point of that button. The sentence now describes the four answers rather than promising a prompt that does not always come.

The install line said `/Applications` and stopped there. The script falls back to `~/Applications` when that is not writable, and clears the quarantine flag, which is the step that actually matters for an ad-hoc-signed build.

**Not touched on purpose:** `docs/shots/panel-request.jpg` still shows Approve/Deny where the app now draws four buttons with the asker and a preview. Correcting its alt text without retaking the picture would swap one mismatch for a worse one, and would falsify the line two rows below saying nothing here shows a screen the app cannot draw. That needs a reshoot, not a caption.