### PR TITLE
Sign out restarts the signer instead of hanging

### DIFF
--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -318,6 +318,8 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
         return handleSetup(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/forget"))
         return handleForget(self, io, w, body);
+    if (eql(method, "POST") and eql(path, "/lock"))
+        return handleLock(self, w);
     if (eql(method, "POST") and eql(path, "/nostrconnect"))
         return handleNostrConnect(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/unlock"))
@@ -511,6 +513,28 @@ fn handleForget(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) 
     if (self.clients) |c| c.clear();
     self.broker.reset();
     self.gate.forget(io);
+
+    // Answered before exiting, so the GUI is told rather than seeing its
+    // connection drop and guessing why.
+    respond(w, 200, "{\"ok\":true}") catch {};
+    w.flush() catch {};
+    std.process.exit(0);
+}
+
+/// Sign out: end the process, keeping the key.
+///
+/// Ending it is the whole point rather than an implementation detail. The relay
+/// threads were handed the key by value when serving began, so nothing short of
+/// exiting takes it back, and a signer that reports itself signed out while it
+/// can still sign is worse than one that never offered.
+///
+/// The key stays where it is, encrypted, so the next daemon comes up locked and
+/// asks for the passphrase. `/forget` is the one that removes it.
+fn handleLock(self: *Server, w: *std.Io.Writer) !void {
+    // Sessions granted before signing out must not outlive it: a client still
+    // holding an authorization would be recognised by the daemon that follows.
+    if (self.clients) |c| c.clear();
+    self.broker.reset();
 
     // Answered before exiting, so the GUI is told rather than seeing its
     // connection drop and guessing why.

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -89,6 +89,7 @@ const setup_key: u64 = 5;
 const unlock_key: u64 = 6;
 const nostrconnect_key: u64 = 11;
 const forget_key: u64 = 12;
+const lock_key: u64 = 18;
 const clipboard_key: u64 = 7;
 /// Its own effect key: two clipboard writes under one key would have the second
 /// rejected while the first is still in flight.
@@ -718,6 +719,8 @@ pub const Msg = union(enum) {
 
     // Signing out (lock, reversible) and removing the key (not reversible).
     sign_out,
+    /// The daemon answered the sign-out before exiting.
+    lock_done: native_sdk.EffectResponse,
     forget_edit: canvas.TextInputEvent,
     reveal_forget,
     cancel_forget,
@@ -889,6 +892,20 @@ fn sendForget(model: *Model, fx: *Effects) void {
         .{ .name = "content-type", .value = "application/json" },
     };
     fx.fetch(.{ .key = forget_key, .method = .POST, .url = url, .headers = &headers, .body = body, .timeout_ms = 20_000, .on_response = Effects.responseMsg(.forget_done) });
+}
+
+/// POST /lock, the sign out.
+///
+/// Asking the daemon to end itself rather than starting a second one beside it.
+/// A restart IS the sign out (the relay threads hold the key by value), and the
+/// old daemon owns the loopback port until it goes, so spawning over the top of
+/// a live one left the new process unable to bind and the window waiting on a
+/// port line that never came.
+fn sendLock(model: *Model, fx: *Effects) void {
+    var url_buf: [128]u8 = undefined;
+    const url = std.fmt.bufPrint(&url_buf, "{s}/lock", .{model.baseUrl()}) catch return;
+    const headers = [_]std.http.Header{.{ .name = "authorization", .value = model.auth() }};
+    fx.fetch(.{ .key = lock_key, .method = .POST, .url = url, .headers = &headers, .timeout_ms = 10_000, .on_response = Effects.responseMsg(.lock_done) });
 }
 
 /// POST /nostrconnect, adopt a client that showed a `nostrconnect://` link.
@@ -1173,12 +1190,28 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             // process takes it back; the daemon then comes up locked and asks
             // for the passphrase. Doing it any other way would leave a signer
             // that reports itself signed out and still signs.
+            //
+            // Ask the daemon to end itself and wait for the answer, rather than
+            // spawning a second one over the top of it. The running daemon owns
+            // the loopback port until it exits, so the new process could not
+            // bind and never printed the port line the window waits for: the
+            // sign out parked at "Starting the signer…" until the app was
+            // restarted. `/lock` keeps the key; `/forget` is the one that
+            // removes it.
             if (!model.managed) return;
-            model.setAuth("");
-            model.clearRows();
-            model.clearSecrets();
             model.clearOnboardError();
             model.submitting = false;
+            sendLock(model, fx);
+        },
+        .lock_done => |response| {
+            // Whatever it answered, the daemon is on its way out or already
+            // gone, so what this window knew about it is stale either way.
+            _ = response;
+            model.setAuth("");
+            model.clearRows();
+            model.clearBunker();
+            model.clearRelays();
+            model.clearSecrets();
             spawnDaemon(model, fx);
             attemptConnect(model, fx);
         },


### PR DESCRIPTION
Signing out spawned a second daemon without ending the first. The running one owns the loopback port until it exits, so the new process could not bind and never printed the port line the window waits for. The app parked at "Starting the signer…" until restarted, with the old daemon still serving and still holding the key.

The daemon gains `POST /lock`: what `/forget` does minus removing the key. Clears granted sessions, answers, exits. The key stays encrypted on disk so the next daemon comes up locked and asks for the passphrase.

Verified against a running daemon: 401 without the bearer token and the process survives, 200 with it and the process exits, key file byte-identical afterwards. Then driven through the real GUI with automation: create a key, sign out, window reaches Locked in under three seconds.