### PR TITLE
Notary is 0.9.1

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,16 +1,10 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
-### What's new in v0.9.0
+### What's new in v0.9.1
 
-**You can take a copy of your key.** There was no way to get it out of this app before: not the nsec, not the encrypted file, and no instructions either. The screen that removes a key even told you to make sure you had its nsec written down first, with nothing anywhere that would give you one. A nostr key cannot be replaced, so a key that cannot leave the Mac holding it is an identity that dies with the Mac.
+**A key imported from a terminal no longer needs a restart.** `signer import` takes your nsec from a terminal and stores it encrypted, and a Notary that was already open never found out. The window sat on "Set up your signer" until you quit and reopened the app, which is a strange thing to ask of somebody who has just typed their nsec and chosen a passphrase for it.
 
-Press **Back up your key**, give it the passphrase, and pick one of two forms. The encrypted one is the file as it sits on disk, still useless to anyone without that passphrase, so it is safe to keep in a password manager or on paper. The other is the key itself, and says so in red, because anyone who reads it becomes you and there is no taking it back.
-
-The passphrase is asked for either way, including the encrypted form that does not strictly need it: an unlocked signer is the normal state, and whoever is at the keyboard then is not necessarily the person who set it up.
-
-**Sign out no longer hangs.** It started a second signer without stopping the first, and the first still owned the port, so the new one could never answer. The app sat at "Starting the signer…" until you quit and reopened it, with the old signer still running and still holding your key. Signing out now ends that process and keeps the key, so what comes back asks for your passphrase, which is what signing out was supposed to mean.
-
-**Two screens scroll that did not.** Revealing a key, or opening "use another key" on the lock screen, adds enough to an already-full column that the bottom of it went under the status bar with no way to reach it.
+It notices now, in about a second, and asks for that passphrase. Importing still writes the key to disk rather than handing it to the running app, and that is on purpose: the channel Notary listens on is deliberately hard to find, so nothing else on your Mac can reach it, and a command that could would have to publish where it is. So this lands on the unlock screen rather than straight into serving. One passphrase, instead of a relaunch.
 
 ### Install
 
@@ -20,4 +14,4 @@ curl -fsSL https://raw.githubusercontent.com/zig-nostr/notary/main/scripts/insta
 
 The installer downloads the latest release, verifies its SHA-256, installs `Notary.app` to `/Applications`, and opens it, ready to use.
 
-Notary is ad-hoc signed, not notarized, on purpose: it holds your keys, so the trust anchor is a build you can reproduce, not an Apple signature. Read the [installer](https://github.com/zig-nostr/notary/blob/main/scripts/install-macos.sh) or [build from source](https://github.com/zig-nostr/notary#build). **Your key never leaves the daemon.**
+Notary is ad-hoc signed, not notarized, on purpose: it holds your keys, so the trust anchor is a build you can reproduce, not an Apple signature. Read the [installer](https://github.com/zig-nostr/notary/blob/main/scripts/install-macos.sh) or [build from source](https://github.com/zig-nostr/notary#build). **Your key never leaves the daemon unless you ask for it.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-08-27
+
+### Fixed
+- **A key imported from a terminal no longer needs a restart.** `signer import`
+  takes an nsec from a terminal and writes it encrypted, and a Notary that was
+  already open never found out: the window sat on "Set up your signer" until the
+  app was quit and reopened, which is a strange thing to ask of somebody who has
+  just typed their nsec and chosen a passphrase for it.
+
+  Both halves were blind. The daemon decided its state once, at boot, from
+  whether the key file existed; `Gate.rescan` asks the disk again, and `/info`
+  calls it before answering, because that is the poll the window sits on while it
+  waits. Only ever uninitialized to locked, by compare-exchange: `/info` is polled
+  while serving too, and a rescan that could reach an unlocked gate would lock a
+  running signer out of its own key on a routine status poll. The window, for its
+  part, only re-polled `/info` while already serving, so the two screens that most
+  needed it never asked again.
+
+  The import still refuses to speak to a running daemon, and that stays
+  deliberate: the control port is ephemeral and told only to the window that
+  spawned it, so a CLI able to reach it would need that port published somewhere
+  readable, which is the property being protected. The key goes to disk and the
+  daemon finds it there. So this lands on the unlock screen rather than straight
+  into serving, which is one passphrase instead of a relaunch, and the passphrase
+  was chosen seconds earlier in the same terminal.
+
 ## [0.9.0] - 2026-08-26
 
 ### Added

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.9.0",
+    .version = "0.9.1",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command", "clipboard" },


### PR DESCRIPTION
A key imported from a terminal is picked up without a restart. The change itself is #71.

A patch bump: it repairs what was already meant to work rather than adding anything to the daemon's API.

One thing beyond the bump. The notes template still carried **Your key never leaves the daemon** unqualified. `/export` made that untrue in 0.9.0, and it would have printed on this release page too. It now says *unless you ask for it*, which is the version already on the website and on the 0.9.0 page.