### PR TITLE
Notice a key imported from a terminal, without a restart

### DIFF
--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -315,7 +315,7 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
     }
 
     if (eql(method, "GET") and eql(path, "/info"))
-        return handleInfo(self, w);
+        return handleInfo(self, io, w);
     if (eql(method, "POST") and eql(path, "/setup"))
         return handleSetup(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/forget"))
@@ -428,7 +428,12 @@ fn handleDecision(self: *Server, w: *std.Io.Writer, body: []const u8) !void {
     return respond(w, 200, j);
 }
 
-fn handleInfo(self: *Server, w: *std.Io.Writer) !void {
+fn handleInfo(self: *Server, io: std.Io, w: *std.Io.Writer) !void {
+    // Ask the disk before answering. This is the poll the window sits on while
+    // it is waiting to be set up or unlocked, so it is the one place that can
+    // notice a key written by `signer import` in a terminal, which by design
+    // cannot reach this process to announce itself.
+    self.gate.rescan(io);
     const state = self.gate.current();
     const state_str = switch (state) {
         .uninitialized => "uninitialized",
@@ -817,9 +822,12 @@ test "GET /info reports the bunker URI once unlocked" {
         .port = 0,
     };
 
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+
     var out = std.Io.Writer.Allocating.init(gpa);
     defer out.deinit();
-    try handleInfo(&server, &out.writer);
+    try handleInfo(&server, threaded.io(), &out.writer);
     var body = out.toArrayList();
     defer body.deinit(gpa);
 
@@ -844,9 +852,12 @@ test "GET /info omits the bunker URI until the key is unlocked" {
         .port = 0,
     };
 
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+
     var out = std.Io.Writer.Allocating.init(gpa);
     defer out.deinit();
-    try handleInfo(&server, &out.writer);
+    try handleInfo(&server, threaded.io(), &out.writer);
     var body = out.toArrayList();
     defer body.deinit(gpa);
 
@@ -874,9 +885,12 @@ test "GET /info reports live per-relay connection status" {
         .port = 0,
     };
 
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+
     var out = std.Io.Writer.Allocating.init(gpa);
     defer out.deinit();
-    try handleInfo(&server, &out.writer);
+    try handleInfo(&server, threaded.io(), &out.writer);
     var body = out.toArrayList();
     defer body.deinit(gpa);
 

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -504,8 +504,10 @@ fn loadSecretKey(gpa: std.mem.Allocator) [32]u8 {
 // `ps` to every process on the machine, which is why this refuses to take one
 // that way at all.
 //
-// If Notary is already running, the key is handed to it over the loopback API
-// so it picks it up live; otherwise it is written for the next launch to find.
+// The key is written for Notary to find, never handed to a running one: the
+// reason is at the write itself. A Notary that is already open notices the file
+// on its next /info poll and asks for the passphrase, so importing no longer
+// costs a relaunch.
 
 fn runImport(gpa: std.mem.Allocator) noreturn {
     var startup = std.Io.Threaded.init(gpa, .{});
@@ -540,9 +542,10 @@ fn runImport(gpa: std.mem.Allocator) noreturn {
     // and tells only the GUI that spawned it which one, so that another process
     // running as this user cannot find the control channel by guessing. A CLI
     // that could reach it would need that port published somewhere readable,
-    // which is exactly the property being protected. So this writes the file
-    // and the reader restarts Notary, which costs a relaunch and gives up
-    // nothing.
+    // which is exactly the property being protected. So this writes the file and
+    // says nothing to anyone. A running Notary finds it on its next /info poll
+    // (`Gate.rescan`) and asks for the passphrase, so the property is kept and
+    // the relaunch it used to cost is not.
     const initial: onboarding.State = if (fileExists(io, key_file)) .locked else .uninitialized;
     var gate = onboarding.Gate.init(gpa, std.Io.Dir.cwd(), key_file, initial);
     gate.setup(io, passphrase, input) catch |err| switch (err) {
@@ -550,7 +553,7 @@ fn runImport(gpa: std.mem.Allocator) noreturn {
         error.InvalidSecretKey => fail("that is not a valid nostr secret key"),
         else => failFmt("could not store the key: {s}", .{@errorName(err)}),
     };
-    std.debug.print("Imported. Start Notary (or restart it) to use it.\n", .{});
+    std.debug.print("Imported. Notary picks it up and asks for this passphrase.\n", .{});
     std.process.exit(0);
 }
 

--- a/daemon/src/onboarding.zig
+++ b/daemon/src/onboarding.zig
@@ -131,6 +131,35 @@ pub const Gate = struct {
         self.publish(kp);
     }
 
+    /// Re-checks the disk for a key file that appeared since boot.
+    ///
+    /// The state is decided once, at startup, from whether the key file is
+    /// there. `signer import` writes that file from a terminal and deliberately
+    /// never speaks to a running daemon: the control port is ephemeral and told
+    /// only to the window that spawned it, precisely so no other process on the
+    /// machine can find it. The cost was that a key imported while Notary was
+    /// open stayed invisible to it until the app was restarted, which is a
+    /// strange thing to ask of somebody who just typed their nsec.
+    ///
+    /// Only ever `uninitialized` -> `locked`. The file is encrypted and the
+    /// passphrase that opens it is not something this can learn, so `locked` is
+    /// the honest destination: the window asks for the passphrase, which is one
+    /// step instead of a relaunch.
+    ///
+    /// Compare-exchange rather than a store, so it can never step on a `setup`
+    /// or an `unlock` publishing a key at the same moment: those move to
+    /// `unlocked`, and this only ever moves away from `uninitialized`.
+    pub fn rescan(self: *Gate, io: std.Io) void {
+        if (self.current() != .uninitialized) return;
+        self.dir.access(io, self.key_file, .{}) catch return;
+        _ = self.state.cmpxchgStrong(
+            @intFromEnum(State.uninitialized),
+            @intFromEnum(State.locked),
+            .release,
+            .monotonic,
+        );
+    }
+
     /// Marks the gate `unlocked` with a key loaded outside the API, used in GUI
     /// mode when the operator preconfigured a key in the environment, so the GUI
     /// skips onboarding. `kp` must already be validated.
@@ -304,4 +333,55 @@ test "unlock decrypts a locked file and rejects a wrong passphrase" {
     try gate.unlock(io, "hunter2");
     try testing.expectEqual(State.unlocked, gate.current());
     try testing.expectEqualSlices(u8, &created_key, &gate.secret_key);
+}
+
+test "rescan notices a key file written while the daemon was running" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // A daemon that booted with no key: this is the window sitting on first-run
+    // setup. Nothing has told it anything since.
+    var gate = Gate.init(gpa, tmp.dir, key_name, .uninitialized);
+    gate.rescan(io);
+    try testing.expectEqual(State.uninitialized, gate.current()); // invents nothing
+
+    // `signer import` in a terminal, which writes the file and by design cannot
+    // reach this process to announce it.
+    var terminal = Gate.init(gpa, tmp.dir, key_name, .uninitialized);
+    try terminal.setup(io, "hunter2", "");
+
+    // The next /info poll is what finds it.
+    gate.rescan(io);
+    try testing.expectEqual(State.locked, gate.current());
+
+    // And the passphrase typed in the terminal opens it, with no restart.
+    try gate.unlock(io, "hunter2");
+    try testing.expectEqual(State.unlocked, gate.current());
+    try testing.expectEqualSlices(u8, &terminal.secret_key, &gate.secret_key);
+}
+
+test "rescan never moves a gate that already holds a key" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // The dangerous direction, and the reason this is a compare-exchange from
+    // `uninitialized` rather than a store: /info is polled while serving too,
+    // and a rescan that could reach an unlocked gate would lock a running
+    // signer out of its own key on a routine status poll.
+    var gate = Gate.init(gpa, tmp.dir, key_name, .uninitialized);
+    try gate.setup(io, "pw", "");
+    try testing.expectEqual(State.unlocked, gate.current());
+
+    gate.rescan(io); // the file it just wrote is right there
+    try testing.expectEqual(State.unlocked, gate.current());
+
+    // A locked gate is left alone too: it is already where a rescan would put
+    // it, and moving it would drop a wrong-passphrase retry back to the start.
+    var locked = Gate.init(gpa, tmp.dir, key_name, .locked);
+    locked.rescan(io);
+    try testing.expectEqual(State.locked, locked.current());
 }

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -1325,10 +1325,26 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         },
 
         .refresh_tick => |t| {
-            // Re-poll /info only while serving and authenticated; otherwise the
-            // connect/retry flow owns /info.
-            if (t.outcome == .fired and model.phase == .connected and model.hasToken())
+            if (t.outcome != .fired or !model.hasToken()) return;
+            // Serving: the live relay status, on the poll that never touches the
+            // phase.
+            if (model.phase == .connected) {
                 refreshInfo(model, fx);
+                return;
+            }
+            // Waiting to be set up or unlocked, and this is the only thing that
+            // ever notices a key arriving from somewhere else. `signer import`
+            // writes the key file from a terminal and deliberately cannot reach
+            // this daemon to announce it, so without asking again the window
+            // sits on "First-run setup" until the app is restarted.
+            //
+            // Through `fetchInfo` rather than `refreshInfo`: the `.info` handler
+            // is the one that picks the screen from the daemon's state, which is
+            // exactly what has to happen here. Not while a passphrase is in
+            // flight, because that response owns the same effect key next.
+            if (model.submitting) return;
+            if (model.phase == .needs_setup or model.phase == .needs_unlock)
+                fetchInfo(model, fx);
         },
         .info_refresh => |r| {
             // Live-status refresh only: update relay status (and bunker); never


### PR DESCRIPTION
`signer import` takes an nsec from a terminal and writes it encrypted, and a Notary that was already open never found out. The window sat on "Set up your signer" until the app was quit and reopened. That is a strange thing to ask of somebody who has just typed their nsec and chosen a passphrase for it.

Two halves were blind, and both had to change.

## The daemon decided once, at boot

The gate's state came from whether the key file existed when the process started, and nothing looked again. `Gate.rescan` asks the disk, and `/info` calls it before answering, because that is the poll the window sits on while it waits to be set up or unlocked.

Only ever `uninitialized` -> `locked`, by compare-exchange rather than a store. The file is encrypted and the passphrase that opens it is not something the daemon can learn, so `locked` is the honest destination. And `/info` is polled while serving too: a rescan that could reach an unlocked gate would lock a running signer out of its own key on a routine status poll. There is a test for that direction specifically.

## The window only asked while it was already serving

`refresh_tick` re-polled `/info` every 3s, guarded on `phase == .connected`, so the two screens that most need to hear about a key never asked again. They ask now, through `fetchInfo` rather than `refreshInfo`, because the `.info` handler is the one that picks the screen from the daemon's state, and that is exactly what has to happen. Skipped while a passphrase is in flight, since that response owns the same effect key next.

## What this deliberately does not do

The import still refuses to talk to a running daemon. That is the property the ephemeral control port exists to protect: it is told only to the window that spawned it, and a CLI that could reach it would need that port published somewhere readable. So the key goes to disk and the daemon finds it there.

The consequence is that this lands on the unlock screen rather than straight into serving. It cannot do better, because opening the file needs the passphrase and nothing can hand it over. That is one passphrase instead of a relaunch, and it was chosen seconds earlier in the same terminal.

## Verified end to end

Against a running app with a throwaway `HOME`, using the SDK's automation rather than an assertion about the widget tree:

1. The window on "Set up your signer".
2. `signer import` in a terminal, which writes the key file and says nothing to anyone.
3. The window moved to "Unlock your signer" in about a second, no restart.
4. Typing the passphrase from the terminal and pressing Unlock served `bunker://dff1d77f…ba659`, which is the key that was imported.

I also put the old blindness back and confirmed `rescan notices a key file written while the daemon was running` went red with `expected .locked, found .uninitialized`, then restored it.

## Also in here

Three comments described the old behaviour, including one at the top of the import CLI claiming the key is handed to a running Notary over the loopback API, which it has never done.

## Checks

Daemon: `zig build`, `zig build test` (39/39), `zig fmt --check .`. GUI: `native check`, `native test` (27/27), `native build`, `zig fmt --check src`.
