### PR TITLE
Let people back up the key they own

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ window: Zig throughout, drawn by the toolkit itself, with no Electron and no
 WebView anywhere. Notary keeps your secret key on a machine you control and
 signs for your apps over
 [NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md). The key
-never leaves the signer, and nothing signs on your behalf until you have said
-so: a request shows which client is asking and what it would sign, and your
-answer stands for that one request, for a day, or always for that client and
-that kind.
+never leaves the signer unless you ask for it, and nothing signs on your behalf
+until you have said so: a request shows which client is asking and what it would
+sign, and your answer stands for that one request, for a day, or always for that
+client and that kind.
 
 Built on [`zig-nostr/nostr`](https://github.com/zig-nostr/nostr), and the signer
 behind [Plaza](https://github.com/zig-nostr/plaza), the native client in the same
@@ -31,6 +31,25 @@ client, and Notary neither knows nor cares which one is asking.
 window is the app's own, so nothing here shows a screen the app cannot draw. The
 signer pubkey and `bunker://` URL come from a stub daemon; no real key appears in
 any of them.</sub>
+
+## Your key is yours to take
+
+A nostr key cannot be replaced. If the only copy is on one Mac, losing the Mac
+loses the account, so Notary will hand the key back to you: **Back up your key**,
+then the passphrase, then one of two forms.
+
+The **encrypted key** is the NIP-49 `ncryptsec1…` exactly as it sits on disk. It
+is still behind your passphrase, so it is safe to keep in a password manager or
+on paper. Keep the passphrase somewhere else.
+
+The **secret key** is the `nsec1…` itself. Anyone who reads it becomes you, for
+good, so it is there for the case where you need it and says as much when it
+appears.
+
+The passphrase is required for both, including the encrypted form that does not
+strictly need it: an unlocked signer is the normal state, and whoever is at the
+keyboard then is not necessarily the person who set it up. Nothing is kept
+afterwards, and closing the panel takes the key off the screen with it.
 
 ## Install
 

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -7,6 +7,8 @@
 //!   GET  /info              {"state":..,"pubkey":..,"bunker":..,"relays":[{"url":..,"status":..}],"timeout_ms":N}
 //!   POST /setup             {"passphrase":..,"secret":..?} → create/import a key
 //!   POST /unlock            {"passphrase":..} → decrypt the key file
+//!   POST /lock              → clear sessions and exit, keeping the key
+//!   POST /export            {"passphrase":..,"form":"ncryptsec"|"nsec"} → the key
 //!   GET  /pending?since=N   long-poll (~1s) → {"version":N,"pending":[...]}
 //!   POST /decision          {"id":N,"decision":"approve"|"reject"} → {"ok":bool}
 //!
@@ -320,6 +322,8 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
         return handleForget(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/lock"))
         return handleLock(self, w);
+    if (eql(method, "POST") and eql(path, "/export"))
+        return handleExport(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/nostrconnect"))
         return handleNostrConnect(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/unlock"))
@@ -519,6 +523,43 @@ fn handleForget(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) 
     respond(w, 200, "{\"ok\":true}") catch {};
     w.flush() catch {};
     std.process.exit(0);
+}
+
+/// Hand the key back to the person who owns it.
+///
+/// A key that cannot leave is not the reader's key, whatever the copy says, and
+/// a Nostr key cannot be rotated: one trapped in one app on one machine is an
+/// identity that dies with the machine. So this exists, and it is deliberately
+/// awkward: the passphrase every time, and the caller has to name which form it
+/// wants.
+///
+/// `form` is "ncryptsec" (the default, still encrypted, safe to write down) or
+/// "nsec" (the key in the clear). The answer is not logged and the daemon keeps
+/// no copy of what it returned.
+fn handleExport(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !void {
+    const Body = struct { passphrase: []const u8 = "", form: []const u8 = "ncryptsec" };
+    const parsed = std.json.parseFromSlice(Body, self.gpa, body, .{ .ignore_unknown_fields = true }) catch
+        return respond(w, 400, bad_request);
+    defer parsed.deinit();
+
+    const raw = eql(parsed.value.form, "nsec");
+    if (!raw and !eql(parsed.value.form, "ncryptsec"))
+        return respond(w, 400, "{\"error\":\"form must be ncryptsec or nsec\"}");
+
+    const key = self.gate.exportKey(io, self.gpa, parsed.value.passphrase, raw) catch |err| return switch (err) {
+        error.BadPassphrase => respond(w, 401, "{\"error\":\"bad passphrase\"}"),
+        error.NotInitialized => respond(w, 409, "{\"error\":\"no key\"}"),
+        else => respond(w, 500, "{\"error\":\"could not read the key\"}"),
+    };
+    defer {
+        std.crypto.secureZero(u8, key);
+        self.gpa.free(key);
+    }
+
+    var out: [512]u8 = undefined;
+    const j = std.fmt.bufPrint(&out, "{{\"ok\":true,\"key\":\"{s}\"}}", .{key}) catch
+        return respond(w, 500, "{\"error\":\"could not read the key\"}");
+    return respond(w, 200, j);
 }
 
 /// Sign out: end the process, keeping the key.

--- a/daemon/src/onboarding.zig
+++ b/daemon/src/onboarding.zig
@@ -159,6 +159,33 @@ pub const Gate = struct {
     /// caller has to finish it: the relay threads were handed the key by value
     /// when serving started and still hold it. Ending the process is what
     /// actually retracts it, which is why the endpoint that calls this exits.
+    pub const ExportError = error{ BadPassphrase, NotInitialized, ReadFailed, OutOfMemory };
+
+    /// The key itself, handed back to the person who owns it.
+    ///
+    /// `raw` chooses the form: false gives the NIP-49 `ncryptsec1…` exactly as
+    /// it sits on disk, which is safe to write down because it is still behind
+    /// the passphrase; true gives the `nsec1…`, which is the key in the clear.
+    ///
+    /// The passphrase is checked by decrypting whichever form is asked for,
+    /// including the encrypted one that does not strictly need it. Being
+    /// unlocked already is not enough to hand out a key: an unlocked daemon is
+    /// the normal state, and whoever is at the keyboard then is not necessarily
+    /// the person who set it up.
+    pub fn exportKey(self: *Gate, io: std.Io, gpa: std.mem.Allocator, passphrase: []const u8, raw: bool) ExportError![]u8 {
+        if (self.current() == .uninitialized) return error.NotInitialized;
+        if (passphrase.len == 0) return error.BadPassphrase;
+
+        const ncryptsec = keystore.readKeyFile(gpa, io, self.dir, self.key_file) catch return error.ReadFailed;
+        defer gpa.free(ncryptsec);
+
+        var secret = keystore.decryptKey(gpa, ncryptsec, passphrase) catch return error.BadPassphrase;
+        defer std.crypto.secureZero(u8, &secret);
+
+        if (!raw) return gpa.dupe(u8, ncryptsec) catch return error.OutOfMemory;
+        return nip19.encodeNsec(gpa, secret) catch return error.OutOfMemory;
+    }
+
     pub fn forget(self: *Gate, io: std.Io) void {
         self.dir.deleteFile(io, self.key_file) catch {};
         std.crypto.secureZero(u8, &self.secret_key);

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -10,6 +10,7 @@
        scroll's viewport was squeezed to about half, and the backup's own buttons
        were clipped out of a column that had plenty of room on paper. Two things
        that both want the leftover space is one thing too many. -->
+  <if test="{show_serving}">
   <scroll grow="1">
   <column gap="0">
   <if test="{show_bunker}">
@@ -92,6 +93,7 @@
   </if>
   </column>
   </scroll>
+  </if>
   <if test="{daemon_down}">
     <column gap="12" main="center" cross="center" grow="1" padding="24">
       <text>{exit_note}</text>
@@ -135,7 +137,12 @@
     </scroll>
   </if>
   <if test="{needs_unlock}">
-    <column gap="12" grow="1" padding="20">
+    <!-- Scrolls for the same reason the setup branch does: opening "use another
+         key" adds a warning, a confirm field and two buttons under a screen that
+         already filled the window, and the confirm field went off the bottom
+         edge with no way to reach it. -->
+    <scroll grow="1">
+    <column gap="12" padding="20">
       <text size="heading">Unlock your signer</text>
       <text>Enter your passphrase to unlock the signing key.</text>
       <row><text-field text="{passphrase}" placeholder="Passphrase" on-input="passphrase_edit" on-submit="submit_unlock" autofocus="true" grow="1"/></row>
@@ -159,6 +166,7 @@
         </if>
       </if>
     </column>
+    </scroll>
   </if>
   <if test="{show_queue}">
     <scroll grow="1">

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -25,6 +25,40 @@
         <button variant="secondary" on-press="sign_out">Sign out</button>
         <text grow="1" foreground="text_muted" wrap="true">Locks the signer. Your key stays on this Mac and needs its passphrase again.</text>
       </row>
+      <separator/>
+      <if test="{backup_closed}">
+        <row gap="8">
+          <button variant="secondary" on-press="reveal_backup">Back up your key</button>
+          <text grow="1" foreground="text_muted" wrap="true">This Mac holds the only copy. Without a backup, losing it loses the identity: a nostr key cannot be replaced.</text>
+        </row>
+      </if>
+      <if test="{backup_open}">
+        <column gap="10">
+          <text>Back up your key</text>
+          <text foreground="text_muted" wrap="true">Two forms. The encrypted one still needs this passphrase to use, so it is safe to keep in a password manager or on paper. The secret one is the key itself: anyone who reads it becomes you, for good.</text>
+          <row><text-field text="{backup_passphrase}" placeholder="Passphrase" on-input="backup_pass_edit" grow="1"/></row>
+          <row gap="8">
+            <button variant="primary" grow="1" on-press="export_encrypted" disabled="{backup_disabled}">Encrypted key</button>
+            <button variant="destructive" grow="1" on-press="export_secret" disabled="{backup_disabled}">Secret key</button>
+            <button on-press="cancel_backup">Close</button>
+          </row>
+          <if test="{has_backup_error}">
+            <text foreground="destructive">{backup_error}</text>
+          </if>
+          <if test="{backup_is_encrypted}">
+            <text foreground="text_muted" wrap="true">Encrypted, and useless without the passphrase. Keep both, apart.</text>
+          </if>
+          <if test="{backup_is_secret}">
+            <text foreground="destructive" wrap="true">This is the key in the clear. Anyone who sees it can sign as you and you cannot take it back. Close this when you are done.</text>
+          </if>
+          <if test="{has_backup_key}">
+            <row gap="8" cross="center">
+              <text grow="1" wrap="true">{backup_key}</text>
+              <button variant="secondary" on-press="copy_backup">{backup_copy_label}</button>
+            </row>
+          </if>
+        </column>
+      </if>
     </column>
     <separator/>
   </if>

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -4,6 +4,14 @@
      lives in the status bar and carries the phase, or the key and the queue
      count once serving. Logic is in src/main.zig. Validate with: native check -->
 <column gap="0">
+  <!-- ONE scroll for the whole serving view: the bunker link, the relays and the
+       queue's empty line. They used to be siblings that each grew, so with a key
+       revealed the scroll and the empty state split the window between them, the
+       scroll's viewport was squeezed to about half, and the backup's own buttons
+       were clipped out of a column that had plenty of room on paper. Two things
+       that both want the leftover space is one thing too many. -->
+  <scroll grow="1">
+  <column gap="0">
   <if test="{show_bunker}">
     <column gap="6" padding="16">
       <text foreground="text_muted">Bunker URL: paste into your Nostr client to connect</text>
@@ -77,6 +85,13 @@
     </column>
     <separator/>
   </if>
+  <if test="{show_empty}">
+    <column gap="12" main="center" cross="center" padding="24">
+      <text>{empty_text}</text>
+    </column>
+  </if>
+  </column>
+  </scroll>
   <if test="{daemon_down}">
     <column gap="12" main="center" cross="center" grow="1" padding="24">
       <text>{exit_note}</text>
@@ -143,11 +158,6 @@
           <text foreground="destructive">{forget_error}</text>
         </if>
       </if>
-    </column>
-  </if>
-  <if test="{show_empty}">
-    <column gap="12" main="center" cross="center" grow="1" padding="24">
-      <text>{empty_text}</text>
     </column>
   </if>
   <if test="{show_queue}">

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -642,6 +642,15 @@ pub const Model = struct {
         return self.bunker_buf[0..self.bunker_len];
     }
     /// Show the connection card only while serving with a URI in hand.
+    /// Whether the serving screen has anything on it.
+    ///
+    /// The scroll around it is `grow`, so it must not exist when this screen is
+    /// not the one showing: an empty one still takes its share of the window,
+    /// and on the unlock screen it pushed the heading half way down.
+    pub fn show_serving(self: *const Model) bool {
+        return self.show_bunker() or self.show_relays() or self.show_empty();
+    }
+
     pub fn show_bunker(self: *const Model) bool {
         return self.phase == .connected and self.bunker_len > 0;
     }

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -90,6 +90,7 @@ const unlock_key: u64 = 6;
 const nostrconnect_key: u64 = 11;
 const forget_key: u64 = 12;
 const lock_key: u64 = 18;
+const export_key: u64 = 19;
 const clipboard_key: u64 = 7;
 /// Its own effect key: two clipboard writes under one key would have the second
 /// rejected while the first is still in flight.
@@ -313,6 +314,21 @@ pub const Model = struct {
     forget_showing: bool = false,
     forget_error_buf: [96]u8 = [_]u8{0} ** 96,
     forget_error_len: usize = 0,
+    /// Backing up the key. Folded away on every launch for the same reason the
+    /// way out is: the passphrase field for it should not be sitting open.
+    backup_showing: bool = false,
+    backup_pass: canvas.TextBuffer(128) = .{},
+    /// The exported key, held only until the reader copies it or closes the
+    /// panel. An `ncryptsec1…` unless they asked for the key in the clear.
+    backup_key_buf: [256]u8 = [_]u8{0} ** 256,
+    backup_key_len: usize = 0,
+    /// Whether what is held is the key in the clear rather than the encrypted
+    /// form, which decides what the panel warns about.
+    backup_is_raw: bool = false,
+    backup_sending: bool = false,
+    backup_error_buf: [96]u8 = [_]u8{0} ** 96,
+    backup_error_len: usize = 0,
+    backup_copied: bool = false,
     secret_buf: canvas.TextBuffer(200) = .{},
     /// false: generate a fresh key; true: import an existing `nsec1…`/hex.
     import_mode: bool = false,
@@ -467,6 +483,60 @@ pub const Model = struct {
         // destructive press cannot be a mis-click.
         return !std.mem.eql(u8, self.forget_buf.text(), "delete my key");
     }
+    pub fn backup_open(self: *const Model) bool {
+        return self.backup_showing;
+    }
+    pub fn backup_closed(self: *const Model) bool {
+        return !self.backup_showing;
+    }
+    pub fn backup_passphrase(self: *const Model) []const u8 {
+        return self.backup_pass.text();
+    }
+    pub fn backup_disabled(self: *const Model) bool {
+        return self.backup_sending or self.backup_pass.text().len == 0;
+    }
+    pub fn backup_key(self: *const Model) []const u8 {
+        return self.backup_key_buf[0..self.backup_key_len];
+    }
+    pub fn has_backup_key(self: *const Model) bool {
+        return self.backup_key_len > 0;
+    }
+    pub fn backup_is_encrypted(self: *const Model) bool {
+        return self.backup_key_len > 0 and !self.backup_is_raw;
+    }
+    pub fn backup_is_secret(self: *const Model) bool {
+        return self.backup_key_len > 0 and self.backup_is_raw;
+    }
+    pub fn backup_error(self: *const Model) []const u8 {
+        return self.backup_error_buf[0..self.backup_error_len];
+    }
+    pub fn has_backup_error(self: *const Model) bool {
+        return self.backup_error_len > 0;
+    }
+    pub fn backup_copy_label(self: *const Model) []const u8 {
+        return if (self.backup_copied) "Copied" else "Copy";
+    }
+
+    /// Everything the backup panel was holding, gone. Called when it closes,
+    /// when the account changes, and when the daemon does: a key sitting in a
+    /// window nobody is looking at is the thing this whole app exists to avoid.
+    fn setBackupError(self: *Model, text: []const u8) void {
+        const n = @min(text.len, self.backup_error_buf.len);
+        @memcpy(self.backup_error_buf[0..n], text[0..n]);
+        self.backup_error_len = n;
+    }
+
+    pub fn clearBackup(self: *Model) void {
+        self.backup_showing = false;
+        self.backup_pass.set("");
+        std.crypto.secureZero(u8, &self.backup_key_buf);
+        self.backup_key_len = 0;
+        self.backup_is_raw = false;
+        self.backup_sending = false;
+        self.backup_error_len = 0;
+        self.backup_copied = false;
+    }
+
     pub fn forget_error(self: *const Model) []const u8 {
         return self.forget_error_buf[0..self.forget_error_len];
     }
@@ -721,6 +791,16 @@ pub const Msg = union(enum) {
     sign_out,
     /// The daemon answered the sign-out before exiting.
     lock_done: native_sdk.EffectResponse,
+    reveal_backup,
+    cancel_backup,
+    backup_pass_edit: canvas.TextInputEvent,
+    /// Ask for the encrypted key: still behind the passphrase, safe to keep.
+    export_encrypted,
+    /// Ask for the key in the clear, which is the one that can be stolen.
+    export_secret,
+    backup_done: native_sdk.EffectResponse,
+    copy_backup,
+    backup_copied: native_sdk.EffectClipboardResult,
     forget_edit: canvas.TextInputEvent,
     reveal_forget,
     cancel_forget,
@@ -892,6 +972,32 @@ fn sendForget(model: *Model, fx: *Effects) void {
         .{ .name = "content-type", .value = "application/json" },
     };
     fx.fetch(.{ .key = forget_key, .method = .POST, .url = url, .headers = &headers, .body = body, .timeout_ms = 20_000, .on_response = Effects.responseMsg(.forget_done) });
+}
+
+/// POST /export, the backup.
+///
+/// The passphrase goes with every request, including for the encrypted form
+/// that does not strictly need it: an unlocked daemon is the normal state, and
+/// whoever is at the keyboard then is not necessarily the person who set it up.
+fn sendExport(model: *Model, fx: *Effects, raw: bool) void {
+    if (model.backup_disabled()) return;
+    model.backup_sending = true;
+    model.backup_error_len = 0;
+    model.backup_copied = false;
+    model.backup_is_raw = raw;
+    var url_buf: [128]u8 = undefined;
+    const url = std.fmt.bufPrint(&url_buf, "{s}/export", .{model.baseUrl()}) catch return;
+    var body_buf: [320]u8 = undefined;
+    const Body = struct { passphrase: []const u8, form: []const u8 };
+    const body = std.fmt.bufPrint(&body_buf, "{f}", .{std.json.fmt(Body{
+        .passphrase = model.backup_pass.text(),
+        .form = if (raw) "nsec" else "ncryptsec",
+    }, .{})}) catch return;
+    const headers = [_]std.http.Header{
+        .{ .name = "authorization", .value = model.auth() },
+        .{ .name = "content-type", .value = "application/json" },
+    };
+    fx.fetch(.{ .key = export_key, .method = .POST, .url = url, .headers = &headers, .body = body, .timeout_ms = 20_000, .on_response = Effects.responseMsg(.backup_done) });
 }
 
 /// POST /lock, the sign out.
@@ -1139,6 +1245,51 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         .command_copied_result => |result| {
             if (result.outcome != .ok) return;
             model.command_copied = true;
+        },
+        .reveal_backup => model.backup_showing = true,
+        .cancel_backup => model.clearBackup(),
+        .backup_pass_edit => |e| {
+            model.backup_pass.apply(e);
+            model.backup_error_len = 0;
+        },
+        .export_encrypted => sendExport(model, fx, false),
+        .export_secret => sendExport(model, fx, true),
+        .backup_done => |response| {
+            model.backup_sending = false;
+            if (response.outcome == .ok and response.status == 200) {
+                var buf: [512]u8 = undefined;
+                var fba = std.heap.FixedBufferAllocator.init(&buf);
+                const Body = struct { key: []const u8 = "" };
+                const parsed = std.json.parseFromSliceLeaky(Body, fba.allocator(), response.body, .{ .ignore_unknown_fields = true }) catch {
+                    model.setBackupError("Could not read the answer.");
+                    return;
+                };
+                const key = parsed.key;
+                const n = @min(key.len, model.backup_key_buf.len);
+                @memcpy(model.backup_key_buf[0..n], key[0..n]);
+                model.backup_key_len = n;
+                // The passphrase has done its job. Holding it after the answer
+                // arrives buys nothing and leaves it in a window.
+                model.backup_pass.set("");
+                return;
+            }
+            model.setBackupError(if (response.status == 401)
+                "That passphrase does not match."
+            else
+                "Could not read the key.");
+        },
+        .copy_backup => {
+            const key = model.backup_key();
+            if (key.len == 0) return;
+            fx.writeClipboard(.{
+                .key = clipboard_key,
+                .text = key,
+                .on_result = Effects.clipboardMsg(.backup_copied),
+            });
+        },
+        .backup_copied => |result| {
+            if (result.outcome != .ok) return;
+            model.backup_copied = true;
         },
         .copy_bunker => {
             const uri = model.bunker();


### PR DESCRIPTION
There was no way to get the key out of this app: not the nsec, not the encrypted file, and no instructions either. The screen that removes a key even tells the reader to "make sure you have its nsec written down first", with nothing anywhere that would give them one.

A nostr key cannot be replaced, so a key that cannot leave the Mac holding it is an identity that dies with the Mac.

`POST /export` plus a panel behind "Back up your key". Two forms: the NIP-49 encrypted file exactly as it sits on disk, still useless without the passphrase, and the key in the clear, which says so in red.

The passphrase is required for both, including the encrypted form that does not strictly need it, because an unlocked daemon is the normal state and whoever is at the keyboard then is not necessarily the person who set it up.

Nothing is kept: the passphrase is dropped when the answer arrives, the key is zeroed when the panel closes, the daemon zeroes its copy before answering.

Verified against a live daemon (401 unauthenticated, 401 wrong passphrase, 400 bad form, 200 both good forms) and driven through the running GUI for all three paths.