### PR TITLE
Hide the passphrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 
 ## [Unreleased]
 
+### Fixed
+- **The passphrase field no longer shows the passphrase.** Both onboarding
+  screens and the backup panel drew every character in the clear, which is the
+  wrong default for something people type in a cafe, on a call, or into a screen
+  recording. They draw stars now, with an eye beside the field for the times you
+  want to read back what you typed. It starts hidden on every launch, and goes
+  back to hidden after each send.
+
+  The mask is one star per byte rather than a prettier bullet, and that is load
+  bearing rather than lazy: the runtime hands back caret offsets into the string
+  it drew, so a mask exactly as long as the text maps them straight through and
+  the caret lands on the character you clicked. Inserting is the one gesture
+  where the two disagree, and the buffer now follows the drawn caret home rather
+  than quietly typing somewhere you are not looking.
+
+  Hiding it also keeps the characters out of the accessible name the window
+  publishes for that field, which is where anything with accessibility access
+  would have read them.
+
+  One rough edge is left, and it belongs to the toolkit rather than to this
+  change: replacing selected text with exactly as many characters leaves the
+  typed ones on screen until the next keystroke, because the toolkit repaints
+  its own copy of the line whenever the length it was handed has not moved.
+  Reveal the field if you want to edit the middle of a passphrase.
+
 ## [0.9.1] - 2026-08-27
 
 ### Fixed

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -45,7 +45,10 @@
         <column gap="10">
           <text>Back up your key</text>
           <text foreground="text_muted" wrap="true">Two forms. The encrypted one still needs this passphrase to use, so it is safe to keep in a password manager or on paper. The secret one is the key itself: anyone who reads it becomes you, for good.</text>
-          <row><text-field text="{backup_passphrase}" placeholder="Passphrase" on-input="backup_pass_edit" grow="1"/></row>
+          <row gap="8">
+            <text-field text="{shown_backup_passphrase}" placeholder="Passphrase" on-input="backup_pass_edit" grow="1"/>
+            <toggle-button icon="eye" selected="{backup_pass_showing}" label="{backup_pass_toggle_label}" on-toggle="toggle_backup_passphrase"/>
+          </row>
           <row gap="8">
             <button variant="primary" grow="1" on-press="export_encrypted" disabled="{backup_disabled}">Encrypted key</button>
             <button variant="destructive" grow="1" on-press="export_secret" disabled="{backup_disabled}">Secret key</button>
@@ -116,7 +119,10 @@
       <if test="{import_selected}">
         <row><textarea text="{secret}" placeholder="nsec1… or 64-char hex secret key" on-input="secret_edit" grow="1"/></row>
       </if>
-      <row><text-field text="{passphrase}" placeholder="Passphrase (encrypts your key at rest)" on-input="passphrase_edit" on-submit="submit_setup" autofocus="true" grow="1"/></row>
+      <row gap="8">
+        <text-field text="{shown_passphrase}" placeholder="Passphrase (encrypts your key at rest)" on-input="passphrase_edit" on-submit="submit_setup" autofocus="true" grow="1"/>
+        <toggle-button icon="eye" selected="{passphrase_showing}" label="{passphrase_toggle_label}" on-toggle="toggle_passphrase"/>
+      </row>
       <if test="{has_onboard_error}">
         <text foreground="destructive">{onboard_error}</text>
       </if>
@@ -145,7 +151,10 @@
     <column gap="12" padding="20">
       <text size="heading">Unlock your signer</text>
       <text>Enter your passphrase to unlock the signing key.</text>
-      <row><text-field text="{passphrase}" placeholder="Passphrase" on-input="passphrase_edit" on-submit="submit_unlock" autofocus="true" grow="1"/></row>
+      <row gap="8">
+        <text-field text="{shown_passphrase}" placeholder="Passphrase" on-input="passphrase_edit" on-submit="submit_unlock" autofocus="true" grow="1"/>
+        <toggle-button icon="eye" selected="{passphrase_showing}" label="{passphrase_toggle_label}" on-toggle="toggle_passphrase"/>
+      </row>
       <if test="{has_onboard_error}">
         <text foreground="destructive">{onboard_error}</text>
       </if>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -73,6 +73,44 @@ const default_address = "127.0.0.1:8787";
 const import_command = "/Applications/Notary.app/Contents/MacOS/signer import";
 const default_token_file = ".zig-nostr-signer.token";
 
+/// What a hidden passphrase field renders instead of its characters.
+///
+/// One star per BYTE, so the mask is exactly as long as the text it stands
+/// for. That is what keeps the caret honest: every offset the runtime stamps
+/// into an edit event is an offset into the string it drew, and a mask of the
+/// same length maps those straight through to the real buffer. A prettier
+/// bullet would be three bytes wide and every click would land elsewhere.
+const passphrase_stars = [_]u8{'*'} ** 128;
+
+/// The mask for a secret `len` bytes long.
+fn stars(len: usize) []const u8 {
+    return passphrase_stars[0..@min(len, passphrase_stars.len)];
+}
+
+/// Apply one edit to a passphrase buffer, and leave the caret where the field
+/// is actually drawing it.
+///
+/// The runtime keeps its own copy of the text it is editing. A masked field
+/// hands it stars while the real characters go in here, so the two disagree the
+/// moment anything is typed, and the runtime answers that by re-seeding the
+/// drawn caret at the end of the line. Left alone this buffer would keep
+/// inserting where the reader last clicked while the caret they can SEE sits at
+/// the end, so the next keystroke lands somewhere they are not looking. Every
+/// character is a star, so nothing about it looks wrong until the daemon says
+/// the passphrase does not match. Deletions stay in step on their own (both
+/// sides lose one glyph and neither re-seeds), so it is only insertions that
+/// have to follow the caret home.
+fn applyMaskedEdit(buf: *canvas.TextBuffer(128), event: canvas.TextInputEvent, masked: bool) void {
+    buf.apply(event);
+    if (!masked) return;
+    switch (event) {
+        .insert_text, .set_composition, .commit_composition => {
+            buf.selection = canvas.TextSelection.collapsed(buf.text().len);
+        },
+        else => {},
+    }
+}
+
 // Effect keys. Fetch/spawn/file effects share one key space and 16 slots; the
 // long-lived daemon spawn holds one slot for the process's lifetime. Timer
 // keys are their own namespace. Decisions use a small pool so several can be
@@ -300,6 +338,10 @@ pub const Model = struct {
     /// screens. They transit this process once to reach `/setup` or `/unlock`
     /// and are cleared right after a successful send.
     passphrase_buf: canvas.TextBuffer(128) = .{},
+    /// Whether the passphrase field is showing its characters. Off on every
+    /// launch and again after every send: a revealed passphrase is a thing to
+    /// ask for, not a state to be left in.
+    passphrase_showing: bool = false,
     /// A `nostrconnect://` link pasted in from a client that is waiting to be
     /// adopted. Long, because it carries relays, a secret and app metadata.
     nostrconnect_buf: canvas.TextBuffer(512) = .{},
@@ -318,6 +360,8 @@ pub const Model = struct {
     /// way out is: the passphrase field for it should not be sitting open.
     backup_showing: bool = false,
     backup_pass: canvas.TextBuffer(128) = .{},
+    /// The same reveal for the backup panel's passphrase field.
+    backup_pass_showing: bool = false,
     /// The exported key, held only until the reader copies it or closes the
     /// panel. An `ncryptsec1…` unless they asked for the key in the clear.
     backup_key_buf: [256]u8 = [_]u8{0} ** 256,
@@ -492,6 +536,13 @@ pub const Model = struct {
     pub fn backup_passphrase(self: *const Model) []const u8 {
         return self.backup_pass.text();
     }
+    pub fn shown_backup_passphrase(self: *const Model) []const u8 {
+        if (self.backup_pass_showing) return self.backup_pass.text();
+        return stars(self.backup_pass.text().len);
+    }
+    pub fn backup_pass_toggle_label(self: *const Model) []const u8 {
+        return if (self.backup_pass_showing) "Hide the passphrase" else "Show the passphrase";
+    }
     pub fn backup_disabled(self: *const Model) bool {
         return self.backup_sending or self.backup_pass.text().len == 0;
     }
@@ -529,6 +580,7 @@ pub const Model = struct {
     pub fn clearBackup(self: *Model) void {
         self.backup_showing = false;
         self.backup_pass.set("");
+        self.backup_pass_showing = false;
         std.crypto.secureZero(u8, &self.backup_key_buf);
         self.backup_key_len = 0;
         self.backup_is_raw = false;
@@ -560,8 +612,26 @@ pub const Model = struct {
         return self.nostrconnect_error_len > 0;
     }
 
+    /// The two fns that hand out a passphrase in the clear. They fill a
+    /// request body on its way to the daemon and nothing else; the fields draw
+    /// `shown_passphrase` and `shown_backup_passphrase`, which are stars until
+    /// the reader asks to see the characters. Declaring them here is how the
+    /// markup checker is told that going unbound is the point, rather than
+    /// something someone forgot to wire up.
+    pub const view_unbound = .{ "passphrase", "backup_passphrase" };
+
     pub fn passphrase(self: *const Model) []const u8 {
         return self.passphrase_buf.text();
+    }
+    /// What the passphrase FIELD draws. `passphrase` above is what gets sent;
+    /// these two are deliberately separate, so a change to the mask can never
+    /// reach the daemon and a change to the request can never reach the glass.
+    pub fn shown_passphrase(self: *const Model) []const u8 {
+        if (self.passphrase_showing) return self.passphrase_buf.text();
+        return stars(self.passphrase_buf.text().len);
+    }
+    pub fn passphrase_toggle_label(self: *const Model) []const u8 {
+        return if (self.passphrase_showing) "Hide the passphrase" else "Show the passphrase";
     }
     pub fn secret(self: *const Model) []const u8 {
         return self.secret_buf.text();
@@ -747,9 +817,10 @@ pub const Model = struct {
     }
     /// Wipes the passphrase and secret buffers (after a successful send, or when
     /// the daemon goes away).
-    fn clearSecrets(self: *Model) void {
+    pub fn clearSecrets(self: *Model) void {
         self.passphrase_buf.clear();
         self.secret_buf.clear();
+        self.passphrase_showing = false;
     }
 
     pub fn removeRow(self: *Model, id: u64) void {
@@ -803,6 +874,7 @@ pub const Msg = union(enum) {
     reveal_backup,
     cancel_backup,
     backup_pass_edit: canvas.TextInputEvent,
+    toggle_backup_passphrase,
     /// Ask for the encrypted key: still behind the passphrase, safe to keep.
     export_encrypted,
     /// Ask for the key in the clear, which is the one that can be stolen.
@@ -823,6 +895,8 @@ pub const Msg = union(enum) {
 
     // Onboarding (first-run key setup / unlock).
     passphrase_edit: canvas.TextInputEvent,
+    /// Show or hide the passphrase characters.
+    toggle_passphrase,
     secret_edit: canvas.TextInputEvent,
     choose_create,
     choose_import,
@@ -1258,9 +1332,10 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         .reveal_backup => model.backup_showing = true,
         .cancel_backup => model.clearBackup(),
         .backup_pass_edit => |e| {
-            model.backup_pass.apply(e);
+            applyMaskedEdit(&model.backup_pass, e, !model.backup_pass_showing);
             model.backup_error_len = 0;
         },
+        .toggle_backup_passphrase => model.backup_pass_showing = !model.backup_pass_showing,
         .export_encrypted => sendExport(model, fx, false),
         .export_secret => sendExport(model, fx, true),
         .backup_done => |response| {
@@ -1353,7 +1428,8 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         },
 
         // -- onboarding --
-        .passphrase_edit => |e| model.passphrase_buf.apply(e),
+        .passphrase_edit => |e| applyMaskedEdit(&model.passphrase_buf, e, !model.passphrase_showing),
+        .toggle_passphrase => model.passphrase_showing = !model.passphrase_showing,
         .nostrconnect_edit => |e| {
             model.nostrconnect_buf.apply(e);
             model.nostrconnect_error_len = 0;

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -44,6 +44,23 @@ fn expectByText(widget: canvas.Widget, kind: canvas.WidgetKind, text: []const u8
     };
 }
 
+/// The same lookup for an icon-only control, which carries no text: its
+/// accessible label is the only name it has.
+fn findByLabel(widget: canvas.Widget, kind: canvas.WidgetKind, label: []const u8) ?canvas.Widget {
+    if (widget.kind == kind and std.mem.eql(u8, widget.semantics.label, label)) return widget;
+    for (widget.children) |child| {
+        if (findByLabel(child, kind, label)) |found| return found;
+    }
+    return null;
+}
+
+fn expectByLabel(widget: canvas.Widget, kind: canvas.WidgetKind, label: []const u8) !canvas.Widget {
+    return findByLabel(widget, kind, label) orelse {
+        std.debug.print("no {t} labelled \"{s}\" in the view - if you changed app.native, update this test to match\n", .{ kind, label });
+        return error.WidgetNotFound;
+    };
+}
+
 // ------------------------------------------------------------- parsing
 
 test "parseInfo fills the header fields" {
@@ -374,6 +391,139 @@ test "submit is disabled until a passphrase is typed, and while in flight" {
 
     m.submitting = true; // a request in flight re-disables it
     try testing.expect(m.submit_disabled());
+}
+
+test "the passphrase field draws stars, and the daemon still gets the passphrase" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+
+    var model = Model{};
+    model.phase = .needs_unlock;
+    model.passphrase_buf.apply(.{ .insert_text = "hunter2" });
+
+    const tree = try buildTree(arena_state.allocator(), &model);
+
+    // The characters are not on the glass anywhere in the view: not in the
+    // field, not in a stray label built from the same binding.
+    try testing.expect(findByText(tree.root, .text_field, "hunter2") == null);
+    _ = try expectByText(tree.root, .text_field, "*******");
+
+    // What gets sent is untouched. This is the half that would break silently
+    // if the mask were ever applied to the buffer instead of to the drawing.
+    try testing.expectEqualStrings("hunter2", model.passphrase());
+}
+
+test "the reveal toggle shows the characters, and starts off" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+
+    var model = Model{};
+    model.phase = .needs_unlock;
+    model.passphrase_buf.apply(.{ .insert_text = "hunter2" });
+
+    // A fresh model hides. Nothing has to be pressed to get there.
+    try testing.expect(!model.passphrase_showing);
+    try testing.expectEqualStrings("*******", model.shown_passphrase());
+    try testing.expectEqualStrings("Show the passphrase", model.passphrase_toggle_label());
+
+    const hidden = try buildTree(arena_state.allocator(), &model);
+    const eye = try expectByLabel(hidden.root, .toggle_button, "Show the passphrase");
+    switch (hidden.msgForPointer(eye.id, .up).?) {
+        .toggle_passphrase => {},
+        else => return error.WrongMessage,
+    }
+
+    model.passphrase_showing = true;
+    try testing.expectEqualStrings("hunter2", model.shown_passphrase());
+    try testing.expectEqualStrings("Hide the passphrase", model.passphrase_toggle_label());
+
+    const shown = try buildTree(arena_state.allocator(), &model);
+    _ = try expectByText(shown.root, .text_field, "hunter2");
+}
+
+test "the mask is exactly as long as what it covers" {
+    // Not cosmetic. The runtime stamps caret and selection offsets into the
+    // string it DREW, and those offsets are replayed onto the buffer holding
+    // the real text. They only line up while the two are the same length, so a
+    // three-byte bullet in place of the star would put every click on the wrong
+    // character. Multibyte input is the case that proves the rule.
+    var m = Model{};
+    m.passphrase_buf.apply(.{ .insert_text = "hüntér2" });
+    try testing.expectEqual(m.passphrase().len, m.shown_passphrase().len);
+
+    m.backup_pass.apply(.{ .insert_text = "hüntér2" });
+    try testing.expectEqual(m.backup_passphrase().len, m.shown_backup_passphrase().len);
+}
+
+test "typing into a hidden field leaves the caret where the field draws it" {
+    // The runtime edits its OWN copy of what it drew. Once that copy is stars
+    // and this one is characters, an insert makes them disagree and the runtime
+    // puts the drawn caret back at the end of the line. If this buffer kept its
+    // own idea of where it was, the next keystroke would land somewhere the
+    // reader is not looking - and with every character a star, the only symptom
+    // would be the daemon refusing a passphrase they typed correctly.
+    var m = Model{};
+    m.passphrase_buf.apply(.{ .insert_text = "abcdef" });
+    m.passphrase_buf.apply(.{ .set_selection = .{ .anchor = 3, .focus = 3 } });
+
+    main.update(&m, Msg{ .passphrase_edit = .{ .insert_text = "Z" } }, undefined);
+    try testing.expectEqualStrings("abcZdef", m.passphrase());
+    try testing.expectEqual(@as(usize, 7), m.passphrase_buf.selection.focus);
+    try testing.expectEqual(@as(usize, 7), m.passphrase_buf.selection.anchor);
+
+    // Revealed, the drawn text IS this text, so the runtime keeps the caret and
+    // this buffer must keep it too: ordinary mid-string editing comes back.
+    m.passphrase_showing = true;
+    m.passphrase_buf.apply(.{ .set_selection = .{ .anchor = 3, .focus = 3 } });
+    main.update(&m, Msg{ .passphrase_edit = .{ .insert_text = "Y" } }, undefined);
+    try testing.expectEqualStrings("abcYZdef", m.passphrase());
+    try testing.expectEqual(@as(usize, 4), m.passphrase_buf.selection.focus);
+
+    // Deleting never re-seeds: both sides lose one glyph, so the caret stays.
+    m.passphrase_showing = false;
+    m.passphrase_buf.apply(.{ .set_selection = .{ .anchor = 3, .focus = 3 } });
+    main.update(&m, Msg{ .passphrase_edit = .delete_backward }, undefined);
+    try testing.expectEqualStrings("abYZdef", m.passphrase());
+    try testing.expectEqual(@as(usize, 2), m.passphrase_buf.selection.focus);
+}
+
+test "a revealed passphrase does not survive the send, or the panel closing" {
+    var m = Model{};
+    m.passphrase_buf.apply(.{ .insert_text = "hunter2" });
+    m.passphrase_showing = true;
+    m.clearSecrets();
+    try testing.expect(!m.passphrase_showing);
+    try testing.expectEqualStrings("", m.shown_passphrase());
+
+    m.backup_pass.apply(.{ .insert_text = "hunter2" });
+    m.backup_pass_showing = true;
+    m.clearBackup();
+    try testing.expect(!m.backup_pass_showing);
+    try testing.expectEqualStrings("", m.shown_backup_passphrase());
+}
+
+test "the backup panel hides its passphrase too" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+
+    var model = Model{};
+    model.phase = .connected;
+    // The panel lives inside the serving view, so give the model a bunker URI
+    // to be serving with.
+    main.parseInfo(&model, "{\"state\":\"unlocked\",\"bunker\":\"bunker://aabb?relay=wss%3A%2F%2Fr.example\"}");
+    model.backup_showing = true;
+    model.backup_pass.apply(.{ .insert_text = "hunter2" });
+
+    const tree = try buildTree(arena_state.allocator(), &model);
+    try testing.expect(findByText(tree.root, .text_field, "hunter2") == null);
+    _ = try expectByText(tree.root, .text_field, "*******");
+
+    const eye = try expectByLabel(tree.root, .toggle_button, "Show the passphrase");
+    switch (tree.msgForPointer(eye.id, .up).?) {
+        .toggle_backup_passphrase => {},
+        else => return error.WrongMessage,
+    }
+    try testing.expectEqualStrings("hunter2", model.backup_passphrase());
 }
 
 test "the setup screen renders create/import and dispatches submit_setup" {


### PR DESCRIPTION
Fixes the passphrase fields drawing every character in the clear.

Both onboarding screens (setup and unlock) and the backup panel showed the passphrase as you typed it. That is the wrong default for something people type in a cafe, on a call, or into a screen recording, and it also meant the characters went into the accessible name the window publishes for that field, where anything with accessibility access could read them.

### What changed

The three passphrase fields draw stars, with an eye button beside each for reading back what you typed. Hidden on every launch, and hidden again after every send: a revealed passphrase is a thing to ask for, not a state to be left in.

The imported-nsec box is deliberately left in the clear. It is pasted rather than typed, and hiding it would make a bad paste invisible until the signer refuses the key.

### Why one star per byte

The toolkit has no masked entry of its own, so the mask is just a different string handed to the field. One star per byte rather than a nicer looking bullet, because the runtime gives back caret offsets into the string it drew: a mask exactly as long as the text maps those straight through, and a click lands on the character under it. A three-byte bullet would put every click somewhere else.

Insertion is the one gesture where the two sides disagree. The runtime keeps its own copy of the line it is editing; once that copy holds characters and the field is handed stars, it sees them stop matching and puts the drawn caret back at the end. Left alone, the buffer would keep inserting where you last clicked while the caret you can see sits at the end, so the next keystroke lands somewhere you are not looking. Every character is a star, so the only symptom would be the signer refusing a passphrase that was typed correctly. Insertions now follow the drawn caret home. Deletions stay in step by themselves and are left alone.

### Verified

Driven live against a running window, not just asserted in tests:

- typed into the masked field, checked the published widget reads `*******` and not the characters
- pressed the eye, checked it reads back and the label flips
- arrow-keyed into the middle of a hidden field, typed, revealed: the character landed under the caret
- the same scenario before the caret fix put the second keystroke in the wrong place, which is what the fix is for

Six new tests, and each was checked by removing the thing it guards and watching the named test go red: unmasking the accessor, swapping the byte mask for a per-character one, and dropping the caret rule.

### Known rough edge

Replacing selected text with exactly as many characters leaves the typed ones on screen until the next keystroke. The toolkit repaints its own copy of the line whenever the length it was handed has not moved, and an app cannot declare a selection to head that off. Revealing the field is the way to edit the middle of a passphrase. Noted in the changelog rather than papered over.
