### PR TITLE
Notary signs for the apps on this machine, and can be shared

### DIFF
--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.12.1.tar.gz",
-            .hash = "nostr-0.12.1-CMyPzX98CADZMimOV1o3LZF5tmbKcsNGdB_2cYby9Mkt",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.12.2.tar.gz",
+            .hash = "nostr-0.12.2-CMyPzbCNCADKsHa5sjfrIuubspCP-af9WeBAply59UIO",
         },
     },
     .paths = .{

--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.12.0.tar.gz",
-            .hash = "nostr-0.12.0-CMyPzRFwCACA_5_8Tk5io0a4RjCbvAeT-vzJPuf-UBqb",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.12.1.tar.gz",
+            .hash = "nostr-0.12.1-CMyPzX98CADZMimOV1o3LZF5tmbKcsNGdB_2cYby9Mkt",
         },
     },
     .paths = .{

--- a/daemon/src/approval.zig
+++ b/daemon/src/approval.zig
@@ -19,6 +19,7 @@
 
 const std = @import("std");
 const nostr = @import("nostr");
+const audit = @import("audit.zig");
 const PolicyConfig = nostr.nip46.PolicyConfig;
 
 const nip46 = nostr.nip46;
@@ -329,6 +330,8 @@ pub const Interactive = struct {
     config: *const PolicyConfig,
     io: std.Io,
     gpa: std.mem.Allocator,
+    /// Where uses of the key are written down. Null writes nothing.
+    log: ?*audit.Log = null,
 
     pub fn asPolicy(self: *const Interactive) nip46.Policy {
         return .{ .ctx = @constCast(self), .decideFn = &decide };
@@ -380,6 +383,7 @@ fn decide(ctx: ?*anyopaque, request: *const nip46.Request, client: [32]u8) nip46
     const kind: i32 = if (nostr.nip46.signEventKind(self.gpa, request)) |k| @intCast(k) else -1;
     const now_ms = std.Io.Timestamp.now(self.io, .real).toMilliseconds();
     if (self.broker.permissions.remembered(client, method, kind, now_ms)) |allowed| {
+        noteRelay(self, client, method, kind, if (allowed) "ok" else "refused");
         return if (allowed) .approve else .reject;
     }
 
@@ -405,10 +409,37 @@ fn decide(ctx: ?*anyopaque, request: *const nip46.Request, client: [32]u8) nip46
     // away said nothing, and storing silence as a denial would lock a client
     // out over an absence.
     const answered = self.broker.submitRemembering(self.io, info);
+    // A request nobody answered is not a refusal, and the log says so. That
+    // difference is the whole reason a timeout is not written down as one.
+    noteRelay(self, client, method, kind, switch (answered.decision) {
+        .approve => "ok",
+        .pending => "unanswered",
+        .reject => "refused",
+    });
     return switch (answered.decision) {
         .approve => .approve,
         else => .reject,
     };
+}
+
+/// Writes down what a request that arrived over a relay was allowed to do.
+///
+/// By pubkey, and `local` false, because this one is proof: whoever sent it
+/// signed it with that key. The line an app on this machine gets carries a
+/// name it chose, and the two must not read alike in the record any more than
+/// they do on the screen.
+fn noteRelay(self: *const Interactive, client: [32]u8, method: nip46.Method, kind: i32, outcome: []const u8) void {
+    const l = self.log orelse return;
+    var who: [64]u8 = undefined;
+    _ = std.fmt.bufPrint(&who, "{x}", .{client}) catch return;
+    l.note(self.io, std.Io.Timestamp.now(self.io, .real).toSeconds(), .{
+        .what = "sign",
+        .outcome = outcome,
+        .who = &who,
+        .local = false,
+        .method = method.name(),
+        .kind = kind,
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/daemon/src/approval.zig
+++ b/daemon/src/approval.zig
@@ -43,6 +43,15 @@ pub const Pending = struct {
     /// queue exists.
     client_buf: [64]u8 = [_]u8{0} ** 64,
     client_len: u8 = 0,
+    /// The 32 bytes this client's answers are filed under.
+    ///
+    /// Carried rather than parsed back out of `client_buf`, because the
+    /// display string and the key are not the same thing and only one of them
+    /// is always hex. A client on this machine shows a name it chose.
+    client_id: [32]u8 = [_]u8{0} ** 32,
+    /// The method as the permission store spells it, parsed once by the caller
+    /// that already had to parse it.
+    method_id: nip46.Method = .sign_event,
     /// What is being signed: the start of the event's content, for `sign_event`.
     ///
     /// The kind number says what SHAPE it is, never what it says. Approving a
@@ -209,28 +218,43 @@ pub const Broker = struct {
 
     /// Applies the GUI's decision to pending entry `id`. Returns true if it was
     /// found and still pending.
-    pub fn resolve(self: *Broker, id: u64, decision: Decision) bool {
-        return self.resolveFor(id, decision, .once);
+    pub fn resolve(self: *Broker, id: u64, decision: Decision, now_ms: i64) bool {
+        return self.resolveFor(id, decision, .once, now_ms);
     }
 
     /// The same, with how long the answer should last.
-    pub fn resolveFor(self: *Broker, id: u64, decision: Decision, how_long: nip46.Remember) bool {
+    ///
+    /// The answer is written down HERE, at the moment it is given, rather than
+    /// by whoever was waiting for it. "Allow for an hour" runs from when the
+    /// person said it, not from when the request arrived, and those differ by
+    /// however long they took to read the row. On a queue whose whole purpose
+    /// is to be read carefully, that difference is the reading.
+    ///
+    /// A request nobody answered never reaches here at all, which is how a
+    /// timeout stays an open question instead of hardening into a refusal.
+    pub fn resolveFor(self: *Broker, id: u64, decision: Decision, how_long: nip46.Remember, now_ms: i64) bool {
         if (decision == .pending) return false;
         self.acquire();
         var found = false;
+        var info: Pending = .{};
         for (&self.slots) |*slot| {
             if (slot.in_use and slot.info.id == id and slot.decision.load(.monotonic) == .pending) {
                 // The duration first, so a thread waking on the decision cannot
                 // read a remember value that has not been written yet.
                 slot.remember = how_long;
                 slot.decision.store(decision, .release);
+                info = slot.info;
                 found = true;
                 break;
             }
         }
         self.release();
-        if (found) _ = self.version.fetchAdd(1, .monotonic);
-        return found;
+        if (!found) return false;
+        _ = self.version.fetchAdd(1, .monotonic);
+        // Outside the broker's lock. The permission store has its own, and
+        // nesting two hand-rolled locks is how a daemon stops answering.
+        self.permissions.remember(info.client_id, info.method_id, info.kind, decision == .approve, how_long, now_ms);
+        return true;
     }
 };
 
@@ -307,15 +331,17 @@ fn decide(ctx: ?*anyopaque, request: *const nip46.Request, client: [32]u8) nip46
     info.client_len = 64;
     // Both already read above, for the permission lookup.
     info.kind = kind;
+    info.client_id = client;
+    info.method_id = method;
     if (method == .sign_event) {
         info.preview_len = signEventPreview(self.gpa, request, &info.preview_buf);
     }
 
+    // What the operator said is written down by `resolveFor`, when they say it.
+    // Nothing is written for a request nobody answered: an operator who walked
+    // away said nothing, and storing silence as a denial would lock a client
+    // out over an absence.
     const answered = self.broker.submitRemembering(self.io, info);
-    // `.once` is never written down, which is how a timeout leaves the question
-    // open: an operator who walked away from the machine said nothing, and
-    // storing silence as a denial would lock a client out over an absence.
-    self.broker.permissions.remember(client, method, kind, answered.decision == .approve, answered.remember, now_ms);
     return switch (answered.decision) {
         .approve => .approve,
         else => .reject,
@@ -329,13 +355,24 @@ fn decide(ctx: ?*anyopaque, request: *const nip46.Request, client: [32]u8) nip46
 
 const testing = std.testing;
 
+/// Wall-clock milliseconds, the way the GUI's own thread reads them.
+///
+/// Real time rather than a fixed number, because the policy under test reads
+/// real time too, and an answer stamped in some other era either lapses on
+/// arrival or never lapses at all.
+fn testNow() i64 {
+    var threaded = std.Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    return std.Io.Timestamp.now(threaded.io(), .real).toMilliseconds();
+}
+
 /// Stand-in for the GUI: waits for one pending entry, then resolves it.
 fn resolveFirstFor(broker: *Broker, decision: Decision, how_long: nip46.Remember) void {
     var buf: [4]Pending = undefined;
     var tries: usize = 0;
     while (tries < 1_000_000) : (tries += 1) {
         if (broker.snapshot(&buf) > 0) {
-            _ = broker.resolveFor(buf[0].id, decision, how_long);
+            _ = broker.resolveFor(buf[0].id, decision, how_long, testNow());
             return;
         }
         std.Thread.yield() catch {};
@@ -347,7 +384,7 @@ fn resolveFirst(broker: *Broker, decision: Decision) void {
     var tries: usize = 0;
     while (tries < 1_000_000) : (tries += 1) {
         if (broker.snapshot(&buf) > 0) {
-            _ = broker.resolve(buf[0].id, decision);
+            _ = broker.resolve(buf[0].id, decision, testNow());
             return;
         }
         std.Thread.yield() catch {};

--- a/daemon/src/approval.zig
+++ b/daemon/src/approval.zig
@@ -141,11 +141,20 @@ pub const Broker = struct {
     timeout_ms: u64 = 120_000,
     /// What the operator has already answered, and for how long.
     ///
-    /// The library's, shared with Plaza's signer so the two cannot drift on what
-    /// a permission means. Until this, Notary prompted for every request
-    /// forever: there was no way to say "always allow this app to post notes"
-    /// and no way to say "stop asking", which is the prompt fatigue that teaches
-    /// people to approve without reading.
+    /// The library's, so no product carries a second idea of what a permission
+    /// means. Before it, Notary prompted for every request forever: there was
+    /// no way to say "let this app post notes" and no way to say "stop
+    /// asking", which is the prompt fatigue that teaches people to approve
+    /// without reading.
+    ///
+    /// IN MEMORY, and nothing writes it down, which is why the longest answer
+    /// the window offers reads "until locked" rather than "always". That is
+    /// not an omission waiting to be filled in with a file. A file of
+    /// permissions is a file that grants signing, and anything running as this
+    /// user could add itself a line and never be asked again, which turns the
+    /// operator's attention from the last defence into no defence at all.
+    /// Persisting these means binding them to the key, not writing them beside
+    /// it.
     permissions: nip46.Permissions = .{},
 
     fn acquire(self: *Broker) void {

--- a/daemon/src/approval.zig
+++ b/daemon/src/approval.zig
@@ -196,7 +196,19 @@ pub const Broker = struct {
     /// Persisting these means binding them to the key, not writing them beside
     /// it.
     permissions: nip46.Permissions = .{},
+    /// When this daemon last did something for somebody, in milliseconds.
+    ///
+    /// Lives here rather than on the loopback server because BOTH ways in have
+    /// to wind it. It was on the server, counting only local traffic, which
+    /// meant a daemon serving a phone over relays with no window open looked
+    /// idle no matter how much signing it was doing, and would clock out in the
+    /// middle of it. Relays are the other half of what this daemon is for.
+    last_request_ms: std.atomic.Value(i64) = .init(0),
     one_shots: [8]OneShot = [_]OneShot{.{}} ** 8,
+
+    pub fn touch(self: *Broker, now_ms: i64) void {
+        self.last_request_ms.store(now_ms, .monotonic);
+    }
 
     fn acquire(self: *Broker) void {
         while (self.lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) {
@@ -316,7 +328,11 @@ pub const Broker = struct {
     /// Deduplicated on exactly what an answer covers, because a client that
     /// retries every second would otherwise fill all thirty-two slots with one
     /// question inside a minute, and bury every other app's under it.
-    pub fn knock(self: *Broker, info: Pending) bool {
+    /// Says whether this call FILED the question or found it already there.
+    /// The caller uses that to decide whether anything is worth writing down:
+    /// a retry is not news, and a client whose every retry produced a line
+    /// could roll the audit log away simply by asking often enough.
+    pub fn knock(self: *Broker, info: Pending) Knock {
         self.acquire();
         for (&self.slots) |*slot| {
             if (!slot.in_use or slot.decision.load(.monotonic) != .pending) continue;
@@ -325,11 +341,41 @@ pub const Broker = struct {
                 std.mem.eql(u8, &slot.info.client_id, &info.client_id))
             {
                 self.release();
-                return true;
+                return .already_asked;
             }
         }
         self.release();
-        return self.claim(info, false) != null;
+        return if (self.claim(info, false) != null) .filed else .no_room;
+    }
+
+    pub const Knock = enum { filed, already_asked, no_room };
+
+    /// Drops questions from the local protocol that nobody has answered.
+    ///
+    /// A relay request cannot leave one behind: the thread that asked is
+    /// parked on the slot and frees it when the broker times out. A local one
+    /// has nobody, so an unanswered question stayed in the queue for good, and
+    /// thirty-two of them filled it permanently. An app can raise a distinct
+    /// question per event KIND, so getting there costs one badly-behaved app a
+    /// few seconds, and once the queue is full nothing else can be asked about
+    /// either, relay requests included: the signer stops asking and starts
+    /// refusing.
+    ///
+    /// The same clock a waiting relay thread uses, so both kinds of question
+    /// have the same patience.
+    pub fn expireUnanswered(self: *Broker, now_s: i64) void {
+        const limit_s = @as(i64, @intCast(self.timeout_ms / 1000));
+        self.acquire();
+        var dropped = false;
+        for (&self.slots) |*slot| {
+            if (!slot.in_use or slot.waiter) continue;
+            if (slot.decision.load(.monotonic) != .pending) continue;
+            if (now_s - slot.info.created_at < limit_s) continue;
+            slot.in_use = false;
+            dropped = true;
+        }
+        self.release();
+        if (dropped) _ = self.version.fetchAdd(1, .monotonic);
     }
 
     fn claim(self: *Broker, info: Pending, waiter: bool) ?usize {
@@ -476,12 +522,29 @@ fn touchesKey(method_name: []const u8) bool {
 fn decide(ctx: ?*anyopaque, request: *const nip46.Request, client: [32]u8) nip46.Decision {
     const self: *const Interactive = @ptrCast(@alignCast(ctx.?));
 
+    // Somebody is using this daemon, even though nothing on this machine is.
+    // Without it a bunker serving a phone reads as abandoned and clocks out
+    // mid-conversation.
+    self.broker.touch(std.Io.Timestamp.now(self.io, .awake).toMilliseconds());
+
     // The static allowlist is the first gate: a disallowed request is denied
     // outright and never bothers the human.
     if (self.config.policy().decide(request, client) == .reject) return .reject;
 
     // Only a request that uses the key is worth waking somebody up for.
     if (!touchesKey(request.method)) return .approve;
+
+    // Kinds 14 and 15 are the UNSIGNED rumors inside a NIP-59 gift wrap, and a
+    // signature on one destroys the deniability the whole scheme exists for.
+    // The local protocol refused them from the day it was written; this side
+    // did not, so a client that reached the same key over a relay could still
+    // ask, and the answer was a prompt rather than a refusal. Refused before
+    // the human, because it is not a judgement call: there is no circumstance
+    // in which the right answer is yes, and putting it on the queue teaches
+    // somebody to approve the one request that should never have been shown.
+    if (nostr.nip46.signEventKind(self.gpa, request)) |k| {
+        if (k == 14 or k == 15) return .reject;
+    }
 
     // Already answered, and the answer has not lapsed. This is what stops
     // Notary asking about the same thing forever: the operator says "always" or
@@ -840,7 +903,7 @@ test "answered local questions do not fill the queue for good" {
     for (0..Broker.capacity * 2) |i| {
         var info = Pending{ .local = true, .kind = @intCast(i), .method_id = .sign_event };
         info.client_id = [_]u8{7} ** 32;
-        try testing.expect(broker.knock(info));
+        try testing.expectEqual(Broker.Knock.filed, broker.knock(info));
         // One at a time, so a slot that was not freed is the only way to run out.
         try testing.expectEqual(@as(usize, 1), broker.snapshot(&q));
         // `.once` is never written down, so every turn is a fresh question
@@ -848,4 +911,89 @@ test "answered local questions do not fill the queue for good" {
         try testing.expect(broker.resolveFor(q[0].id, .reject, .once, 0));
         try testing.expectEqual(@as(usize, 0), broker.snapshot(&q));
     }
+}
+
+test "one app cannot fill the queue and stop every other question" {
+    // A local question has nobody parked on it to time it out, so it stayed in
+    // the queue for good. An app raises a distinct question per event KIND, so
+    // thirty-two of them costs a badly-behaved app a few seconds, and once the
+    // queue is full nothing can be asked about at all: relay requests included,
+    // because they share these slots. The signer stops asking and starts
+    // refusing, which looks exactly like a signer that is working.
+    var broker = Broker{ .timeout_ms = 120_000 };
+    const start: i64 = 1_700_000_000;
+
+    for (0..Broker.capacity) |i| {
+        var info = Pending{
+            .local = true,
+            .kind = @intCast(i),
+            .method_id = .sign_event,
+            .client_id = [_]u8{9} ** 32,
+            .created_at = start,
+        };
+        info.client_len = 0;
+        try testing.expectEqual(Broker.Knock.filed, broker.knock(info));
+    }
+
+    // Full, and a relay request cannot get in. This is the wedge.
+    var q: [Broker.capacity]Pending = undefined;
+    try testing.expectEqual(Broker.capacity, broker.snapshot(&q));
+    const relay = Pending{ .kind = 1, .method_id = .sign_event, .client_id = [_]u8{1} ** 32, .created_at = start };
+    try testing.expectEqual(Broker.Knock.no_room, broker.knock(relay));
+
+    // Nothing expires before the same patience a waiting relay thread gets.
+    broker.expireUnanswered(start + 119);
+    try testing.expectEqual(Broker.capacity, broker.snapshot(&q));
+
+    // And then they all go, because nobody answered any of them.
+    broker.expireUnanswered(start + 120);
+    try testing.expectEqual(@as(usize, 0), broker.snapshot(&q));
+    try testing.expectEqual(Broker.Knock.filed, broker.knock(relay));
+}
+
+test "a question somebody is waiting on is never expired out from under them" {
+    // The relay path frees its own slots when the broker times out, and that
+    // thread is still parked reading the decision off this slot. Dropping it
+    // here would hand the same slot to somebody else while a relay thread is
+    // still looking at it.
+    var broker = Broker{ .timeout_ms = 1000 };
+    const start: i64 = 1_700_000_000;
+    const idx = broker.claim(.{ .kind = 1, .created_at = start }, true).?;
+    broker.expireUnanswered(start + 10_000);
+    try testing.expect(broker.slots[idx].in_use);
+}
+
+test "a gift-wrap rumor is refused over a relay too, without asking anybody" {
+    // The local protocol refused kinds 14 and 15 from the day it was written.
+    // This side did not, so a client that reached the same key over a relay
+    // could still ask for one, and what it got was a PROMPT. That is worse
+    // than a hole: it teaches somebody to approve the one request that should
+    // never have been shown to them.
+    var threaded = std.Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var broker = Broker{ .timeout_ms = 400 };
+    var cfg = PolicyConfig{ .gpa = testing.allocator };
+    const inter = Interactive{ .broker = &broker, .config = &cfg, .io = io, .gpa = testing.allocator };
+    const p = inter.asPolicy();
+    const client = [_]u8{4} ** 32;
+
+    for ([_]u16{ 14, 15 }) |kind| {
+        var buf: [128]u8 = undefined;
+        const tmpl = try std.fmt.bufPrint(&buf, "{{\"kind\":{d},\"content\":\"hi\",\"tags\":[],\"created_at\":1}}", .{kind});
+        const req = nip46.Request{ .id = "1", .method = "sign_event", .params = &[_][]const u8{tmpl} };
+        const before = broker.version.load(.monotonic);
+        try testing.expectEqual(nip46.Decision.reject, p.decide(&req, client));
+        // And nobody was woken up about it.
+        try testing.expectEqual(before, broker.version.load(.monotonic));
+    }
+
+    // An ordinary note still reaches the queue, so this is a refusal of two
+    // kinds rather than of signing.
+    const ok_tmpl = "{\"kind\":1,\"content\":\"hi\",\"tags\":[],\"created_at\":1}";
+    const ok_req = nip46.Request{ .id = "2", .method = "sign_event", .params = &[_][]const u8{ok_tmpl} };
+    const before = broker.version.load(.monotonic);
+    _ = p.decide(&ok_req, client); // times out into a reject; the queue is the point
+    try testing.expect(broker.version.load(.monotonic) != before);
 }

--- a/daemon/src/approval.zig
+++ b/daemon/src/approval.zig
@@ -131,6 +131,45 @@ pub const Broker = struct {
     /// Max simultaneously-pending approvals; further submits fail closed.
     pub const capacity = 32;
 
+    /// An answer given ONCE, to a request that had nobody waiting for it.
+    ///
+    /// "Allow once" is the safest thing a person can press and it was the one
+    /// button that did nothing. `Remember.once` is deliberately never written
+    /// to the permission store, because on the relay path the thread that
+    /// asked is parked on the slot and reads the decision straight off it: the
+    /// answer covered that request, and there is nothing to remember.
+    ///
+    /// A local request has no such thread. It was refused the moment it
+    /// arrived and the app was told to ask again, so the ONLY way an answer
+    /// can reach it is through this daemon's memory. With `.once` storing
+    /// nothing, the retry found nothing, was refused again, and queued another
+    /// identical question. Pressing the primary button re-prompted forever and
+    /// no local app could ever sign; only "For a day" and "Until locked"
+    /// worked.
+    ///
+    /// So a `.once` answer is held right here until the retry collects it, and
+    /// collecting it destroys it. That is what "once" means, and it is now
+    /// true on both paths instead of one.
+    const OneShot = struct {
+        used: bool = false,
+        client: [32]u8 = [_]u8{0} ** 32,
+        method: nip46.Method = .sign_event,
+        kind: i32 = -1,
+        allow: bool = false,
+        /// When it was given. An answer nobody came back for is not kept: the
+        /// app that asked may have been closed between the question and the
+        /// answer, and an allow left lying around would be spent by whatever
+        /// asked next.
+        at_ms: i64 = 0,
+    };
+
+    /// How long an uncollected one-shot answer stands.
+    ///
+    /// Long enough for a client that retries on a human timescale, short
+    /// enough that an answer given to an app that has since quit is gone
+    /// before anything else can pick it up.
+    pub const one_shot_ms: i64 = 60 * 1000;
+
     lock: std.atomic.Value(bool) = .init(false),
     slots: [capacity]Slot = [_]Slot{.{}} ** capacity,
     next_id: u64 = 1,
@@ -139,6 +178,7 @@ pub const Broker = struct {
     /// Milliseconds a submitted request waits before it is auto-denied when no
     /// GUI resolves it.
     timeout_ms: u64 = 120_000,
+
     /// What the operator has already answered, and for how long.
     ///
     /// The library's, so no product carries a second idea of what a permission
@@ -156,6 +196,7 @@ pub const Broker = struct {
     /// Persisting these means binding them to the key, not writing them beside
     /// it.
     permissions: nip46.Permissions = .{},
+    one_shots: [8]OneShot = [_]OneShot{.{}} ** 8,
 
     fn acquire(self: *Broker) void {
         while (self.lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) {
@@ -202,6 +243,59 @@ pub const Broker = struct {
         _ = self.version.fetchAdd(1, .monotonic);
         if (final == .pending) return .{ .decision = .reject, .remember = .once };
         return .{ .decision = final, .remember = how_long };
+    }
+
+    /// Holds a `.once` answer until the request that prompted it comes back.
+    ///
+    /// The oldest is overwritten when full. Eight is far more than the number
+    /// of questions a person can have answered in the last minute, and an
+    /// answer that old has already been collected or abandoned.
+    fn keepOneShot(self: *Broker, info: Pending, allow: bool, now_ms: i64) void {
+        self.acquire();
+        defer self.release();
+        var pick: usize = 0;
+        for (&self.one_shots, 0..) |*g, i| {
+            if (!g.used or !liveOneShot(g, now_ms)) {
+                pick = i;
+                break;
+            }
+            if (g.at_ms < self.one_shots[pick].at_ms) pick = i;
+        }
+        self.one_shots[pick] = .{
+            .used = true,
+            .client = info.client_id,
+            .method = info.method_id,
+            .kind = info.kind,
+            .allow = allow,
+            .at_ms = now_ms,
+        };
+    }
+
+    /// Collects a `.once` answer, and SPENDS it.
+    ///
+    /// Null when there is none, which is the caller's cue to consult what was
+    /// remembered instead. Taking it destroys it, because that is the whole of
+    /// what "once" means: the next request is a fresh question.
+    pub fn takeOneShot(self: *Broker, client: [32]u8, method: nip46.Method, kind: i32, now_ms: i64) ?bool {
+        self.acquire();
+        defer self.release();
+        for (&self.one_shots) |*g| {
+            if (!g.used) continue;
+            if (!liveOneShot(g, now_ms)) {
+                g.* = .{};
+                continue;
+            }
+            if (g.method != method or g.kind != kind) continue;
+            if (!std.mem.eql(u8, &g.client, &client)) continue;
+            const allow = g.allow;
+            g.* = .{};
+            return allow;
+        }
+        return null;
+    }
+
+    fn liveOneShot(g: *const OneShot, now_ms: i64) bool {
+        return now_ms - g.at_ms < one_shot_ms;
     }
 
     /// Puts a question on the queue for a request that is NOT waiting for the
@@ -306,6 +400,7 @@ pub const Broker = struct {
         if (decision == .pending) return false;
         self.acquire();
         var found = false;
+        var had_waiter = true;
         var info: Pending = .{};
         for (&self.slots) |*slot| {
             if (slot.in_use and slot.info.id == id and slot.decision.load(.monotonic) == .pending) {
@@ -314,6 +409,7 @@ pub const Broker = struct {
                 slot.remember = how_long;
                 slot.decision.store(decision, .release);
                 info = slot.info;
+                had_waiter = slot.waiter;
                 // Nobody is coming to collect this one. Left in use it would
                 // hold a slot forever, and there are thirty-two of them.
                 if (!slot.waiter) slot.in_use = false;
@@ -326,7 +422,13 @@ pub const Broker = struct {
         _ = self.version.fetchAdd(1, .monotonic);
         // Outside the broker's lock. The permission store has its own, and
         // nesting two hand-rolled locks is how a daemon stops answering.
-        self.permissions.remember(info.client_id, info.method_id, info.kind, decision == .approve, how_long, now_ms);
+        if (how_long == .once and !had_waiter) {
+            // Nobody is parked on this one to read the answer off the slot, so
+            // "once" has to be kept somewhere until the retry collects it.
+            self.keepOneShot(info, decision == .approve, now_ms);
+        } else {
+            self.permissions.remember(info.client_id, info.method_id, info.kind, decision == .approve, how_long, now_ms);
+        }
         return true;
     }
 };

--- a/daemon/src/approval.zig
+++ b/daemon/src/approval.zig
@@ -52,6 +52,14 @@ pub const Pending = struct {
     /// The method as the permission store spells it, parsed once by the caller
     /// that already had to parse it.
     method_id: nip46.Method = .sign_event,
+    /// Whether `client_buf` is a name an app on this machine chose for itself,
+    /// rather than the pubkey of whoever signed a request that came over a
+    /// relay.
+    ///
+    /// The two look nothing alike and mean nothing alike, and a person deciding
+    /// whether to allow a signature has to be told which one they are reading.
+    /// A relay client proved it holds a key. A local one typed a word.
+    local: bool = false,
     /// What is being signed: the start of the event's content, for `sign_event`.
     ///
     /// The kind number says what SHAPE it is, never what it says. Approving a
@@ -84,7 +92,17 @@ fn signEventPreview(gpa: std.mem.Allocator, request: *const nip46.Request, out: 
         .{ .ignore_unknown_fields = true },
     ) catch return 0;
     defer parsed.deinit();
-    const text = std.mem.trim(u8, parsed.value.content, " \t\r\n");
+    return previewOf(parsed.value.content, out);
+}
+
+/// The same clip, for a caller that already holds the text.
+///
+/// One implementation, because the rule it enforces is not obvious and a second
+/// copy would be the copy that forgets it: a preview is cut on a character
+/// boundary, since half a UTF-8 sequence is not a character and this string
+/// goes into a JSON response and then onto a screen.
+pub fn previewOf(text_in: []const u8, out: *[160]u8) u8 {
+    const text = std.mem.trim(u8, text_in, " \t\r\n");
     var n = @min(text.len, out.len);
     while (n > 0 and n < text.len and (text[n] & 0xc0) == 0x80) n -= 1;
     @memcpy(out[0..n], text[0..n]);
@@ -98,6 +116,14 @@ const Slot = struct {
     /// How long the operator's answer should last. Written under the lock
     /// before the decision is published, and read after it.
     remember: nip46.Remember = .once,
+    /// Whether a thread is parked on this slot waiting for the answer.
+    ///
+    /// True for a request that arrived over a relay: that thread is inside
+    /// `submitRemembering` and frees the slot on its way out. False for one
+    /// that arrived over the local protocol, which was answered the moment it
+    /// was asked and left this behind as a question for a person. Nothing is
+    /// coming back for that one, so `resolveFor` frees it.
+    waiter: bool = true,
 };
 
 pub const Broker = struct {
@@ -144,7 +170,7 @@ pub const Broker = struct {
     pub const Answered = struct { decision: Decision, remember: nip46.Remember };
 
     pub fn submitRemembering(self: *Broker, io: std.Io, info: Pending) Answered {
-        const idx = self.claim(info) orelse return .{ .decision = .reject, .remember = .once };
+        const idx = self.claim(info, true) orelse return .{ .decision = .reject, .remember = .once };
 
         // Poll the decision slot, pacing with io.sleep (as the reconnect loop
         // does). Elapsed time is counted in sleep steps, no wall clock needed.
@@ -168,12 +194,46 @@ pub const Broker = struct {
         return .{ .decision = final, .remember = how_long };
     }
 
-    fn claim(self: *Broker, info: Pending) ?usize {
+    /// Puts a question on the queue for a request that is NOT waiting for the
+    /// answer, and says whether it is now there.
+    ///
+    /// The local protocol cannot wait. `submitRemembering` parks the calling
+    /// thread for up to the full approval timeout, and on the loopback server
+    /// that thread is one of eight, so eight unanswered local requests take
+    /// every handler the server has. The GUI polls the queue over that same
+    /// server, so it could no longer fetch the very questions it was being
+    /// asked to answer, and no answer could arrive to release anything. That is
+    /// not a slow path, it is a signer that has stopped, and reaching it costs
+    /// an attacker eight requests.
+    ///
+    /// So the request is refused now and the question is left here. The client
+    /// asks again; by then a person may have answered.
+    ///
+    /// Deduplicated on exactly what an answer covers, because a client that
+    /// retries every second would otherwise fill all thirty-two slots with one
+    /// question inside a minute, and bury every other app's under it.
+    pub fn knock(self: *Broker, info: Pending) bool {
+        self.acquire();
+        for (&self.slots) |*slot| {
+            if (!slot.in_use or slot.decision.load(.monotonic) != .pending) continue;
+            if (slot.info.local == info.local and slot.info.method_id == info.method_id and
+                slot.info.kind == info.kind and
+                std.mem.eql(u8, &slot.info.client_id, &info.client_id))
+            {
+                self.release();
+                return true;
+            }
+        }
+        self.release();
+        return self.claim(info, false) != null;
+    }
+
+    fn claim(self: *Broker, info: Pending, waiter: bool) ?usize {
         self.acquire();
         defer self.release();
         for (&self.slots, 0..) |*slot, i| {
             if (!slot.in_use) {
-                slot.* = .{ .in_use = true, .info = info, .decision = .init(.pending) };
+                slot.* = .{ .in_use = true, .info = info, .decision = .init(.pending), .waiter = waiter };
                 slot.info.id = self.next_id;
                 self.next_id += 1;
                 _ = self.version.fetchAdd(1, .monotonic);
@@ -244,6 +304,9 @@ pub const Broker = struct {
                 slot.remember = how_long;
                 slot.decision.store(decision, .release);
                 info = slot.info;
+                // Nobody is coming to collect this one. Left in use it would
+                // hold a slot forever, and there are thirty-two of them.
+                if (!slot.waiter) slot.in_use = false;
                 found = true;
                 break;
             }
@@ -618,4 +681,29 @@ test "walking away is not an answer, so a timeout is not remembered as a denial"
     const t = try std.Thread.spawn(.{}, resolveFirstFor, .{ &broker, Decision.approve, nip46.Remember.once });
     defer t.join();
     try testing.expectEqual(nip46.Decision.approve, p.decide(&req, client));
+}
+
+test "answered local questions do not fill the queue for good" {
+    // Nothing is parked on a local request. It was refused the moment it
+    // arrived and the app went away, so the only thing that can free its slot
+    // is the answer itself.
+    //
+    // The consequence is what this drives, not the mechanism: run more
+    // questions through than there are slots. If an answered one kept its
+    // slot, the queue silently fills, and from then on no app can raise a
+    // question and no relay request can either. The signer would look fine and
+    // simply stop asking.
+    var broker = Broker{};
+    var q: [Broker.capacity]Pending = undefined;
+    for (0..Broker.capacity * 2) |i| {
+        var info = Pending{ .local = true, .kind = @intCast(i), .method_id = .sign_event };
+        info.client_id = [_]u8{7} ** 32;
+        try testing.expect(broker.knock(info));
+        // One at a time, so a slot that was not freed is the only way to run out.
+        try testing.expectEqual(@as(usize, 1), broker.snapshot(&q));
+        // `.once` is never written down, so every turn is a fresh question
+        // rather than a permission piling up.
+        try testing.expect(broker.resolveFor(q[0].id, .reject, .once, 0));
+        try testing.expectEqual(@as(usize, 0), broker.snapshot(&q));
+    }
 }

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -332,7 +332,7 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
     if (eql(method, "GET") and std.mem.startsWith(u8, path, "/pending"))
         return handlePending(self, io, w, path);
     if (eql(method, "POST") and eql(path, "/decision"))
-        return handleDecision(self, w, body);
+        return handleDecision(self, io, w, body);
     // The local signing protocol (nostr's `signer_ipc`), which is what lets a
     // client on this machine use this daemon without a relay round trip. The
     // paths come from the library so every product speaks one protocol rather
@@ -411,7 +411,7 @@ fn appendJsonString(out: *std.ArrayList(u8), gpa: std.mem.Allocator, s: []const 
     try out.append(gpa, '"');
 }
 
-fn handleDecision(self: *Server, w: *std.Io.Writer, body: []const u8) !void {
+fn handleDecision(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !void {
     const Body = struct { id: u64, decision: []const u8, remember: []const u8 = "once" };
     const parsed = std.json.parseFromSlice(Body, self.gpa, body, .{ .ignore_unknown_fields = true }) catch
         return respond(w, 400, bad_request);
@@ -435,7 +435,7 @@ fn handleDecision(self: *Server, w: *std.Io.Writer, body: []const u8) !void {
     else
         .once;
 
-    const ok = self.broker.resolveFor(parsed.value.id, decision, how_long);
+    const ok = self.broker.resolveFor(parsed.value.id, decision, how_long, std.Io.Timestamp.now(io, .real).toMilliseconds());
     var out: [32]u8 = undefined;
     const j = std.fmt.bufPrint(&out, "{{\"ok\":{s}}}", .{if (ok) "true" else "false"}) catch unreachable;
     return respond(w, 200, j);
@@ -1295,6 +1295,9 @@ test "forgetting a key needs the exact confirmation phrase" {
 
 test "POST /decision carries how long the answer lasts, and a bad duration is the shortest" {
     const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
     var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
     var broker: Broker = .{};
     var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
@@ -1315,7 +1318,7 @@ test "POST /decision carries how long the answer lasts, and a bad duration is th
 
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleDecision(&server, &out.writer, c.body);
+        try handleDecision(&server, io, &out.writer, c.body);
         var body = out.toArrayList();
         defer body.deinit(gpa);
 

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -1010,7 +1010,13 @@ fn localAllowed(
         // that was never asked.
         .no_room => {
             note(self, io, .{ .what = what, .outcome = "no room", .who = name, .local = true, .method = method.name(), .kind = kind });
-            try respondIpcError(self, w, 503, ipc.reason_refused);
+            // NOT `reason_refused`: that one means a person said no and the
+            // client should stop. A full queue is nobody's decision and it
+            // clears on its own, so this says so in a message the contract
+            // does not spell, which a client reads as "some other failure"
+            // and a 503 tells it to try later. A fourth reason constant would
+            // say it better and is a change to the shared library.
+            try respondIpcError(self, w, 503, "the approval queue is full");
             return false;
         },
     }

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -77,6 +77,22 @@ pub const Server = struct {
     host: []const u8,
     port: u16,
 
+    /// Filled by `bind`, consumed by `run`. Null until bound.
+    listener: ?net.Server = null,
+
+    /// When the last authorized request arrived, or when the daemon bound its
+    /// port if none has.
+    ///
+    /// Every request touches it, including the polls both windows run while
+    /// they are open, which is what makes it a usable measure of "is anybody
+    /// there": a reader looking at either window is a steady stream of
+    /// requests, and silence means every app that was using this daemon has
+    /// gone.
+    last_request_ms: std.atomic.Value(i64) = .init(0),
+    /// How long that silence may last before the daemon exits. Zero stays up
+    /// forever.
+    idle_exit_ms: i64 = 0,
+
     active: std.atomic.Value(u32) = .init(0),
     /// Filled once the listener is up. With `port` 0 this is the only place the
     /// real port exists.
@@ -159,9 +175,30 @@ pub const Server = struct {
     ///
     /// Without the flag a duplicate bind fails, this listener refuses to start,
     /// and the daemon exits instead of leaving a hole open.
-    pub fn run(self: *Server, io: std.Io) !void {
+    /// Takes the address, and nothing else.
+    ///
+    /// Separate from `run` because of WHEN it has to happen. A daemon that
+    /// detaches from whoever started it has to fork; a fork must happen while
+    /// only one thread exists, since only the calling thread survives one; and
+    /// the spawner has to be told whether the port was obtained before its
+    /// child disappears. That ordering is only expressible if binding is its
+    /// own step: bind, report, fork, then serve. The listening socket survives
+    /// the fork, which is the whole reason this works.
+    pub fn bind(self: *Server, io: std.Io) !void {
         const addr = try net.IpAddress.parseIp4(self.host, self.port);
-        var server = try addr.listen(io, .{});
+        self.listener = try addr.listen(io, .{});
+        self.bound_port.store(boundPort(self.listener.?), .release);
+        // The idle clock starts now, so a daemon nobody ever reaches still
+        // goes. Measured live: with the clock starting at the first request
+        // instead, a daemon that was only ever knocked on by something without
+        // the token stayed up indefinitely.
+        self.last_request_ms.store(std.Io.Timestamp.now(io, .awake).toMilliseconds(), .monotonic);
+    }
+
+    /// Serves forever on the calling thread, binding first if nobody has.
+    pub fn run(self: *Server, io: std.Io) !void {
+        if (self.listener == null) try self.bind(io);
+        var server = self.listener.?;
         // Watches the connections the handlers hold and cuts off any that stops
         // making progress. There are only eight handler threads, and a peer
         // that opened a socket and wrote half a request line held one forever:
@@ -192,12 +229,6 @@ pub const Server = struct {
         // child's stderr outright (`.stderr = ... else .ignore`), so the
         // ordinary `std.debug.print` banner below would be dropped on the
         // floor and the GUI would wait forever for a port it was never told.
-        self.bound_port.store(boundPort(server), .release);
-        var out_buf: [64]u8 = undefined;
-        var stdout = std.Io.File.stdout().writer(io, &out_buf);
-        stdout.interface.print("{s} {d}\n", .{ port_line_prefix, self.bound_port.load(.acquire) }) catch {};
-        stdout.interface.flush() catch {};
-
         while (true) {
             const stream = server.accept(io) catch continue;
             if (self.active.load(.monotonic) >= max_conns) {
@@ -230,15 +261,58 @@ fn boundPort(server: net.Server) u16 {
     return std.mem.bigToNative(u16, sa.port);
 }
 
-/// Wakes once a second and cuts off connections that have stopped progressing.
+/// Wakes once a second, cuts off connections that have stopped progressing,
+/// and clocks the daemon out once nothing is using it.
 fn runReaper(self: *Server) void {
     var threaded = std.Io.Threaded.init(self.gpa, .{});
     defer threaded.deinit();
     const io = threaded.io();
     while (true) {
         io.sleep(std.Io.Duration.fromSeconds(1), .awake) catch {};
-        self.reapStale(io, std.Io.Timestamp.now(io, .awake).toMilliseconds());
+        const now = std.Io.Timestamp.now(io, .awake).toMilliseconds();
+        self.reapStale(io, now);
+        if (idleExpired(self.idle_exit_ms, self.last_request_ms.load(.monotonic), now))
+            exitIdle(self, io);
     }
+}
+
+/// Whether a daemon that has answered nobody for this long should go.
+///
+/// Pure, because the alternative is testing it by waiting and the interesting
+/// cases are a quarter of an hour apart.
+///
+/// The clock starts at STARTUP, not at the first request, and that is the
+/// whole subtlety. Treating "nobody has asked yet" as a reason to stay meant a
+/// daemon nobody ever reached lived forever: started by an app that then died,
+/// or knocked on only by something without the token, it sat there indefinitely
+/// waiting for a first request that was never coming. Measuring from startup
+/// covers the gap between starting and the app connecting just as well, because
+/// the gap is seconds and the window is a quarter of an hour.
+///
+/// Zero disables it.
+pub fn idleExpired(idle_exit_ms: i64, last_request_ms: i64, now_ms: i64) bool {
+    if (idle_exit_ms <= 0) return false;
+    return now_ms - last_request_ms >= idle_exit_ms;
+}
+
+/// Goes, because nothing is using the key any more.
+///
+/// This daemon deliberately outlives whoever started it, so that closing one
+/// app does not take the signer away from the others. The cost of that is that
+/// nothing ends it, and a keyholder nothing ends is a decrypted key sitting in
+/// memory until the machine is turned off.
+///
+/// Exit rather than lock in place, because exiting hands the pages back;
+/// a locked daemon still holds them. Whoever wants it next starts it again and
+/// it comes up locked, which is the right state for somebody returning to a
+/// machine they walked away from.
+fn exitIdle(self: *Server, io: std.Io) noreturn {
+    note(self, io, .{ .what = "lock", .outcome = "idle" });
+    // Same care as `/lock`: an authorization granted before this must not be
+    // recognised by whatever daemon comes next.
+    if (self.clients) |c| c.clear();
+    self.broker.reset();
+    std.process.exit(0);
 }
 
 /// One connection on its own thread with its own io (for the long-poll sleep).
@@ -303,6 +377,11 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
     }
 
     if (!authOk(auth, self.token)) return respond(w, 401, "{\"error\":\"unauthorized\"}");
+
+    // Somebody is here. Stamped AFTER the credential check, so a stranger
+    // cannot keep the key alive by knocking: the clock means "the apps allowed
+    // to use this are still around", and failed attempts are not those apps.
+    self.last_request_ms.store(std.Io.Timestamp.now(io, .awake).toMilliseconds(), .monotonic);
 
     // Assemble the body: bytes already read after the head, plus any remainder.
     var body_storage: [4096]u8 = undefined;
@@ -1944,4 +2023,49 @@ test "the key leaving the machine is written down, in the form it left as" {
     try testing.expect(std.mem.indexOf(u8, written, "nsec1") == null);
     try testing.expect(std.mem.indexOf(u8, written, passphrase) == null);
     try testing.expect(std.mem.indexOf(u8, written, "wrong") == null);
+}
+
+test "a daemon nobody is using clocks out, and one nobody has reached yet does not" {
+    const minute = 60 * 1000;
+    const idle = 15 * minute;
+
+    // Nothing has ever asked, and the clock runs from startup, so this daemon
+    // goes too. Measured live: with a first-request clock, a daemon that was
+    // only ever knocked on by something WITHOUT the token stayed up
+    // indefinitely, because the knocks never counted and the clock never
+    // started. Nobody was ever coming.
+    try testing.expect(!idleExpired(idle, 1_000_000, 1_000_000 + minute));
+    try testing.expect(idleExpired(idle, 1_000_000, 1_000_000 + idle));
+
+    // Somebody asked a minute ago. Both windows poll while they are open, so
+    // this is what "a reader is looking at it" measures as.
+    try testing.expect(!idleExpired(idle, 1_000_000, 1_000_000 + minute));
+    try testing.expect(!idleExpired(idle, 1_000_000, 1_000_000 + idle - 1));
+
+    // Nobody for the whole window: every app that was using the key has gone,
+    // and the key must not outlast them.
+    try testing.expect(idleExpired(idle, 1_000_000, 1_000_000 + idle));
+    try testing.expect(idleExpired(idle, 1_000_000, 1_000_000 + 60 * minute));
+
+    // Turned off, for a headless bunker with no window to poll it, where
+    // silence is the normal state rather than a sign that everyone left.
+    try testing.expect(!idleExpired(0, 1_000_000, 1_000_000 + 60 * minute));
+    try testing.expect(!idleExpired(-1, 1_000_000, 1_000_000 + 60 * minute));
+}
+
+test "the idle clock is only wound by a caller that presented the token" {
+    // A stranger knocking must not keep the key alive. The clock means "the
+    // apps allowed to use this are still around", and failed attempts are not
+    // those apps. Asserted on the source's own ordering, because the
+    // alternative is a live server and a fifteen-minute wait.
+    const src = @embedFile("approval_http.zig");
+    const auth_at = std.mem.indexOf(u8, src, "if (!authOk(auth, self.token)) return respond").?;
+    // The request handler's stamp, not `bind`'s: both write the same field,
+    // and only one of them is on the path a caller can reach.
+    const stamp_at = std.mem.indexOfPos(u8, src, auth_at, "self.last_request_ms.store(").?;
+    try testing.expect(auth_at < stamp_at);
+    // And there is no OTHER stamp between the head being read and the check,
+    // which is where an unauthorized caller would slip one in.
+    const head_at = std.mem.indexOf(u8, src, "const request_line = lines.next()").?;
+    try testing.expect(std.mem.indexOfPos(u8, src, head_at, "self.last_request_ms.store(").? == stamp_at);
 }

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -490,11 +490,30 @@ fn handleInfo(self: *Server, io: std.Io, w: *std.Io.Writer) !void {
 /// A non-empty `secret` (an `nsec1…` or 64-char hex) imports an existing key;
 /// absent/empty generates a fresh one. The key is created and encrypted in the
 /// daemon; only the derived public key is returned.
+/// POST /setup: mint a key, or take one the reader pasted.
+///
+/// The method is STATED, never inferred. This used to read "an empty secret
+/// means create", which is the same sentence as "a client that meant to import
+/// and sent nothing gets a brand new identity instead". That is one trimmed
+/// whitespace-only paste away, it destroys nothing the daemon can see, and the
+/// reader finds out later when their account is not theirs. A nostr key cannot
+/// be replaced, so this asks rather than guesses, and refuses when the answer
+/// does not make sense.
 fn handleSetup(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !void {
-    const Body = struct { passphrase: []const u8 = "", secret: []const u8 = "" };
+    const Body = struct { method: []const u8 = "", passphrase: []const u8 = "", secret: []const u8 = "" };
     const parsed = std.json.parseFromSlice(Body, self.gpa, body, .{ .ignore_unknown_fields = true }) catch
         return respond(w, 400, bad_request);
     defer parsed.deinit();
+
+    const importing = eql(parsed.value.method, ipc.Setup.method_import);
+    if (!importing and !eql(parsed.value.method, ipc.Setup.method_create))
+        return respond(w, 400, "{\"error\":\"method must be create or import\"}");
+    // An import with nothing to import is the dangerous one: it used to fall
+    // through to minting a key. Refusing is the whole point of asking.
+    if (importing and parsed.value.secret.len == 0)
+        return respond(w, 400, "{\"error\":\"import needs a secret\"}");
+    if (!importing and parsed.value.secret.len != 0)
+        return respond(w, 400, "{\"error\":\"create takes no secret\"}");
 
     self.gate.setup(io, parsed.value.passphrase, parsed.value.secret) catch |err| return switch (err) {
         error.AlreadyInitialized => respond(w, 409, "{\"error\":\"already initialized\"}"),
@@ -1222,6 +1241,45 @@ test "a nostrconnect link cannot make the daemon dial without limit" {
     // sockets on somebody else's list.
     try testing.expect(max_nostrconnect_relays > 0);
     try testing.expect(max_nostrconnect_relays <= 8);
+}
+
+test "an import with nothing to import is refused, not turned into a new key" {
+    // The dangerous shape this replaced: "an empty secret means create". That
+    // is the same sentence as "a client that meant to import and sent nothing
+    // gets a brand new identity", which is one whitespace-only paste away and
+    // is only discovered later, when the account turns out not to be theirs.
+    // A nostr key cannot be replaced, so the method is stated and a request
+    // that does not make sense is refused rather than guessed at.
+    const gpa = testing.allocator;
+    var broker: Broker = .{};
+
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+
+    const Case = struct { body: []const u8, want: []const u8 };
+    for ([_]Case{
+        // The one that used to mint a key.
+        .{ .body = "{\"method\":\"import\",\"passphrase\":\"pw\",\"secret\":\"\"}", .want = "400" },
+        // No method at all: the old clients' shape, now refused rather than
+        // silently read as a create.
+        .{ .body = "{\"passphrase\":\"pw\",\"secret\":\"\"}", .want = "400" },
+        .{ .body = "{\"method\":\"\",\"passphrase\":\"pw\"}", .want = "400" },
+        // A create that carries a secret is a confused client, not a create.
+        .{ .body = "{\"method\":\"create\",\"passphrase\":\"pw\",\"secret\":\"nsec1x\"}", .want = "400" },
+        // Nonsense method.
+        .{ .body = "{\"method\":\"replace\",\"passphrase\":\"pw\"}", .want = "400" },
+    }) |c| {
+        var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+        var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSetup(&server, threaded.io(), &out.writer, c.body);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, c.want) != null);
+        // Whatever went wrong, no key was made.
+        try testing.expectEqual(onboarding.State.uninitialized, gate.current());
+    }
 }
 
 test "forgetting a key needs the exact confirmation phrase" {

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -909,6 +909,21 @@ fn respondIpcError(self: *Server, w: *std.Io.Writer, status: u16, message: []con
 /// Whether the app named `name` may do this, and if nobody has ever said, the
 /// question that asks them.
 ///
+/// WHAT THIS IS NOT, stated here because the rest of this file reads like it is
+/// more: it is not a defence against a hostile program running as this user.
+/// Such a program can read the bearer token, and the token is all `/decision`
+/// asks for, so it can answer its own question without a person ever seeing it.
+/// Nothing in a file can separate this daemon's window from anything else the
+/// same user runs, which is the whole reason a same-uid attacker was named as
+/// out of scope from the start.
+///
+/// What it IS: separate answers for separate apps that are behaving. That is
+/// worth having on its own, because "the messenger may read my messages, my
+/// feed reader may not" cannot even be SAID otherwise, and because a person who
+/// is asked can say no. Every one of these decisions is written to the audit
+/// log, so an app that answers for itself leaves the record of having done so,
+/// which is the most this layer can honestly offer.
+///
 /// Returns false having ALREADY answered the request. The three refusals are
 /// spelled apart because a client has to do three different things with them:
 /// name yourself, wait and ask again, or stop.

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -620,11 +620,21 @@ fn handleExport(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) 
     if (!raw and !eql(parsed.value.form, "ncryptsec"))
         return respond(w, 400, "{\"error\":\"form must be ncryptsec or nsec\"}");
 
-    const key = self.gate.exportKey(io, self.gpa, parsed.value.passphrase, raw) catch |err| return switch (err) {
-        error.BadPassphrase => respond(w, 401, "{\"error\":\"bad passphrase\"}"),
-        error.NotInitialized => respond(w, 409, "{\"error\":\"no key\"}"),
-        else => respond(w, 500, "{\"error\":\"could not read the key\"}"),
+    const key = self.gate.exportKey(io, self.gpa, parsed.value.passphrase, raw) catch |err| {
+        // A refused export is worth as much as an allowed one. Somebody
+        // guessing at the passphrase is guessing at the key itself, and this
+        // is the endpoint that hands it over whole.
+        note(self, io, .{ .what = "export", .outcome = if (err == error.BadPassphrase) "bad" else "error", .method = parsed.value.form });
+        return switch (err) {
+            error.BadPassphrase => respond(w, 401, "{\"error\":\"bad passphrase\"}"),
+            error.NotInitialized => respond(w, 409, "{\"error\":\"no key\"}"),
+            else => respond(w, 500, "{\"error\":\"could not read the key\"}"),
+        };
     };
+    // The key left this machine. Nothing else the daemon does compares, and
+    // until now the only record of it was the operator's memory. Which FORM,
+    // too: an ncryptsec is still behind the passphrase, an nsec is not.
+    note(self, io, .{ .what = "export", .outcome = "ok", .method = parsed.value.form });
     defer {
         std.crypto.secureZero(u8, key);
         self.gpa.free(key);
@@ -730,6 +740,12 @@ fn handleNostrConnect(self: *Server, io: std.Io, w: *std.Io.Writer, body: []cons
     // AFTER it is out, not before. Authorizing a client we failed to answer
     // leaves a grant standing for a connection that never happened.
     clients.authorize(uri.value.client_pubkey);
+    // Which key was let in, and when. Adopting a client is the moment somebody
+    // else gains the ability to ask this daemon for signatures; the requests
+    // that follow are all downstream of this line.
+    var who: [64]u8 = undefined;
+    _ = std.fmt.bufPrint(&who, "{x}", .{uri.value.client_pubkey}) catch unreachable;
+    note(self, io, .{ .what = "connect", .outcome = "ok", .who = &who, .local = false });
     return respond(w, 200, "{\"ok\":true}");
 }
 
@@ -1873,4 +1889,59 @@ test "a wrong passphrase is written down, because a run of them is the only warn
     try testing.expect(std.mem.indexOf(u8, written, "\"what\":\"unlock\"") != null);
     // The attempt, never the attempt's passphrase.
     try testing.expect(std.mem.indexOf(u8, written, "hunter2") == null);
+}
+
+test "the key leaving the machine is written down, in the form it left as" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // A real encrypted key file, so the export is the real path rather than an
+    // early refusal that would prove nothing about it.
+    const secret = [_]u8{0xab} ** 32;
+    const passphrase = "correct horse battery staple";
+    const ncryptsec = try nostr.keystore.encryptKey(gpa, io, secret, passphrase, .known_secure);
+    defer gpa.free(ncryptsec);
+    try nostr.keystore.writeNewKeyFile(io, tmp.dir, "key.ncryptsec", ncryptsec);
+
+    var log = audit.Log{ .dir = tmp.dir, .path = "audit.log" };
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, tmp.dir, "key.ncryptsec", .locked);
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .log = &log, .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    // Wrong passphrase first: somebody guessing at the passphrase is guessing
+    // at the key, and this endpoint hands it over whole.
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleExport(&server, io, &out.writer, "{\"passphrase\":\"wrong\",\"form\":\"nsec\"}");
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "401") != null);
+    }
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        const req = try std.fmt.allocPrint(gpa, "{{\"passphrase\":\"{s}\",\"form\":\"nsec\"}}", .{passphrase});
+        defer gpa.free(req);
+        try handleExport(&server, io, &out.writer, req);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "\"ok\":true") != null);
+    }
+
+    const written = try tmp.dir.readFileAlloc(io, "audit.log", gpa, .unlimited);
+    defer gpa.free(written);
+    try testing.expectEqual(@as(usize, 2), std.mem.count(u8, written, "\n"));
+    try testing.expect(std.mem.indexOf(u8, written, "\"what\":\"export\",\"outcome\":\"bad\"") != null);
+    // The form matters: an ncryptsec that leaves is still behind the
+    // passphrase, an nsec is not, and a reader of this log needs to know which
+    // of those is loose.
+    try testing.expect(std.mem.indexOf(u8, written, "\"what\":\"export\",\"outcome\":\"ok\",\"method\":\"nsec\"") != null);
+
+    // Never the key, and never the passphrase that opened it.
+    try testing.expect(std.mem.indexOf(u8, written, "nsec1") == null);
+    try testing.expect(std.mem.indexOf(u8, written, passphrase) == null);
+    try testing.expect(std.mem.indexOf(u8, written, "wrong") == null);
 }

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -24,6 +24,7 @@
 const std = @import("std");
 const nostr = @import("nostr");
 const approval = @import("approval.zig");
+const audit = @import("audit.zig");
 const onboarding = @import("onboarding.zig");
 
 const net = std.Io.net;
@@ -69,6 +70,9 @@ pub const Server = struct {
     gate: *Gate,
     /// Bearer token clients must present.
     token: []const u8,
+    /// Where uses of the key are written down. Null writes nothing, which is
+    /// how the tests that are about something else stay about something else.
+    log: ?*audit.Log = null,
     info: Info,
     host: []const u8,
     port: u16,
@@ -324,7 +328,7 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
     if (eql(method, "POST") and eql(path, "/forget"))
         return handleForget(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/lock"))
-        return handleLock(self, w);
+        return handleLock(self, io, w);
     if (eql(method, "POST") and eql(path, "/export"))
         return handleExport(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/nostrconnect"))
@@ -444,7 +448,24 @@ fn handleDecision(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8
     else
         .once;
 
+    // What the operator was looking at when they answered, so the record says
+    // who they allowed rather than only that they pressed something.
+    var asked: [Broker.capacity]Pending = undefined;
+    const n = self.broker.snapshot(&asked);
+    const row: ?Pending = for (asked[0..n]) |p| {
+        if (p.id == parsed.value.id) break p;
+    } else null;
+
     const ok = self.broker.resolveFor(parsed.value.id, decision, how_long, std.Io.Timestamp.now(io, .real).toMilliseconds());
+    if (ok) if (row) |p| note(self, io, .{
+        .what = "decision",
+        .outcome = if (decision == .approve) "allowed" else "denied",
+        .who = p.client(),
+        .local = p.local,
+        .method = p.method(),
+        .kind = p.kind,
+        .remember = @tagName(how_long),
+    });
     var out: [32]u8 = undefined;
     const j = std.fmt.bufPrint(&out, "{{\"ok\":{s}}}", .{if (ok) "true" else "false"}) catch unreachable;
     return respond(w, 200, j);
@@ -530,6 +551,10 @@ fn handleSetup(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !
         error.InvalidSecretKey => respond(w, 400, "{\"error\":\"invalid secret key\"}"),
         else => respond(w, 500, "{\"error\":\"could not create the key\"}"),
     };
+    // Which of the two happened, because they are not the same event: one
+    // made an identity and one adopted one, and only the log can say which
+    // this key is.
+    note(self, io, .{ .what = "setup", .outcome = if (importing) "import" else "create" });
     return respondPubkey(self, w);
 }
 
@@ -560,6 +585,9 @@ fn handleForget(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) 
     // Sessions granted against the key being removed must not outlive it. A
     // client still holding an authorization is one that would be recognised by
     // whatever key is set up next.
+    // Written before the key goes, so the last line in the log is the one that
+    // says where it went. This is the only irreversible thing the daemon does.
+    note(self, io, .{ .what = "forget", .outcome = "ok" });
     if (self.clients) |c| c.clear();
     self.broker.reset();
     self.gate.forget(io);
@@ -617,7 +645,8 @@ fn handleExport(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) 
 ///
 /// The key stays where it is, encrypted, so the next daemon comes up locked and
 /// asks for the passphrase. `/forget` is the one that removes it.
-fn handleLock(self: *Server, w: *std.Io.Writer) !void {
+fn handleLock(self: *Server, io: std.Io, w: *std.Io.Writer) !void {
+    note(self, io, .{ .what = "lock", .outcome = "ok" });
     // Sessions granted before signing out must not outlive it: a client still
     // holding an authorization would be recognised by the daemon that follows.
     if (self.clients) |c| c.clear();
@@ -711,11 +740,18 @@ fn handleUnlock(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) 
         return respond(w, 400, bad_request);
     defer parsed.deinit();
 
-    self.gate.unlock(io, parsed.value.passphrase) catch |err| return switch (err) {
-        error.BadPassphrase => respond(w, 401, "{\"error\":\"bad passphrase\"}"),
-        error.NotLocked => respond(w, 409, "{\"error\":\"not locked\"}"),
-        else => respond(w, 500, "{\"error\":\"could not unlock\"}"),
+    self.gate.unlock(io, parsed.value.passphrase) catch |err| {
+        // A wrong passphrase is worth writing down. One is a typo; a run of
+        // them at four in the morning is the only warning this daemon can
+        // give that somebody is working on the key.
+        note(self, io, .{ .what = "unlock", .outcome = if (err == error.BadPassphrase) "bad" else "error" });
+        return switch (err) {
+            error.BadPassphrase => respond(w, 401, "{\"error\":\"bad passphrase\"}"),
+            error.NotLocked => respond(w, 409, "{\"error\":\"not locked\"}"),
+            else => respond(w, 500, "{\"error\":\"could not unlock\"}"),
+        };
     };
+    note(self, io, .{ .what = "unlock", .outcome = "ok" });
     return respondPubkey(self, w);
 }
 
@@ -739,6 +775,14 @@ fn signerState(gate: *const Gate) []const u8 {
         .locked => ipc.state_locked,
         .unlocked => ipc.state_ready,
     };
+}
+
+/// Writes one line about what the key was asked to do, if anybody is keeping a
+/// record. One helper rather than a check at every call site, because the call
+/// site that forgets the check is the one that stops recording.
+fn note(self: *Server, io: std.Io, event: audit.Event) void {
+    const l = self.log orelse return;
+    l.note(io, std.Io.Timestamp.now(io, .real).toSeconds(), event);
 }
 
 fn respondIpcError(self: *Server, w: *std.Io.Writer, status: u16, message: []const u8) !void {
@@ -770,11 +814,13 @@ fn localAllowed(
     method: nip46.Method,
     kind: i32,
     preview: []const u8,
+    comptime what: []const u8,
 ) !bool {
     // An app that will not say what it is gets nothing. There is no shared
     // "some local app" permission to fall back on, deliberately: that is the
     // single client this whole mechanism exists to break up.
     if (!ipc.clientNameOk(name)) {
+        note(self, io, .{ .what = what, .outcome = "unnamed", .method = method.name(), .kind = kind });
         try respondIpcError(self, w, 400, ipc.reason_unnamed);
         return false;
     }
@@ -783,6 +829,7 @@ fn localAllowed(
     const now_ms = std.Io.Timestamp.now(io, .real).toMilliseconds();
     if (self.broker.permissions.remembered(id, method, kind, now_ms)) |allowed| {
         if (allowed) return true;
+        note(self, io, .{ .what = what, .outcome = "refused", .who = name, .local = true, .method = method.name(), .kind = kind });
         try respondIpcError(self, w, 403, ipc.reason_refused);
         return false;
     }
@@ -810,6 +857,7 @@ fn localAllowed(
     info.preview_len = approval.previewOf(preview, &info.preview_buf);
     _ = self.broker.knock(info);
 
+    note(self, io, .{ .what = what, .outcome = "awaiting", .who = name, .local = true, .method = method.name(), .kind = kind });
     try respondIpcError(self, w, 403, ipc.reason_awaiting_approval);
     return false;
 }
@@ -852,7 +900,7 @@ fn handleSignerSign(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const 
 
     // Locked first, then permission. Asking somebody to allow a signature the
     // daemon could not produce anyway is a question with no useful answer.
-    if (!try localAllowed(self, io, w, client_name, .sign_event, ev.kind, ev.content)) return;
+    if (!try localAllowed(self, io, w, client_name, .sign_event, ev.kind, ev.content, "sign")) return;
 
     var signer = nostr.keys.Signer.init();
     defer signer.deinit();
@@ -864,6 +912,21 @@ fn handleSignerSign(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const 
     const json = nostr.event.toJson(self.gpa, signed) catch
         return respondIpcError(self, w, 500, "out of memory");
     defer self.gpa.free(json);
+
+    // By id, which is what finds the note again and is public the moment it is
+    // published. The content is not written down: an audit log that quotes what
+    // you wrote is a second copy of it in a file nothing else protects.
+    var id_hex: [64]u8 = undefined;
+    _ = std.fmt.bufPrint(&id_hex, "{x}", .{signed.id}) catch unreachable;
+    note(self, io, .{
+        .what = "sign",
+        .outcome = "ok",
+        .who = client_name,
+        .local = true,
+        .method = "sign_event",
+        .kind = ev.kind,
+        .id = &id_hex,
+    });
 
     const out = ipc.SignEvent{ .event = json };
     const out_json = out.toJson(self.gpa) catch
@@ -904,7 +967,7 @@ fn handleSignerCipher(
         .encrypt => .nip44_encrypt,
         .decrypt => .nip44_decrypt,
     };
-    if (!try localAllowed(self, io, w, client_name, method, -1, "")) return;
+    if (!try localAllowed(self, io, w, client_name, method, -1, "", "cipher")) return;
 
     var signer = nostr.keys.Signer.init();
     defer signer.deinit();
@@ -922,6 +985,18 @@ fn handleSignerCipher(
         out.append(self.gpa, result) catch
             return respondIpcError(self, w, 500, "out of memory");
     }
+
+    // Who with and how many, never what. The plaintext is the whole thing this
+    // is protecting.
+    note(self, io, .{
+        .what = "cipher",
+        .outcome = "ok",
+        .who = client_name,
+        .local = true,
+        .method = method.name(),
+        .peer = req.peer,
+        .count = req.items.len,
+    });
 
     const res = ipc.CipherResult{ .items = out.items };
     const j = res.toJson(self.gpa) catch
@@ -1713,4 +1788,89 @@ test "an app cannot name itself out of the queue's JSON" {
     try testing.expectEqualStrings(hostile, parsed.value.pending[0].client);
     try testing.expectEqual(@as(i32, 1), parsed.value.pending[0].kind);
     try testing.expect(parsed.value.pending[0].local);
+}
+
+test "what the key did is written down, and what it was told in confidence is not" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var log = audit.Log{ .dir = tmp.dir, .path = "audit.log" };
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    gate.preload(kp);
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .log = &log, .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    const req = try signRequest(gpa, 1);
+    defer gpa.free(req);
+
+    // Refused first, then answered, then signed: the three things that can
+    // happen to one request, in the order a person actually meets them.
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, io, &out.writer, req, test_client);
+    }
+    var queue: [Broker.capacity]Pending = undefined;
+    try testing.expectEqual(@as(usize, 1), broker.snapshot(&queue));
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        const body = try std.fmt.allocPrint(gpa, "{{\"id\":{d},\"decision\":\"approve\",\"remember\":\"always\"}}", .{queue[0].id});
+        defer gpa.free(body);
+        try handleDecision(&server, io, &out.writer, body);
+    }
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
+    }
+
+    const written = try tmp.dir.readFileAlloc(io, "audit.log", gpa, .unlimited);
+    defer gpa.free(written);
+
+    try testing.expectEqual(@as(usize, 3), std.mem.count(u8, written, "\n"));
+    try testing.expect(std.mem.indexOf(u8, written, "\"outcome\":\"awaiting\"") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "\"what\":\"decision\"") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "\"remember\":\"always\"") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "\"outcome\":\"ok\"") != null);
+    // Which app, and what it signed, by an id that finds the note again.
+    try testing.expect(std.mem.indexOf(u8, written, "\"who\":\"test-app\"") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "\"kind\":1") != null);
+    try testing.expect(std.mem.indexOf(u8, written, "\"id\":\"") != null);
+
+    // And not what it said. The content of a signed note is the one thing a
+    // record of signatures must not become a second copy of.
+    try testing.expect(std.mem.indexOf(u8, written, "hello") == null);
+}
+
+test "a wrong passphrase is written down, because a run of them is the only warning" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var log = audit.Log{ .dir = tmp.dir, .path = "audit.log" };
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "no-such-key.ncryptsec", .locked);
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .log = &log, .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    var out = std.Io.Writer.Allocating.init(gpa);
+    defer out.deinit();
+    try handleUnlock(&server, io, &out.writer, "{\"passphrase\":\"hunter2\"}");
+
+    const written = try tmp.dir.readFileAlloc(io, "audit.log", gpa, .unlimited);
+    defer gpa.free(written);
+    try testing.expect(std.mem.indexOf(u8, written, "\"what\":\"unlock\"") != null);
+    // The attempt, never the attempt's passphrase.
+    try testing.expect(std.mem.indexOf(u8, written, "hunter2") == null);
 }

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -289,9 +289,11 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
     const path = parts.next() orelse return respond(w, 400, bad_request);
 
     var auth: []const u8 = "";
+    var client_name: []const u8 = "";
     var content_length: usize = 0;
     while (lines.next()) |line| {
         if (headerValue(line, "authorization")) |v| auth = v;
+        if (headerValue(line, ipc.header_client)) |v| client_name = v;
         if (headerValue(line, "content-length")) |v|
             content_length = std.fmt.parseInt(usize, v, 10) catch 0;
     }
@@ -340,11 +342,11 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
     if (eql(method, "GET") and eql(path, ipc.path_pubkey))
         return handleSignerPubkey(self, w);
     if (eql(method, "POST") and eql(path, ipc.path_sign))
-        return handleSignerSign(self, w, body);
+        return handleSignerSign(self, io, w, body, client_name);
     if (eql(method, "POST") and eql(path, ipc.path_nip44_encrypt))
-        return handleSignerCipher(self, io, w, body, .encrypt);
+        return handleSignerCipher(self, io, w, body, client_name, .encrypt);
     if (eql(method, "POST") and eql(path, ipc.path_nip44_decrypt))
-        return handleSignerCipher(self, io, w, body, .decrypt);
+        return handleSignerCipher(self, io, w, body, client_name, .decrypt);
     return respond(w, 404, "{\"error\":\"not found\"}");
 }
 
@@ -369,18 +371,25 @@ fn handlePending(self: *Server, io: std.Io, w: *std.Io.Writer, path: []const u8)
     try json.appendSlice(self.gpa, head);
     for (pending[0..n], 0..) |p, i| {
         if (i != 0) try json.append(self.gpa, ',');
-        // `method` and `client` are safe to interpolate: a request only reaches
-        // the policy once its method has parsed as one of seven fixed names,
-        // and the client is hex. `preview` is the requester's own text and is
-        // escaped, or a quote in a note would end the string and the rest of it
-        // would be read as fields of this object.
+        // `method` is safe to interpolate: a request only reaches the queue
+        // once its method has parsed as one of seven fixed names.
+        //
+        // `client` is NOT. It used to be, when every request came over a relay
+        // and the field was a pubkey in hex. A request from this machine puts
+        // the app's own chosen name there instead, and printable ASCII includes
+        // the quote and the backslash, so an app could name itself out of this
+        // string and into the object around it.
+        //
+        // `preview` is the requester's own text and always needed escaping.
         const item = try std.fmt.allocPrint(
             self.gpa,
-            "{{\"id\":{d},\"method\":\"{s}\",\"kind\":{d},\"created_at\":{d},\"client\":\"{s}\",\"preview\":",
-            .{ p.id, p.method(), p.kind, p.created_at, p.client() },
+            "{{\"id\":{d},\"method\":\"{s}\",\"kind\":{d},\"created_at\":{d},\"local\":{s},\"client\":",
+            .{ p.id, p.method(), p.kind, p.created_at, if (p.local) "true" else "false" },
         );
         defer self.gpa.free(item);
         try json.appendSlice(self.gpa, item);
+        try appendJsonString(&json, self.gpa, p.client());
+        try json.appendSlice(self.gpa, ",\"preview\":");
         try appendJsonString(&json, self.gpa, p.preview());
         try json.append(self.gpa, '}');
     }
@@ -739,6 +748,72 @@ fn respondIpcError(self: *Server, w: *std.Io.Writer, status: u16, message: []con
     return respond(w, status, j);
 }
 
+/// Whether the app named `name` may do this, and if nobody has ever said, the
+/// question that asks them.
+///
+/// Returns false having ALREADY answered the request. The three refusals are
+/// spelled apart because a client has to do three different things with them:
+/// name yourself, wait and ask again, or stop.
+///
+/// Nothing here blocks. The obvious implementation is the relay side's: park
+/// the caller until a person answers. On this server that caller is one of
+/// eight handler threads, and the GUI fetches the queue over the same eight, so
+/// eight unanswered local requests would leave the GUI unable to fetch the
+/// questions it is being asked to answer, and no answer could arrive to release
+/// anything. Refusing now and leaving the question behind costs a round trip
+/// and cannot wedge.
+fn localAllowed(
+    self: *Server,
+    io: std.Io,
+    w: *std.Io.Writer,
+    name: []const u8,
+    method: nip46.Method,
+    kind: i32,
+    preview: []const u8,
+) !bool {
+    // An app that will not say what it is gets nothing. There is no shared
+    // "some local app" permission to fall back on, deliberately: that is the
+    // single client this whole mechanism exists to break up.
+    if (!ipc.clientNameOk(name)) {
+        try respondIpcError(self, w, 400, ipc.reason_unnamed);
+        return false;
+    }
+
+    const id = ipc.clientId(name);
+    const now_ms = std.Io.Timestamp.now(io, .real).toMilliseconds();
+    if (self.broker.permissions.remembered(id, method, kind, now_ms)) |allowed| {
+        if (allowed) return true;
+        try respondIpcError(self, w, 403, ipc.reason_refused);
+        return false;
+    }
+
+    var info = Pending{
+        .kind = kind,
+        .created_at = std.Io.Timestamp.now(io, .real).toSeconds(),
+        .client_id = id,
+        .method_id = method,
+        .local = true,
+    };
+    const mname = method.name();
+    const mlen = @min(mname.len, info.method_buf.len);
+    @memcpy(info.method_buf[0..mlen], mname[0..mlen]);
+    info.method_len = @intCast(mlen);
+    // The name as the app wrote it. `clientNameOk` bounds it, and the bound
+    // lives in the other repo, so this pins the two together rather than
+    // trusting them to be widened in step.
+    comptime {
+        const cap = @typeInfo(@FieldType(Pending, "client_buf")).array.len;
+        std.debug.assert(ipc.client_name_max <= cap);
+    }
+    @memcpy(info.client_buf[0..name.len], name);
+    info.client_len = @intCast(name.len);
+    info.preview_len = approval.previewOf(preview, &info.preview_buf);
+    _ = self.broker.knock(info);
+
+    try respondIpcError(self, w, 403, ipc.reason_awaiting_approval);
+    return false;
+}
+
 /// GET /pubkey: what state this daemon is in and whose key it holds.
 ///
 /// The pubkey rides along while LOCKED as well as ready, because whose key it
@@ -755,8 +830,8 @@ fn handleSignerPubkey(self: *Server, w: *std.Io.Writer) !void {
     return respond(w, 200, j);
 }
 
-/// POST /sign: sign one event with the held key.
-fn handleSignerSign(self: *Server, w: *std.Io.Writer, body: []const u8) !void {
+/// POST /sign: sign one event with the held key, if this app may.
+fn handleSignerSign(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8, client_name: []const u8) !void {
     var parsed = ipc.parse(ipc.SignEvent, self.gpa, body) catch
         return respondIpcError(self, w, 400, "malformed sign request");
     defer parsed.deinit();
@@ -773,7 +848,11 @@ fn handleSignerSign(self: *Server, w: *std.Io.Writer, body: []const u8) !void {
         return respondIpcError(self, w, 422, "kind 14 and 15 are never signed");
 
     if (self.gate.current() != .unlocked)
-        return respondIpcError(self, w, 409, "the key is locked");
+        return respondIpcError(self, w, 409, ipc.reason_locked);
+
+    // Locked first, then permission. Asking somebody to allow a signature the
+    // daemon could not produce anyway is a question with no useful answer.
+    if (!try localAllowed(self, io, w, client_name, .sign_event, ev.kind, ev.content)) return;
 
     var signer = nostr.keys.Signer.init();
     defer signer.deinit();
@@ -801,6 +880,7 @@ fn handleSignerCipher(
     io: std.Io,
     w: *std.Io.Writer,
     body: []const u8,
+    client_name: []const u8,
     comptime dir: enum { encrypt, decrypt },
 ) !void {
     var parsed = ipc.parse(ipc.Cipher, self.gpa, body) catch
@@ -813,7 +893,18 @@ fn handleSignerCipher(
         return respondIpcError(self, w, 400, "peer must be 32-byte hex");
 
     if (self.gate.current() != .unlocked)
-        return respondIpcError(self, w, 409, "the key is locked");
+        return respondIpcError(self, w, 409, ipc.reason_locked);
+
+    // One answer covers the whole batch and every batch after it, which is the
+    // point: a catch-up is thousands of items, and a question per item is a
+    // question nobody reads. There is no event kind here, so it is filed under
+    // the method alone, and encrypt and decrypt are separate methods. Being
+    // allowed to write a message is not being allowed to read one.
+    const method: nip46.Method = switch (dir) {
+        .encrypt => .nip44_encrypt,
+        .decrypt => .nip44_decrypt,
+    };
+    if (!try localAllowed(self, io, w, client_name, method, -1, "")) return;
 
     var signer = nostr.keys.Signer.init();
     defer signer.deinit();
@@ -962,6 +1053,10 @@ test "parseSince reads the query parameter" {
 /// One `/sign` request body of the shape a client really sends: a complete
 /// event whose id, pubkey and signature are zeroed, since those are the three
 /// things it is asking the daemon to fill in.
+/// The name a test app calls itself. Any app on the machine may claim any
+/// name, which is exactly why the tests use a plain one.
+const test_client = "test-app";
+
 fn signRequest(gpa: std.mem.Allocator, kind: u16) ![]u8 {
     const unsigned = nostr.event.Event{
         .id = [_]u8{0} ** 32,
@@ -1040,6 +1135,9 @@ test "GET /pubkey tells a local client which of THREE states this is" {
 
 test "POST /sign signs with the held key, and refuses a locked one" {
     const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
 
     var signer = nostr.keys.Signer.init();
     defer signer.deinit();
@@ -1047,6 +1145,9 @@ test "POST /sign signs with the held key, and refuses a locked one" {
     const kp = try signer.keyPairFromSecretKey(secret);
 
     var broker: Broker = .{};
+    // Allowed, so that the thing under test here is the signing and not the
+    // permission gate, which has tests of its own.
+    broker.permissions.remember(nostr.signer_ipc.clientId(test_client), .sign_event, 1, true, .always, 0);
     // The shape a client actually sends: a complete event with the id, pubkey
     // and signature left zeroed, because those are what it is asking for.
     const req = try signRequest(gpa, 1);
@@ -1059,7 +1160,7 @@ test "POST /sign signs with the held key, and refuses a locked one" {
         var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, &out.writer, req);
+        try handleSignerSign(&server, io, &out.writer, req, test_client);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
@@ -1073,7 +1174,7 @@ test "POST /sign signs with the held key, and refuses a locked one" {
         var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, &out.writer, req);
+        try handleSignerSign(&server, io, &out.writer, req, test_client);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "409") != null);
@@ -1086,6 +1187,9 @@ test "a gift-wrap rumor is never signed, locked or not" {
     // and a messenger asking for it is asking for a mistake. Refused before the
     // gate is even consulted, so it reads the same whatever state the key is in.
     const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
 
     var signer = nostr.keys.Signer.init();
     defer signer.deinit();
@@ -1103,7 +1207,7 @@ test "a gift-wrap rumor is never signed, locked or not" {
 
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, &out.writer, req);
+        try handleSignerSign(&server, io, &out.writer, req, test_client);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "422") != null);
@@ -1325,4 +1429,288 @@ test "POST /decision carries how long the answer lasts, and a bad duration is th
         try testing.expect(std.mem.indexOf(u8, body.items, "\"ok\":true") != null);
         try testing.expectEqual(c.want, broker.slots[0].remember);
     }
+}
+
+test "an app nobody has answered for is refused, and asks once" {
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    gate.preload(kp);
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    const req = try signRequest(gpa, 1);
+    defer gpa.free(req);
+
+    // Unlocked, holding the key, and still refused: nobody has said this app
+    // may use it. That is the whole change. Before it, any process that could
+    // read the token signed anything it liked and nothing was recorded.
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "403") != null);
+        try testing.expect(std.mem.indexOf(u8, body.items, nostr.signer_ipc.reason_awaiting_approval) != null);
+        try testing.expect(std.mem.indexOf(u8, body.items, "\"sig\"") == null);
+    }
+
+    var queue: [Broker.capacity]Pending = undefined;
+    try testing.expectEqual(@as(usize, 1), broker.snapshot(&queue));
+    try testing.expect(queue[0].local);
+    try testing.expectEqualStrings(test_client, queue[0].client());
+    try testing.expectEqualStrings("sign_event", queue[0].method());
+    try testing.expectEqual(@as(i32, 1), queue[0].kind);
+    // What is being signed, not just what shape it is.
+    try testing.expectEqualStrings("hello", queue[0].preview());
+
+    // Nothing here waits for an answer, so an app is free to hammer. Ten more
+    // tries must not become ten more rows: thirty-two of these and every other
+    // app's question is buried under one app's retries.
+    for (0..10) |_| {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, io, &out.writer, req, test_client);
+    }
+    try testing.expectEqual(@as(usize, 1), broker.snapshot(&queue));
+}
+
+test "an answer given once is not asked again, and frees its slot" {
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    gate.preload(kp);
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    const req = try signRequest(gpa, 1);
+    defer gpa.free(req);
+
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, io, &out.writer, req, test_client);
+    }
+    var queue: [Broker.capacity]Pending = undefined;
+    try testing.expectEqual(@as(usize, 1), broker.snapshot(&queue));
+
+    // The person says yes, always. Nobody is parked on this request: it was
+    // refused and the client went away. If answering it left the slot in use,
+    // thirty-two answered questions would fill the queue for good.
+    try testing.expect(broker.resolveFor(queue[0].id, .approve, .always, 0));
+    try testing.expectEqual(@as(usize, 0), broker.snapshot(&queue));
+
+    // And now it signs, without asking anybody anything.
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
+        try testing.expect(std.mem.indexOf(u8, body.items, "dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659") != null);
+    }
+    try testing.expectEqual(@as(usize, 0), broker.snapshot(&queue));
+}
+
+test "a refused app is refused without asking again" {
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var broker: Broker = .{};
+    // "No, and stop asking." A denial has to be as durable as a grant, or
+    // refusing an app is just asking it to try again in a second.
+    broker.permissions.remember(nostr.signer_ipc.clientId(test_client), .sign_event, 1, false, .always, 0);
+
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    gate.preload(kp);
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    const req = try signRequest(gpa, 1);
+    defer gpa.free(req);
+    var out = std.Io.Writer.Allocating.init(gpa);
+    defer out.deinit();
+    try handleSignerSign(&server, io, &out.writer, req, test_client);
+    var body = out.toArrayList();
+    defer body.deinit(gpa);
+    try testing.expect(std.mem.indexOf(u8, body.items, "403") != null);
+    // Refused for good, not queued for a person: the two say different things
+    // to a client, and a refused app must not be able to raise a prompt.
+    try testing.expect(std.mem.indexOf(u8, body.items, nostr.signer_ipc.reason_refused) != null);
+    var queue: [Broker.capacity]Pending = undefined;
+    try testing.expectEqual(@as(usize, 0), broker.snapshot(&queue));
+}
+
+test "an app that will not name itself gets nothing, and raises nothing" {
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    gate.preload(kp);
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    const req = try signRequest(gpa, 1);
+    defer gpa.free(req);
+
+    // No name at all, and a name that could rewrite the row it is shown on.
+    // Neither may raise a prompt: an app that cannot be named cannot be
+    // answered for, so a queue entry for one is a question with no subject.
+    for ([_][]const u8{ "", "app\nname", "an app name with spaces in it" }) |name| {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, io, &out.writer, req, name);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "400") != null);
+        try testing.expect(std.mem.indexOf(u8, body.items, nostr.signer_ipc.reason_unnamed) != null);
+        try testing.expect(std.mem.indexOf(u8, body.items, "\"sig\"") == null);
+    }
+    var queue: [Broker.capacity]Pending = undefined;
+    try testing.expectEqual(@as(usize, 0), broker.snapshot(&queue));
+}
+
+test "writing a message and reading one are answered separately" {
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var broker: Broker = .{};
+    // Allowed to encrypt. Says nothing about decrypting, which is the one that
+    // reads somebody's messages back.
+    broker.permissions.remember(nostr.signer_ipc.clientId(test_client), .nip44_encrypt, -1, true, .always, 0);
+
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    gate.preload(kp);
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    const peer = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    const body_json = try (nostr.signer_ipc.Cipher{ .peer = peer, .items = &.{"hello"} }).toJson(gpa);
+    defer gpa.free(body_json);
+
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerCipher(&server, io, &out.writer, body_json, test_client, .encrypt);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
+    }
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerCipher(&server, io, &out.writer, body_json, test_client, .decrypt);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "403") != null);
+        try testing.expect(std.mem.indexOf(u8, body.items, nostr.signer_ipc.reason_awaiting_approval) != null);
+    }
+}
+
+test "a locked daemon says so rather than asking for permission it cannot use" {
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .locked);
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    const req = try signRequest(gpa, 1);
+    defer gpa.free(req);
+    var out = std.Io.Writer.Allocating.init(gpa);
+    defer out.deinit();
+    try handleSignerSign(&server, io, &out.writer, req, test_client);
+    var body = out.toArrayList();
+    defer body.deinit(gpa);
+
+    // Locked is the answer, and the client needs it: it has to ask for the
+    // passphrase, not wait for an approval nobody will be shown. Waking
+    // somebody to allow a signature the daemon could not produce anyway
+    // teaches them that the prompts do not mean anything.
+    try testing.expect(std.mem.indexOf(u8, body.items, "409") != null);
+    try testing.expect(std.mem.indexOf(u8, body.items, nostr.signer_ipc.reason_locked) != null);
+    var queue: [Broker.capacity]Pending = undefined;
+    try testing.expectEqual(@as(usize, 0), broker.snapshot(&queue));
+}
+
+test "an app cannot name itself out of the queue's JSON" {
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    // Printable ASCII, so the name rules allow it, and it closes the string it
+    // is printed into. This field held a pubkey in hex until local apps started
+    // choosing what goes in it.
+    const hostile = "a\",\"kind\":666,\"x\":\"";
+    var info = Pending{ .id = 7, .local = true, .kind = 1 };
+    @memcpy(info.method_buf[0..10], "sign_event");
+    info.method_len = 10;
+    @memcpy(info.client_buf[0..hostile.len], hostile);
+    info.client_len = @intCast(hostile.len);
+    try testing.expect(broker.knock(info));
+
+    var out = std.Io.Writer.Allocating.init(gpa);
+    defer out.deinit();
+    try handlePending(&server, io, &out.writer, "/pending?since=0");
+    var body = out.toArrayList();
+    defer body.deinit(gpa);
+
+    const start = std.mem.indexOf(u8, body.items, "{\"version\"").?;
+    const Parsed = struct {
+        version: u64,
+        pending: []struct { id: u64, method: []const u8, kind: i32, created_at: i64, local: bool, client: []const u8, preview: []const u8 },
+    };
+    const parsed = try std.json.parseFromSlice(Parsed, gpa, body.items[start..], .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+
+    try testing.expectEqual(@as(usize, 1), parsed.value.pending.len);
+    // The name arrives whole, as data, and the kind it tried to overwrite is
+    // still the one the daemon put there.
+    try testing.expectEqualStrings(hostile, parsed.value.pending[0].client);
+    try testing.expectEqual(@as(i32, 1), parsed.value.pending[0].kind);
+    try testing.expect(parsed.value.pending[0].local);
 }

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -384,20 +384,44 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
     self.last_request_ms.store(std.Io.Timestamp.now(io, .awake).toMilliseconds(), .monotonic);
 
     // Assemble the body: bytes already read after the head, plus any remainder.
+    //
+    // Four kilobytes on the stack covers a passphrase, a decision and an
+    // ordinary note, and it is nowhere near enough for the two things this
+    // server grew: a `/sign` body carries a whole event as ESCAPED JSON inside
+    // another JSON string, so a note with a few tags and a link doubles on the
+    // way in, and the cipher endpoints are batched precisely so a catch-up of
+    // thousands of messages is not thousands of round trips. A batch that has
+    // to fit in four kilobytes is not a batch.
+    //
+    // So anything larger is read onto the heap, and the ceiling is a real
+    // refusal rather than a formality: a body arrives before any of it is
+    // understood, and something has to say when to stop.
     var body_storage: [4096]u8 = undefined;
     defer std.crypto.secureZero(u8, &body_storage);
+    var heap_body: ?[]u8 = null;
+    defer if (heap_body) |b| {
+        // The same care the stack buffer gets. A `/setup` import or a decrypted
+        // batch passes through here, and freed memory is not erased memory.
+        std.crypto.secureZero(u8, b);
+        self.gpa.free(b);
+    };
     var body: []const u8 = "";
     if (content_length > 0) {
-        if (content_length > body_storage.len) return respond(w, 413, "{\"error\":\"body too large\"}");
+        if (content_length > max_body_bytes) return respond(w, 413, "{\"error\":\"body too large\"}");
+        const dest: []u8 = if (content_length <= body_storage.len) body_storage[0..content_length] else blk: {
+            heap_body = self.gpa.alloc(u8, content_length) catch
+                return respond(w, 413, "{\"error\":\"body too large\"}");
+            break :blk heap_body.?;
+        };
         const body_start = head_end + 4;
         var got = @min(len - body_start, content_length);
-        @memcpy(body_storage[0..got], buf[body_start .. body_start + got]);
+        @memcpy(dest[0..got], buf[body_start .. body_start + got]);
         while (got < content_length) {
-            const n = r.readSliceShort(body_storage[got..content_length]) catch break;
+            const n = r.readSliceShort(dest[got..content_length]) catch break;
             if (n == 0) break;
             got += n;
         }
-        body = body_storage[0..got];
+        body = dest[0..got];
     }
 
     if (eql(method, "GET") and eql(path, "/info"))
@@ -922,6 +946,18 @@ fn localAllowed(
 
     const id = ipc.clientId(name);
     const now_ms = std.Io.Timestamp.now(io, .real).toMilliseconds();
+
+    // An answer given ONCE, to the question this request already raised. Taking
+    // it spends it, which is the whole of what "once" means. Checked before
+    // what was remembered, because a request only reached the queue at all
+    // when nothing was remembered for it.
+    if (self.broker.takeOneShot(id, method, kind, now_ms)) |allowed| {
+        if (allowed) return true;
+        note(self, io, .{ .what = what, .outcome = "refused", .who = name, .local = true, .method = method.name(), .kind = kind });
+        try respondIpcError(self, w, 403, ipc.reason_refused);
+        return false;
+    }
+
     if (self.broker.permissions.remembered(id, method, kind, now_ms)) |allowed| {
         if (allowed) return true;
         note(self, io, .{ .what = what, .outcome = "refused", .who = name, .local = true, .method = method.name(), .kind = kind });
@@ -1107,6 +1143,18 @@ fn respondPubkey(self: *Server, w: *std.Io.Writer) !void {
 }
 
 // --- HTTP plumbing -------------------------------------------------------
+
+/// The largest request body this server will read.
+///
+/// One megabyte, against a batched NIP-44 catch-up, which is the only thing
+/// here that is legitimately big: a few thousand ciphertexts of a few hundred
+/// bytes each. A signed event is a fraction of it even after the JSON escaping
+/// doubles it.
+///
+/// A ceiling rather than no limit, because the length is a number the caller
+/// chose and the memory is committed before a single byte of the body has been
+/// looked at.
+const max_body_bytes = 1024 * 1024;
 
 const bad_request = "{\"error\":\"bad request\"}";
 
@@ -2068,4 +2116,104 @@ test "the idle clock is only wound by a caller that presented the token" {
     // which is where an unauthorized caller would slip one in.
     const head_at = std.mem.indexOf(u8, src, "const request_line = lines.next()").?;
     try testing.expect(std.mem.indexOfPos(u8, src, head_at, "self.last_request_ms.store(").? == stamp_at);
+}
+
+test "Allow once actually lets one request through, and only one" {
+    // The button a careful person presses, and the one that did nothing.
+    //
+    // `.once` is deliberately never written to the permission store, because
+    // on the relay path the thread that asked is parked on the slot and reads
+    // the answer straight off it. A local request has no such thread: it was
+    // refused the moment it arrived, so the only way an answer can reach it is
+    // through the daemon's memory. With `.once` storing nothing, the retry
+    // found nothing and queued the same question again. Pressing "Allow once"
+    // re-prompted forever and no local app could ever sign.
+    const gpa = testing.allocator;
+    const io = testing.io;
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    gate.preload(kp);
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    const req = try signRequest(gpa, 1);
+    defer gpa.free(req);
+
+    // Asked, and refused pending an answer.
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, io, &out.writer, req, test_client);
+    }
+    var queue: [Broker.capacity]Pending = undefined;
+    try testing.expectEqual(@as(usize, 1), broker.snapshot(&queue));
+
+    // "Allow once".
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        const body = try std.fmt.allocPrint(gpa, "{{\"id\":{d},\"decision\":\"approve\",\"remember\":\"once\"}}", .{queue[0].id});
+        defer gpa.free(body);
+        try handleDecision(&server, io, &out.writer, body);
+    }
+
+    // The retry signs. This is the assertion that was false.
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
+        try testing.expect(std.mem.indexOf(u8, body.items, "dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659") != null);
+    }
+
+    // And ONLY one. The next request is a fresh question, or "once" would be a
+    // quieter way of saying "always".
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "403") != null);
+        try testing.expect(std.mem.indexOf(u8, body.items, nostr.signer_ipc.reason_awaiting_approval) != null);
+    }
+    try testing.expectEqual(@as(usize, 1), broker.snapshot(&queue));
+}
+
+test "a one-shot answer covers only the question it answered" {
+    var broker: Broker = .{};
+    const plaza = nostr.signer_ipc.clientId("plaza");
+    const other = nostr.signer_ipc.clientId("something-else");
+
+    var info = Pending{ .local = true, .kind = 1, .method_id = .sign_event, .client_id = plaza };
+    try testing.expect(broker.knock(info));
+    var q: [Broker.capacity]Pending = undefined;
+    _ = broker.snapshot(&q);
+    try testing.expect(broker.resolveFor(q[0].id, .approve, .once, 1_000_000));
+
+    // Not another app's request, not another method, not another kind. Each of
+    // those is a different question, and an answer to one is not an answer to
+    // any of the others.
+    try testing.expect(broker.takeOneShot(other, .sign_event, 1, 1_000_000) == null);
+    try testing.expect(broker.takeOneShot(plaza, .nip44_decrypt, 1, 1_000_000) == null);
+    try testing.expect(broker.takeOneShot(plaza, .sign_event, 3, 1_000_000) == null);
+
+    // The right one, once.
+    try testing.expectEqual(true, broker.takeOneShot(plaza, .sign_event, 1, 1_000_000).?);
+    try testing.expect(broker.takeOneShot(plaza, .sign_event, 1, 1_000_000) == null);
+
+    // An answer nobody came back for lapses, so it cannot be spent by whatever
+    // asks next: the app it was given to may have been closed in between.
+    info.kind = 7;
+    try testing.expect(broker.knock(info));
+    _ = broker.snapshot(&q);
+    try testing.expect(broker.resolveFor(q[0].id, .approve, .once, 1_000_000));
+    try testing.expect(broker.takeOneShot(plaza, .sign_event, 7, 1_000_000 + Broker.one_shot_ms) == null);
 }

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -28,6 +28,7 @@ const onboarding = @import("onboarding.zig");
 
 const net = std.Io.net;
 const nip46 = nostr.nip46;
+const ipc = nostr.signer_ipc;
 const Broker = approval.Broker;
 const Pending = approval.Pending;
 const Gate = onboarding.Gate;
@@ -332,6 +333,18 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
         return handlePending(self, io, w, path);
     if (eql(method, "POST") and eql(path, "/decision"))
         return handleDecision(self, w, body);
+    // The local signing protocol (nostr's `signer_ipc`), which is what lets a
+    // client on this machine use this daemon without a relay round trip. The
+    // paths come from the library so every product speaks one protocol rather
+    // than each inventing its own.
+    if (eql(method, "GET") and eql(path, ipc.path_pubkey))
+        return handleSignerPubkey(self, w);
+    if (eql(method, "POST") and eql(path, ipc.path_sign))
+        return handleSignerSign(self, w, body);
+    if (eql(method, "POST") and eql(path, ipc.path_nip44_encrypt))
+        return handleSignerCipher(self, io, w, body, .encrypt);
+    if (eql(method, "POST") and eql(path, ipc.path_nip44_decrypt))
+        return handleSignerCipher(self, io, w, body, .decrypt);
     return respond(w, 404, "{\"error\":\"not found\"}");
 }
 
@@ -678,6 +691,135 @@ fn handleUnlock(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) 
     return respondPubkey(self, w);
 }
 
+// --- the local signing protocol ------------------------------------------
+//
+// `nostr.signer_ipc` over this same channel, so a client on this machine can
+// use the key without a relay round trip. The relay side of this daemon serves
+// clients that reached it over NIP-46; this serves the ones that are right
+// here. Both end at the same key, the same gate and the same permissions.
+
+/// The state the wire reports, from the gate's own.
+///
+/// Three states, not two, and the mapping is the point. A LOCKED daemon must
+/// not report `uninitialized`: that reads as "there is no key here", and a
+/// client that believes it offers to make one over the top of an identity that
+/// already exists. A nostr key cannot be replaced, so that is the one mistake
+/// worth designing the vocabulary around.
+fn signerState(gate: *const Gate) []const u8 {
+    return switch (gate.current()) {
+        .uninitialized => ipc.state_uninitialized,
+        .locked => ipc.state_locked,
+        .unlocked => ipc.state_ready,
+    };
+}
+
+fn respondIpcError(self: *Server, w: *std.Io.Writer, status: u16, message: []const u8) !void {
+    const body = ipc.Failure{ .@"error" = message };
+    const j = body.toJson(self.gpa) catch return respond(w, status, bad_request);
+    defer self.gpa.free(j);
+    return respond(w, status, j);
+}
+
+/// GET /pubkey: what state this daemon is in and whose key it holds.
+///
+/// The pubkey rides along while LOCKED as well as ready, because whose key it
+/// is was never the secret and a client that knows it can name the account it
+/// is asking to unlock rather than showing a passphrase box for nobody.
+fn handleSignerPubkey(self: *Server, w: *std.Io.Writer) !void {
+    const locked_or_ready = self.gate.current() != .uninitialized;
+    const body = ipc.Pubkey{
+        .state = signerState(self.gate),
+        .pubkey = if (locked_or_ready) self.gate.pubkeyHex() else "",
+    };
+    const j = body.toJson(self.gpa) catch return respond(w, 500, bad_request);
+    defer self.gpa.free(j);
+    return respond(w, 200, j);
+}
+
+/// POST /sign: sign one event with the held key.
+fn handleSignerSign(self: *Server, w: *std.Io.Writer, body: []const u8) !void {
+    var parsed = ipc.parse(ipc.SignEvent, self.gpa, body) catch
+        return respondIpcError(self, w, 400, "malformed sign request");
+    defer parsed.deinit();
+
+    var unsigned = nostr.event.fromJson(self.gpa, parsed.value.event) catch
+        return respondIpcError(self, w, 400, "not a valid event");
+    defer unsigned.deinit();
+    const ev = unsigned.value;
+
+    // Kinds 14 and 15 are the UNSIGNED rumors inside a NIP-59 gift wrap. A
+    // signature on one destroys the deniability the whole scheme exists for,
+    // so this refuses them however they are asked for.
+    if (ev.kind == 14 or ev.kind == 15)
+        return respondIpcError(self, w, 422, "kind 14 and 15 are never signed");
+
+    if (self.gate.current() != .unlocked)
+        return respondIpcError(self, w, 409, "the key is locked");
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const kp = signer.keyPairFromSecretKey(self.gate.secret_key) catch
+        return respondIpcError(self, w, 500, "bad key");
+
+    const signed = nostr.event.create(self.gpa, signer, kp, ev.created_at, ev.kind, ev.tags, ev.content, null) catch
+        return respondIpcError(self, w, 500, "signing failed");
+    const json = nostr.event.toJson(self.gpa, signed) catch
+        return respondIpcError(self, w, 500, "out of memory");
+    defer self.gpa.free(json);
+
+    const out = ipc.SignEvent{ .event = json };
+    const out_json = out.toJson(self.gpa) catch
+        return respondIpcError(self, w, 500, "out of memory");
+    defer self.gpa.free(out_json);
+    return respond(w, 200, out_json);
+}
+
+/// POST /nip44/encrypt and /nip44/decrypt: batched, N items in and N out in
+/// order. Batching is the point rather than a nicety: a DM catch-up is
+/// thousands of decrypts and one round trip each would drown in overhead.
+fn handleSignerCipher(
+    self: *Server,
+    io: std.Io,
+    w: *std.Io.Writer,
+    body: []const u8,
+    comptime dir: enum { encrypt, decrypt },
+) !void {
+    var parsed = ipc.parse(ipc.Cipher, self.gpa, body) catch
+        return respondIpcError(self, w, 400, "malformed cipher request");
+    defer parsed.deinit();
+    const req = parsed.value;
+
+    var peer: [32]u8 = undefined;
+    if (req.peer.len != 64 or (std.fmt.hexToBytes(&peer, req.peer) catch null) == null)
+        return respondIpcError(self, w, 400, "peer must be 32-byte hex");
+
+    if (self.gate.current() != .unlocked)
+        return respondIpcError(self, w, 409, "the key is locked");
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+
+    var out: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (out.items) |item| self.gpa.free(item);
+        out.deinit(self.gpa);
+    }
+    for (req.items) |item| {
+        const result = switch (dir) {
+            .encrypt => nostr.nip44.encrypt(self.gpa, io, signer, self.gate.secret_key, peer, item),
+            .decrypt => nostr.nip44.decrypt(self.gpa, signer, self.gate.secret_key, peer, item),
+        } catch return respondIpcError(self, w, 422, "a cipher item failed");
+        out.append(self.gpa, result) catch
+            return respondIpcError(self, w, 500, "out of memory");
+    }
+
+    const res = ipc.CipherResult{ .items = out.items };
+    const j = res.toJson(self.gpa) catch
+        return respondIpcError(self, w, 500, "out of memory");
+    defer self.gpa.free(j);
+    return respond(w, 200, j);
+}
+
 fn respondPubkey(self: *Server, w: *std.Io.Writer) !void {
     var out: [128]u8 = undefined;
     const j = std.fmt.bufPrint(&out, "{{\"ok\":true,\"pubkey\":\"{s}\"}}", .{self.gate.pubkeyHex()}) catch unreachable;
@@ -796,6 +938,158 @@ test "parseSince reads the query parameter" {
     try testing.expectEqual(@as(u64, 0), parseSince("/pending"));
     try testing.expectEqual(@as(u64, 7), parseSince("/pending?since=7"));
     try testing.expectEqual(@as(u64, 3), parseSince("/pending?foo=1&since=3"));
+}
+
+/// One `/sign` request body of the shape a client really sends: a complete
+/// event whose id, pubkey and signature are zeroed, since those are the three
+/// things it is asking the daemon to fill in.
+fn signRequest(gpa: std.mem.Allocator, kind: u16) ![]u8 {
+    const unsigned = nostr.event.Event{
+        .id = [_]u8{0} ** 32,
+        .pubkey = [_]u8{0} ** 32,
+        .created_at = 1_700_000_000,
+        .kind = kind,
+        .tags = &.{},
+        .content = "hello",
+        .sig = [_]u8{0} ** 64,
+    };
+    const unsigned_json = try nostr.event.toJson(gpa, unsigned);
+    defer gpa.free(unsigned_json);
+    return (ipc.SignEvent{ .event = unsigned_json }).toJson(gpa);
+}
+
+test "GET /pubkey tells a local client which of THREE states this is" {
+    // The mapping is the whole point. A locked daemon reporting
+    // "uninitialized" would read as "there is no key here", and a client that
+    // believes that offers to create one over the top of an identity that
+    // already exists. A nostr key cannot be replaced, so this is the mistake
+    // the vocabulary is shaped around.
+    const gpa = testing.allocator;
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+    const pubkey_hex = "dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659";
+
+    var broker: Broker = .{};
+
+    // Nothing set up: no key, and no pubkey to name.
+    {
+        var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+        var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerPubkey(&server, &out.writer);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "\"state\":\"uninitialized\"") != null);
+        try testing.expect(std.mem.indexOf(u8, body.items, "\"pubkey\":\"\"") != null);
+    }
+
+    // Holds a key, cannot use it yet. It says so, AND it says whose key it is,
+    // so a client can name the account it is asking to unlock.
+    {
+        var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+        gate.preload(kp);
+        gate.state.store(@intFromEnum(onboarding.State.locked), .release);
+        var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerPubkey(&server, &out.writer);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "\"state\":\"locked\"") != null);
+        try testing.expect(std.mem.indexOf(u8, body.items, pubkey_hex) != null);
+        // The one reading that must never happen.
+        try testing.expect(std.mem.indexOf(u8, body.items, "uninitialized") == null);
+    }
+
+    // Unlocked: ready, in the word the wire uses rather than the gate's own.
+    {
+        var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+        gate.preload(kp);
+        var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerPubkey(&server, &out.writer);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "\"state\":\"ready\"") != null);
+    }
+}
+
+test "POST /sign signs with the held key, and refuses a locked one" {
+    const gpa = testing.allocator;
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var broker: Broker = .{};
+    // The shape a client actually sends: a complete event with the id, pubkey
+    // and signature left zeroed, because those are what it is asking for.
+    const req = try signRequest(gpa, 1);
+    defer gpa.free(req);
+
+    // Unlocked: the answer carries a signed event under the held key.
+    {
+        var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+        gate.preload(kp);
+        var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, &out.writer, req);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
+        // Signed as the key this daemon holds, not as somebody else.
+        try testing.expect(std.mem.indexOf(u8, body.items, "dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659") != null);
+    }
+
+    // Locked: refuses rather than signing with a key it has not been given.
+    {
+        var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .locked);
+        var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, &out.writer, req);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "409") != null);
+    }
+}
+
+test "a gift-wrap rumor is never signed, locked or not" {
+    // Kinds 14 and 15 are the UNSIGNED inner payloads of a NIP-59 gift wrap. A
+    // signature on one destroys the deniability the whole scheme exists for,
+    // and a messenger asking for it is asking for a mistake. Refused before the
+    // gate is even consulted, so it reads the same whatever state the key is in.
+    const gpa = testing.allocator;
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var broker: Broker = .{};
+    for ([_]u16{ 14, 15 }) |kind| {
+        var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+        gate.preload(kp); // unlocked, so nothing else can be the reason
+        var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+        const req = try signRequest(gpa, kind);
+        defer gpa.free(req);
+
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleSignerSign(&server, &out.writer, req);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "422") != null);
+        try testing.expect(std.mem.indexOf(u8, body.items, "\"sig\"") == null);
+    }
 }
 
 test "GET /info reports the bunker URI once unlocked" {

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -80,15 +80,6 @@ pub const Server = struct {
     /// Filled by `bind`, consumed by `run`. Null until bound.
     listener: ?net.Server = null,
 
-    /// When the last authorized request arrived, or when the daemon bound its
-    /// port if none has.
-    ///
-    /// Every request touches it, including the polls both windows run while
-    /// they are open, which is what makes it a usable measure of "is anybody
-    /// there": a reader looking at either window is a steady stream of
-    /// requests, and silence means every app that was using this daemon has
-    /// gone.
-    last_request_ms: std.atomic.Value(i64) = .init(0),
     /// How long that silence may last before the daemon exits. Zero stays up
     /// forever.
     idle_exit_ms: i64 = 0,
@@ -192,7 +183,7 @@ pub const Server = struct {
         // goes. Measured live: with the clock starting at the first request
         // instead, a daemon that was only ever knocked on by something without
         // the token stayed up indefinitely.
-        self.last_request_ms.store(std.Io.Timestamp.now(io, .awake).toMilliseconds(), .monotonic);
+        self.broker.touch(std.Io.Timestamp.now(io, .awake).toMilliseconds());
     }
 
     /// Serves forever on the calling thread, binding first if nobody has.
@@ -271,7 +262,11 @@ fn runReaper(self: *Server) void {
         io.sleep(std.Io.Duration.fromSeconds(1), .awake) catch {};
         const now = std.Io.Timestamp.now(io, .awake).toMilliseconds();
         self.reapStale(io, now);
-        if (idleExpired(self.idle_exit_ms, self.last_request_ms.load(.monotonic), now))
+        // Questions from the local protocol have nobody waiting to time them
+        // out, so this is where they go. Without it, thirty-two unanswered
+        // ones fill the queue for good and nothing can be asked about again.
+        self.broker.expireUnanswered(std.Io.Timestamp.now(io, .real).toSeconds());
+        if (idleExpired(self.idle_exit_ms, self.broker.last_request_ms.load(.monotonic), now))
             exitIdle(self, io);
     }
 }
@@ -381,7 +376,7 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
     // Somebody is here. Stamped AFTER the credential check, so a stranger
     // cannot keep the key alive by knocking: the clock means "the apps allowed
     // to use this are still around", and failed attempts are not those apps.
-    self.last_request_ms.store(std.Io.Timestamp.now(io, .awake).toMilliseconds(), .monotonic);
+    self.broker.touch(std.Io.Timestamp.now(io, .awake).toMilliseconds());
 
     // Assemble the body: bytes already read after the head, plus any remainder.
     //
@@ -986,9 +981,25 @@ fn localAllowed(
     @memcpy(info.client_buf[0..name.len], name);
     info.client_len = @intCast(name.len);
     info.preview_len = approval.previewOf(preview, &info.preview_buf);
-    _ = self.broker.knock(info);
+    // Only a question actually FILED is worth a line. A client that retries
+    // every second is not news, and one whose every retry wrote a line could
+    // roll the audit log away by asking often enough.
+    switch (self.broker.knock(info)) {
+        .filed => note(self, io, .{ .what = what, .outcome = "awaiting", .who = name, .local = true, .method = method.name(), .kind = kind }),
+        .already_asked => {},
+        // The queue is full, so nobody will ever see this question. Answering
+        // "awaiting approval" would send the client away to wait for something
+        // that was never asked.
+        // The queue is full, so nobody will ever see this question. Answering
+        // "awaiting approval" would send the client away to wait for something
+        // that was never asked.
+        .no_room => {
+            note(self, io, .{ .what = what, .outcome = "no room", .who = name, .local = true, .method = method.name(), .kind = kind });
+            try respondIpcError(self, w, 503, ipc.reason_refused);
+            return false;
+        },
+    }
 
-    note(self, io, .{ .what = what, .outcome = "awaiting", .who = name, .local = true, .method = method.name(), .kind = kind });
     try respondIpcError(self, w, 403, ipc.reason_awaiting_approval);
     return false;
 }
@@ -1909,7 +1920,7 @@ test "an app cannot name itself out of the queue's JSON" {
     info.method_len = 10;
     @memcpy(info.client_buf[0..hostile.len], hostile);
     info.client_len = @intCast(hostile.len);
-    try testing.expect(broker.knock(info));
+    try testing.expectEqual(Broker.Knock.filed, broker.knock(info));
 
     var out = std.Io.Writer.Allocating.init(gpa);
     defer out.deinit();
@@ -2110,12 +2121,12 @@ test "the idle clock is only wound by a caller that presented the token" {
     const auth_at = std.mem.indexOf(u8, src, "if (!authOk(auth, self.token)) return respond").?;
     // The request handler's stamp, not `bind`'s: both write the same field,
     // and only one of them is on the path a caller can reach.
-    const stamp_at = std.mem.indexOfPos(u8, src, auth_at, "self.last_request_ms.store(").?;
+    const stamp_at = std.mem.indexOfPos(u8, src, auth_at, "self.broker.touch(").?;
     try testing.expect(auth_at < stamp_at);
     // And there is no OTHER stamp between the head being read and the check,
     // which is where an unauthorized caller would slip one in.
     const head_at = std.mem.indexOf(u8, src, "const request_line = lines.next()").?;
-    try testing.expect(std.mem.indexOfPos(u8, src, head_at, "self.last_request_ms.store(").? == stamp_at);
+    try testing.expect(std.mem.indexOfPos(u8, src, head_at, "self.broker.touch(").? == stamp_at);
 }
 
 test "Allow once actually lets one request through, and only one" {
@@ -2193,7 +2204,7 @@ test "a one-shot answer covers only the question it answered" {
     const other = nostr.signer_ipc.clientId("something-else");
 
     var info = Pending{ .local = true, .kind = 1, .method_id = .sign_event, .client_id = plaza };
-    try testing.expect(broker.knock(info));
+    try testing.expectEqual(Broker.Knock.filed, broker.knock(info));
     var q: [Broker.capacity]Pending = undefined;
     _ = broker.snapshot(&q);
     try testing.expect(broker.resolveFor(q[0].id, .approve, .once, 1_000_000));
@@ -2212,7 +2223,7 @@ test "a one-shot answer covers only the question it answered" {
     // An answer nobody came back for lapses, so it cannot be spent by whatever
     // asks next: the app it was given to may have been closed in between.
     info.kind = 7;
-    try testing.expect(broker.knock(info));
+    try testing.expectEqual(Broker.Knock.filed, broker.knock(info));
     _ = broker.snapshot(&q);
     try testing.expect(broker.resolveFor(q[0].id, .approve, .once, 1_000_000));
     try testing.expect(broker.takeOneShot(plaza, .sign_event, 7, 1_000_000 + Broker.one_shot_ms) == null);

--- a/daemon/src/audit.zig
+++ b/daemon/src/audit.zig
@@ -1,0 +1,290 @@
+//! What the key did, written down.
+//!
+//! Until this, nothing was. The daemon printed relay lifecycle to stderr, and
+//! when the window starts it the SDK's spawn discards that stream outright, so
+//! for everybody who runs this as an application there was no record anywhere
+//! of a single signature. "Did something sign as me while I was away" had no
+//! answer, and neither did "how did this note get published".
+//!
+//! One JSON object per line, appended. Line-oriented because the reader is
+//! `tail -f` or `grep`, and a format that has to be closed to be valid is a
+//! format that a crash leaves unreadable.
+//!
+//! What is NOT here is as deliberate as what is. No passphrases, no keys, no
+//! plaintext, no note content. A signed event is recorded by its id, which is
+//! public the moment it is published and is exactly what finds it again. A
+//! cipher is recorded by peer and item count. An audit log that quotes what you
+//! wrote is a second copy of your messages in a file nothing else protects.
+//!
+//! Best effort, always. A log that cannot be written must never stop a
+//! signature: the failure mode of "audit or refuse" on a full disk is a signer
+//! that will not sign, which is a worse day than a gap in a log.
+
+const std = @import("std");
+
+/// Where the log goes when nobody chose, under $HOME beside the key.
+pub const default_file = ".zig-nostr-signer.log";
+
+/// How large the log may get before it is rolled over to `<path>.1`.
+///
+/// One line is around 150 bytes and one line is one use of the key, so this is
+/// years of ordinary use, and two files is a bound on the disk a signer can
+/// take rather than a history worth pruning.
+pub const max_bytes: u64 = 4 << 20;
+
+/// One thing that happened. Only what is set is written, so the lines stay
+/// short enough to read in a terminal.
+pub const Event = struct {
+    /// What happened, in one word: `sign`, `cipher`, `decision`, `unlock`,
+    /// `setup`, `lock`, `forget`.
+    what: []const u8,
+    /// How it ended: `ok`, `refused`, `awaiting`, `locked`, `unnamed`, `bad`.
+    outcome: []const u8 = "",
+    /// Who asked. A pubkey in hex over a relay, a self-chosen name from an app
+    /// on this machine, and `local` says which, because they are not the same
+    /// kind of fact.
+    who: []const u8 = "",
+    local: bool = false,
+    method: []const u8 = "",
+    /// The event kind for a signature, or -1 where there is none.
+    kind: i32 = -1,
+    /// The id of what was signed. Not its content.
+    id: []const u8 = "",
+    /// The other side of a NIP-44 conversation, and how many items were in the
+    /// batch. Not the messages.
+    peer: []const u8 = "",
+    count: usize = 0,
+    /// How long an answer was recorded for, on a `decision`.
+    remember: []const u8 = "",
+};
+
+pub const Log = struct {
+    /// The directory `path` is resolved against. Held rather than assumed, the
+    /// way the key gate holds its own, so a test writes into a temporary
+    /// directory instead of the reader's home.
+    dir: std.Io.Dir = undefined,
+    /// Empty disables the log. Tests that are not about the log run this way,
+    /// and so does a reader who set the path to nothing on purpose.
+    path: []const u8 = "",
+    lock: std.atomic.Value(bool) = .init(false),
+
+    fn acquire(self: *Log) void {
+        while (self.lock.cmpxchgWeak(false, true, .acquire, .monotonic) != null) {
+            std.Thread.yield() catch {};
+        }
+    }
+    fn release(self: *Log) void {
+        self.lock.store(false, .release);
+    }
+
+    /// Appends one line. Never fails, never blocks anything real.
+    pub fn note(self: *Log, io: std.Io, at: i64, event: Event) void {
+        if (self.path.len == 0) return;
+
+        var line: [640]u8 = undefined;
+        var lw = std.Io.Writer.fixed(&line);
+        format(&lw, at, event) catch return; // A line too long to fit is dropped, not truncated into a half-object.
+        const bytes = lw.buffered();
+
+        self.acquire();
+        defer self.release();
+
+        var file = self.dir.createFile(io, self.path, .{
+            .truncate = false,
+            .permissions = std.Io.File.Permissions.fromMode(0o600),
+        }) catch return;
+        var end: u64 = if (file.stat(io)) |st| st.size else |_| 0;
+
+        // Rolled rather than truncated: the last four megabytes of history are
+        // worth more than the first four, and losing both at once is how a log
+        // that was supposed to answer a question comes up empty.
+        if (end + bytes.len > max_bytes) {
+            file.close(io);
+            self.roll(io);
+            file = self.dir.createFile(io, self.path, .{
+                .truncate = false,
+                .permissions = std.Io.File.Permissions.fromMode(0o600),
+            }) catch return;
+            end = 0;
+        }
+        defer file.close(io);
+
+        var buf: [640]u8 = undefined;
+        var w = file.writer(io, &buf);
+        w.seekTo(end) catch return;
+        w.interface.writeAll(bytes) catch return;
+        w.interface.flush() catch return;
+    }
+
+    fn roll(self: *Log, io: std.Io) void {
+        var old: [1024]u8 = undefined;
+        if (self.path.len + 2 > old.len) return;
+        const prev = std.fmt.bufPrint(&old, "{s}.1", .{self.path}) catch return;
+        self.dir.rename(self.path, self.dir, prev, io) catch {};
+    }
+};
+
+/// Writes one line, including its newline.
+fn format(w: *std.Io.Writer, at: i64, e: Event) !void {
+    try w.print("{{\"at\":{d},\"what\":\"{s}\"", .{ at, e.what });
+    if (e.outcome.len != 0) try w.print(",\"outcome\":\"{s}\"", .{e.outcome});
+    if (e.who.len != 0) {
+        try w.writeAll(",\"local\":");
+        try w.writeAll(if (e.local) "true" else "false");
+        try w.writeAll(",\"who\":");
+        try jsonString(w, e.who);
+    }
+    if (e.method.len != 0) try w.print(",\"method\":\"{s}\"", .{e.method});
+    if (e.kind >= 0) try w.print(",\"kind\":{d}", .{e.kind});
+    if (e.id.len != 0) try w.print(",\"id\":\"{s}\"", .{e.id});
+    if (e.peer.len != 0) try w.print(",\"peer\":\"{s}\"", .{e.peer});
+    if (e.count != 0) try w.print(",\"count\":{d}", .{e.count});
+    if (e.remember.len != 0) try w.print(",\"remember\":\"{s}\"", .{e.remember});
+    try w.writeAll("}\n");
+}
+
+/// `s` as a JSON string literal, quotes included.
+///
+/// Only `who` needs this, and only since apps on this machine started choosing
+/// what goes in it: printable ASCII includes the quote and the backslash, so a
+/// name can close the string it is written into and put whatever it likes in
+/// the object around it. The queue's JSON has the same problem and its own
+/// answer in `approval_http.appendJsonString`; this one writes to a stream
+/// rather than an allocating list.
+fn jsonString(w: *std.Io.Writer, s: []const u8) !void {
+    try w.writeByte('"');
+    for (s) |c| switch (c) {
+        '"' => try w.writeAll("\\\""),
+        '\\' => try w.writeAll("\\\\"),
+        '\n' => try w.writeAll("\\n"),
+        '\r' => try w.writeAll("\\r"),
+        '\t' => try w.writeAll("\\t"),
+        0x00...0x08, 0x0b, 0x0c, 0x0e...0x1f => try w.print("\\u{x:0>4}", .{c}),
+        else => try w.writeByte(c),
+    };
+    try w.writeByte('"');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+fn render(gpa: std.mem.Allocator, at: i64, e: Event) ![]u8 {
+    var out = std.Io.Writer.Allocating.init(gpa);
+    errdefer out.deinit();
+    try format(&out.writer, at, e);
+    return out.toOwnedSlice();
+}
+
+test "a line carries what happened and nothing it was told in confidence" {
+    const gpa = testing.allocator;
+    const l = try render(gpa, 1700000000, .{
+        .what = "sign",
+        .outcome = "ok",
+        .who = "plaza",
+        .local = true,
+        .method = "sign_event",
+        .kind = 1,
+        .id = "ab" ** 32,
+    });
+    defer gpa.free(l);
+
+    try testing.expect(std.mem.endsWith(u8, l, "}\n"));
+    const parsed = try std.json.parseFromSlice(struct {
+        at: i64,
+        what: []const u8,
+        outcome: []const u8,
+        local: bool,
+        who: []const u8,
+        method: []const u8,
+        kind: i32,
+        id: []const u8,
+    }, gpa, l, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(i64, 1700000000), parsed.value.at);
+    try testing.expectEqualStrings("plaza", parsed.value.who);
+    try testing.expect(parsed.value.local);
+    try testing.expectEqual(@as(i32, 1), parsed.value.kind);
+}
+
+test "an app cannot name itself out of the log either" {
+    // The same hole as the approval queue's JSON, in a second sink. A name is
+    // printable ASCII, and printable ASCII includes the quote: a line that
+    // interpolated it raw would let an app write its own fields into the
+    // record of what it did, which is precisely the record it would want to
+    // rewrite.
+    const gpa = testing.allocator;
+    const hostile = "a\",\"what\":\"nothing happened\",\"x\":\"";
+    const l = try render(gpa, 1, .{ .what = "sign", .outcome = "ok", .who = hostile, .local = true });
+    defer gpa.free(l);
+
+    const parsed = try std.json.parseFromSlice(
+        struct { what: []const u8, who: []const u8 },
+        gpa,
+        l,
+        .{ .ignore_unknown_fields = true },
+    );
+    defer parsed.deinit();
+    try testing.expectEqualStrings(hostile, parsed.value.who);
+    try testing.expectEqualStrings("sign", parsed.value.what);
+}
+
+test "a field nobody set is left out rather than written empty" {
+    const gpa = testing.allocator;
+    const l = try render(gpa, 5, .{ .what = "lock" });
+    defer gpa.free(l);
+    try testing.expectEqualStrings("{\"at\":5,\"what\":\"lock\"}\n", l);
+}
+
+test "the log appends, and rolls over rather than growing without end" {
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var log = Log{ .dir = tmp.dir, .path = "audit.log" };
+    log.note(io, 1, .{ .what = "unlock", .outcome = "ok" });
+    log.note(io, 2, .{ .what = "sign", .outcome = "refused", .who = "plaza", .local = true });
+
+    const first = try tmp.dir.readFileAlloc(io, "audit.log", gpa, .unlimited);
+    defer gpa.free(first);
+    // Appended, not overwritten. A log that keeps only the last thing that
+    // happened answers no question worth asking.
+    try testing.expectEqual(@as(usize, 2), std.mem.count(u8, first, "\n"));
+    try testing.expect(std.mem.indexOf(u8, first, "\"what\":\"unlock\"") != null);
+    try testing.expect(std.mem.indexOf(u8, first, "\"what\":\"sign\"") != null);
+
+    // Only the same user may read what the key has been doing.
+    const st = try tmp.dir.statFile(io, "audit.log", .{});
+    try testing.expectEqual(@as(std.posix.mode_t, 0), st.permissions.toMode() & 0o077);
+}
+
+test "a full log is rolled to one side, not thrown away" {
+    const io = testing.io;
+    const gpa = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Already at the cap, so the next line has to make room. Written straight
+    // to the file rather than by logging four megabytes a line at a time.
+    const filler = try gpa.alloc(u8, max_bytes);
+    defer gpa.free(filler);
+    @memset(filler, 'x');
+    try tmp.dir.writeFile(io, .{ .sub_path = "audit.log", .data = filler });
+
+    var log = Log{ .dir = tmp.dir, .path = "audit.log" };
+    log.note(io, 9, .{ .what = "sign", .outcome = "ok" });
+
+    // The new line is alone in a fresh file, and the old one is beside it. An
+    // audit log that truncated itself would drop the older half of the history
+    // at the moment somebody most wants to read it.
+    const now = try tmp.dir.readFileAlloc(io, "audit.log", gpa, .unlimited);
+    defer gpa.free(now);
+    try testing.expectEqualStrings("{\"at\":9,\"what\":\"sign\",\"outcome\":\"ok\"}\n", now);
+
+    const kept = try tmp.dir.readFileAlloc(io, "audit.log.1", gpa, .unlimited);
+    defer gpa.free(kept);
+    try testing.expectEqual(max_bytes, kept.len);
+}

--- a/daemon/src/audit.zig
+++ b/daemon/src/audit.zig
@@ -100,12 +100,24 @@ pub const Log = struct {
         // that was supposed to answer a question comes up empty.
         if (end + bytes.len > max_bytes) {
             file.close(io);
-            self.roll(io);
+            if (!self.roll(io)) {
+                // The rename did not happen, so the old file is still there and
+                // still full. Assuming otherwise and writing at offset zero
+                // would paint this line over the START of the history, which is
+                // the worst possible outcome for a log: not a gap, a forgery.
+                // Better to lose this line than to corrupt the ones before it.
+                return;
+            }
             file = self.dir.createFile(io, self.path, .{
                 .truncate = false,
                 .permissions = std.Io.File.Permissions.fromMode(0o600),
             }) catch return;
-            end = 0;
+            // Re-read rather than assume. The rename succeeded, but between it
+            // and this open anything could have put a file back.
+            end = if (file.stat(io)) |st| st.size else |_| {
+                file.close(io);
+                return;
+            };
         }
         defer file.close(io);
 
@@ -116,11 +128,13 @@ pub const Log = struct {
         w.interface.flush() catch return;
     }
 
-    fn roll(self: *Log, io: std.Io) void {
+    /// Moves the full log aside, saying whether it actually happened.
+    fn roll(self: *Log, io: std.Io) bool {
         var old: [1024]u8 = undefined;
-        if (self.path.len + 2 > old.len) return;
-        const prev = std.fmt.bufPrint(&old, "{s}.1", .{self.path}) catch return;
-        self.dir.rename(self.path, self.dir, prev, io) catch {};
+        if (self.path.len + 2 > old.len) return false;
+        const prev = std.fmt.bufPrint(&old, "{s}.1", .{self.path}) catch return false;
+        self.dir.rename(self.path, self.dir, prev, io) catch return false;
+        return true;
     }
 };
 
@@ -287,4 +301,38 @@ test "a full log is rolled to one side, not thrown away" {
     const kept = try tmp.dir.readFileAlloc(io, "audit.log.1", gpa, .unlimited);
     defer gpa.free(kept);
     try testing.expectEqual(max_bytes, kept.len);
+}
+
+test "a rollover that did not happen never writes over the history" {
+    // The failure this exists for is not a gap, it is a forgery. If the rename
+    // is refused and the code assumes it worked, the next line lands at offset
+    // zero, on top of the OLDEST entries, and the file still parses. A reader
+    // would be looking at a log whose beginning is somebody else's afternoon.
+    const io = testing.io;
+    const gpa = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const filler = try gpa.alloc(u8, max_bytes);
+    defer gpa.free(filler);
+    @memset(filler, 'x');
+    // A recognisable head, so overwriting it is visible rather than inferred.
+    @memcpy(filler[0..5], "HEAD.");
+    try tmp.dir.writeFile(io, .{ .sub_path = "audit.log", .data = filler });
+
+    // A DIRECTORY where the rolled-aside file would go. Renaming a file onto a
+    // directory is refused by the OS, which is the failure without simulating
+    // one.
+    try tmp.dir.createDirPath(io, "audit.log.1");
+
+    var log = Log{ .dir = tmp.dir, .path = "audit.log" };
+    log.note(io, 9, .{ .what = "sign", .outcome = "ok" });
+
+    const after = try tmp.dir.readFileAlloc(io, "audit.log", gpa, .unlimited);
+    defer gpa.free(after);
+    try testing.expectEqual(max_bytes, after.len);
+    try testing.expectEqualStrings("HEAD.", after[0..5]);
+    // And the line that could not be filed is simply absent, rather than
+    // sitting where the history used to be.
+    try testing.expect(std.mem.indexOf(u8, after, "\"what\":\"sign\"") == null);
 }

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -240,12 +240,15 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
         .path = getEnv("SIGNER_LOG_FILE") orelse resolveHome(gpa, default_log_file),
     };
 
-    const token_hex = makeAndWriteToken(gpa, token_path);
     var approval_server: approval_http.Server = .{
         .gpa = gpa,
         .broker = &broker_storage,
         .gate = &gate,
-        .token = token_hex,
+        // Filled after the bind. Minting it here would overwrite a RUNNING
+        // daemon's token before discovering the port is already theirs, and
+        // every client holding the old one would start getting 401s from a
+        // daemon that was working perfectly.
+        .token = "",
         .log = &g_audit,
         .idle_exit_ms = idleExitMs(),
         .info = .{ .relays = relays.items, .timeout_ms = broker_storage.timeout_ms, .secret = conn_secret, .relay_status = relay_status },
@@ -263,6 +266,12 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
     // detach rather than after: afterwards there is nobody left to tell.
     approval_server.bind(io) catch |err|
         failFmt("could not bind the approval API on {s}: {s}", .{ addr, @errorName(err) });
+
+    // The port is ours, so the credential for it is ours to mint. Not one line
+    // earlier: the address is fixed and well known, so losing the race to it is
+    // the ordinary way a second daemon starts, and a loser that had already
+    // rewritten the shared token file would take every client down with it.
+    approval_server.token = makeAndWriteToken(gpa, token_path);
     announcePort(io, approval_server.bound_port.load(.acquire));
 
     if (detach) detachFromSpawner();

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -19,6 +19,7 @@ const PolicyConfig = nostr.nip46.PolicyConfig;
 const approval = @import("approval.zig");
 const approval_http = @import("approval_http.zig");
 const onboarding = @import("onboarding.zig");
+const audit = @import("audit.zig");
 const relay_keeper = @import("relay_keeper.zig");
 
 const keys = nostr.keys;
@@ -30,6 +31,7 @@ const hex = nostr.hex;
 // configuration; each is overridable via its environment variable. The key and
 // token files sit under $HOME; relays default to a public relay.
 const default_token_file = ".zig-nostr-signer.token";
+const default_log_file = audit.default_file;
 
 const default_key_file = ".zig-nostr-signer.key";
 // What the GUI serves on when the reader has not chosen. THREE, not one.
@@ -56,6 +58,14 @@ const default_key_file = ".zig-nostr-signer.key";
 var g_seen_requests: nostr.signer.SeenRequests = .{};
 var g_authorized_clients: nip46.AuthorizedClients = .{};
 
+/// Where every use of the key is written down.
+///
+/// Process-lived and shared, because both the relay threads and the approval
+/// server write to it, and one file with one lock is the only way those lines
+/// stay whole. Its path is set at startup; until then it is a log that goes
+/// nowhere, which is what the non-GUI paths want anyway.
+var g_audit: audit.Log = .{};
+
 const default_gui_relays = "wss://nostr.oxtr.dev,wss://theforest.nostr1.com,wss://relay.primal.net";
 
 const usage =
@@ -72,6 +82,8 @@ const usage =
     \\  SIGNER_ALLOWED_KINDS   comma-separated event kinds sign_event may sign
     \\                         (default: any kind)
     \\  SIGNER_INIT            if set, create/import an encrypted key file and exit
+    \\  SIGNER_LOG_FILE        where uses of the key are written down (default:
+    \\                         $HOME/.zig-nostr-signer.log; empty turns it off)
     \\
     \\Subcommands:
     \\  import                 paste an existing nsec, read from the terminal
@@ -192,12 +204,21 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
         fail("out of memory tracking relay status");
     for (relay_status) |*s| s.* = std.atomic.Value(u8).init(@intFromEnum(approval_http.RelayStatus.connecting));
 
+    // Beside the key, and readable only by this user, because it is a list of
+    // everything that key has done. `SIGNER_LOG_FILE=""` turns it off for
+    // somebody who would rather it did not exist.
+    g_audit = .{
+        .dir = std.Io.Dir.cwd(),
+        .path = getEnv("SIGNER_LOG_FILE") orelse resolveHome(gpa, default_log_file),
+    };
+
     const token_hex = makeAndWriteToken(gpa, token_path);
     var approval_server: approval_http.Server = .{
         .gpa = gpa,
         .broker = &broker_storage,
         .gate = &gate,
         .token = token_hex,
+        .log = &g_audit,
         .info = .{ .relays = relays.items, .timeout_ms = broker_storage.timeout_ms, .secret = conn_secret, .relay_status = relay_status },
         .clients = &g_authorized_clients,
         .host = hp.host,
@@ -217,10 +238,11 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
         \\  approval API : http://{s}  (bearer token → {s})
         \\  key file     : {s}
         \\  key state    : {s}
+        \\  audit log    : {s}
         \\
         \\{s}
         \\
-    , .{ addr, token_path, key_file, @tagName(booted), key_note });
+    , .{ addr, token_path, key_file, @tagName(booted), if (g_audit.path.len == 0) "(off)" else g_audit.path, key_note });
 
     // Block until the GUI creates or unlocks the key (returns at once if a
     // preconfigured key was loaded above), then serve with it. The broker is
@@ -408,6 +430,7 @@ fn serveRelayForever(
         .config = policy_config,
         .io = io,
         .gpa = gpa,
+        .log = &g_audit,
     };
     const request_policy = if (broker != null) interactive.asPolicy() else policy_config.policy();
 
@@ -762,6 +785,7 @@ test {
     //
     // The serve loop, keystore, and policy tests now run in the nostr library.
     _ = @import("approval.zig");
+    _ = @import("audit.zig");
     _ = @import("approval_http.zig");
     _ = @import("onboarding.zig");
     _ = @import("relay_keeper.zig");

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -30,6 +30,7 @@ const hex = nostr.hex;
 // configuration; each is overridable via its environment variable. The key and
 // token files sit under $HOME; relays default to a public relay.
 const default_token_file = ".zig-nostr-signer.token";
+
 const default_key_file = ".zig-nostr-signer.key";
 // What the GUI serves on when the reader has not chosen. THREE, not one.
 //

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -33,6 +33,25 @@ const hex = nostr.hex;
 const default_token_file = ".zig-nostr-signer.token";
 const default_log_file = audit.default_file;
 
+/// How long the daemon stays up with nothing using it.
+///
+/// Fifteen minutes, and the number is a trade rather than a preference. Both
+/// windows poll while they are open, so this clock only starts once every app
+/// has gone; shorter and somebody who quits an app for two minutes has to type
+/// their passphrase again, longer and a machine left alone keeps a decrypted
+/// key for an afternoon.
+///
+/// `SIGNER_IDLE_EXIT_MS=0` keeps it up forever, which is what somebody running
+/// this headless as a bunker for their phone wants: there is no window there
+/// to poll, so silence is the normal state rather than a sign that everyone
+/// left.
+const default_idle_exit_ms: i64 = 15 * 60 * 1000;
+
+fn idleExitMs() i64 {
+    const raw = getEnv("SIGNER_IDLE_EXIT_MS") orelse return default_idle_exit_ms;
+    return std.fmt.parseInt(i64, raw, 10) catch default_idle_exit_ms;
+}
+
 const default_key_file = ".zig-nostr-signer.key";
 // What the GUI serves on when the reader has not chosen. THREE, not one.
 //
@@ -84,6 +103,10 @@ const usage =
     \\  SIGNER_INIT            if set, create/import an encrypted key file and exit
     \\  SIGNER_LOG_FILE        where uses of the key are written down (default:
     \\                         $HOME/.zig-nostr-signer.log; empty turns it off)
+    \\  SIGNER_DETACH          if set, leave the starting app's process group, so
+    \\                         the daemon outlives it and can be shared
+    \\  SIGNER_IDLE_EXIT_MS    exit after this long with no request (default:
+    \\                         900000, fifteen minutes; 0 stays up forever)
     \\
     \\Subcommands:
     \\  import                 paste an existing nsec, read from the terminal
@@ -134,17 +157,22 @@ pub fn main(init: std.process.Init) !void {
     // `SIGNER_APPROVAL_HTTP`. Parse argv here so the slice lives for the process
     // (GUI/relay mode never returns).
     var approval_addr = getEnv("SIGNER_APPROVAL_HTTP");
+    // `--detach` for the same reason as the address: an app started from
+    // Finder has no environment worth inheriting, so anything the window needs
+    // to say to the daemon has to be said in argv.
+    var detach = envIsOn("SIGNER_DETACH");
     var args = std.process.Args.Iterator.init(init.minimal.args);
     _ = args.skip(); // argv[0]
     while (args.next()) |arg| {
         if (std.mem.eql(u8, arg, "--approval-http")) {
             approval_addr = args.next();
-            break;
+        } else if (std.mem.eql(u8, arg, "--detach")) {
+            detach = true;
         }
     }
 
     if (approval_addr) |addr| {
-        runGuiMode(gpa, addr, conn_secret, &policy_config);
+        runGuiMode(gpa, addr, conn_secret, &policy_config, detach);
     }
 
     // Headless mode: the key must already be available (from an encrypted key
@@ -167,7 +195,7 @@ pub fn main(init: std.process.Init) !void {
 /// first-run key onboarding over it, then serve with the resulting key. The
 /// broker and server live in this frame, which never returns (it tail-calls the
 /// forever-serving `runRelays`), so their addresses are stable for the process.
-fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8, policy_config: *const PolicyConfig) noreturn {
+fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8, policy_config: *const PolicyConfig, detach: bool) noreturn {
     const hp = parseHostPort(addr) orelse
         fail("SIGNER_APPROVAL_HTTP must be host:port, e.g. 127.0.0.1:8787");
 
@@ -219,11 +247,26 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
         .gate = &gate,
         .token = token_hex,
         .log = &g_audit,
+        .idle_exit_ms = idleExitMs(),
         .info = .{ .relays = relays.items, .timeout_ms = broker_storage.timeout_ms, .secret = conn_secret, .relay_status = relay_status },
         .clients = &g_authorized_clients,
         .host = hp.host,
         .port = hp.port,
     };
+    // Bind BEFORE anything else, and before any thread exists, because the
+    // next two things both depend on it: the spawner is told the port only if
+    // there is one, and the fork that frees this daemon from its spawner has
+    // to happen while this is still a single-threaded process.
+    //
+    // A bind that fails kills the daemon here, loudly, while the spawner is
+    // still watching. That is the whole reason the port is reported before the
+    // detach rather than after: afterwards there is nobody left to tell.
+    approval_server.bind(io) catch |err|
+        failFmt("could not bind the approval API on {s}: {s}", .{ addr, @errorName(err) });
+    announcePort(io, approval_server.bound_port.load(.acquire));
+
+    if (detach) detachFromSpawner();
+
     const server_thread = std.Thread.spawn(.{}, runApprovalServer, .{&approval_server}) catch
         fail("could not start the approval server");
     server_thread.detach();
@@ -736,6 +779,78 @@ fn makeAndWriteToken(gpa: std.mem.Allocator, path: []const u8) []u8 {
         .flags = .{ .truncate = true, .permissions = std.Io.File.Permissions.fromMode(0o600) },
     }) catch |err| failFmt("could not write the token file '{s}': {s}", .{ path, @errorName(err) });
     return token_hex;
+}
+
+/// The one line the spawner reads: the port this daemon is listening on.
+///
+/// STDOUT, and that matters. The SDK's line-mode spawn ignores a child's
+/// stderr outright (`.stderr = ... else .ignore`), so the human-facing banner
+/// below it is dropped on the floor and a spawner watching for this would wait
+/// forever.
+///
+/// Printed after the bind and before the detach. Both halves of that are
+/// deliberate: after, because a port nobody got is not worth reporting; before,
+/// because once this process has detached there is nobody left listening.
+fn announcePort(io: std.Io, port: u16) void {
+    var out_buf: [64]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(io, &out_buf);
+    stdout.interface.print("{s} {d}\n", .{ approval_http.port_line_prefix, port }) catch {};
+    stdout.interface.flush() catch {};
+}
+
+/// Leaves the process group of whoever started this daemon, when asked to.
+///
+/// A keyholder that several apps share cannot be one app's child. The Native
+/// SDK group-kills the children it spawns when the app quits, which is right
+/// for a private helper and catastrophic for a shared one: close the window
+/// that happened to start the daemon and every OTHER app loses its signer
+/// mid-sentence, with no error anywhere, because from their side the socket
+/// simply stops answering.
+///
+/// A plain `setsid` does not get out of the way. The group kill falls back to
+/// signalling the child's own pid, and after `setsid` that pid is exactly what
+/// the new group is named after, so it is hit either way. Escaping takes a
+/// DESCENDANT: this process forks, the parent exits at once so the spawner
+/// sees a clean exit, and the child takes a new session whose id is its own
+/// pid, which nothing the spawner knows about can name.
+///
+/// Then the three inherited standard descriptors go to /dev/null. Not tidiness:
+/// a detached child holding the spawner's stdout write end open means the
+/// spawner's reader never sees EOF and its worker is abandoned rather than
+/// finishing. Nothing is lost by closing them, because a process that has just
+/// left its terminal has no reader.
+///
+/// The listening socket is untouched and survives the fork, which is the whole
+/// reason binding happens first.
+/// Whether an environment variable is set to something meaning yes.
+///
+/// Present-but-empty and "0" mean no, so a launcher that exports the name
+/// unconditionally does not turn a behaviour on by accident.
+fn envIsOn(name: [*:0]const u8) bool {
+    const v = getEnv(name) orelse return false;
+    return v.len != 0 and !std.mem.eql(u8, v, "0");
+}
+
+fn detachFromSpawner() void {
+    const pid = std.c.fork();
+    if (pid < 0) {
+        // Could not fork: keep serving as a child rather than not at all. The
+        // shared-daemon hazard is back, and saying so is better than exiting
+        // and leaving the reader with no signer whatsoever.
+        std.debug.print("signer: could not detach; this daemon will end when the app that started it does\n", .{});
+        return;
+    }
+    if (pid > 0) std.c._exit(0); // the spawner's child, done the moment it has forked
+
+    _ = std.c.setsid();
+
+    const devnull = std.c.open("/dev/null", .{ .ACCMODE = .RDWR });
+    if (devnull >= 0) {
+        _ = std.c.dup2(devnull, 0);
+        _ = std.c.dup2(devnull, 1);
+        _ = std.c.dup2(devnull, 2);
+        if (devnull > 2) _ = std.c.close(devnull);
+    }
 }
 
 /// Runs the approval HTTP server on its own thread with its own io.

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -184,7 +184,7 @@
           <card padding="12">
             <column gap="10">
               <text>{r.label}</text>
-              <text foreground="text_muted">{r.asker}</text>
+              <text foreground="text_muted" wrap="true">{r.asker}</text>
               <if test="{r.has_preview}">
                 <text wrap="true">{r.preview}</text>
               </if>

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -191,7 +191,7 @@
               <row gap="8">
                 <button variant="primary" grow="1" on-press="approve:{r.id}">Allow once</button>
                 <button grow="1" on-press="approve_day:{r.id}">For a day</button>
-                <button grow="1" on-press="approve_always:{r.id}">Always</button>
+                <button grow="1" on-press="approve_always:{r.id}">Until locked</button>
               </row>
               <button variant="destructive" on-press="reject:{r.id}">Deny</button>
             </column>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -914,9 +914,26 @@ pub const app_markup = @embedFile("app.native");
 const NotaryApp = native_sdk.UiApp(Model, Msg);
 const Effects = NotaryApp.Effects;
 
-/// What we ask the daemon to bind in managed mode: loopback, port chosen by the
-/// kernel. See `Model.port_known` for why.
-const managed_bind_address = "127.0.0.1:0";
+/// What we ask the daemon to bind in managed mode.
+///
+/// The WELL KNOWN address now, not `127.0.0.1:0`. A kernel-chosen port and a
+/// stdout line is a rendezvous only the spawner can use, and it was the right
+/// shape while this window was the daemon's only client. It is the wrong shape
+/// for a daemon meant to be shared: another app that wants the same key did not
+/// spawn it, has no stdout to read, and has to be able to find one that is
+/// already running.
+///
+/// The NUMBER is the rendezvous, not a file naming the number. A port file is
+/// the obvious alternative and it is the dangerous one: it sits on disk
+/// writable by this same user, so anything running as them could point it at a
+/// listener of its own and every client would go there instead, while the real
+/// daemon sat healthy and idle, never knowing. There is nothing here to
+/// rewrite.
+///
+/// The bind stays EXCLUSIVE (`approval_http.Server.run`). Something that takes
+/// this port first does not get to answer for the daemon quietly: the bind
+/// fails and the daemon says so.
+const managed_bind_address = "127.0.0.1:8787";
 
 fn spawnDaemon(model: *Model, fx: *Effects) void {
     model.phase = .starting;

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -159,6 +159,13 @@ pub const Row = struct {
     /// The requesting client's pubkey, hex.
     client_buf: [64]u8 = [_]u8{0} ** 64,
     client_len: u8 = 0,
+    /// Whether `client_buf` holds a name an app on this Mac chose for itself,
+    /// rather than the pubkey of whoever signed a request over a relay.
+    ///
+    /// The two are not the same kind of fact and the row must not read as
+    /// though they were. A relay client proved it holds a key. A local one
+    /// typed a word, and any program running as this user can type any word.
+    local: bool = false,
     /// The start of what would be signed.
     preview_buf: [160]u8 = [_]u8{0} ** 160,
     preview_len: u8 = 0,
@@ -206,14 +213,25 @@ pub const Row = struct {
         return self.method();
     }
 
-    /// Who is asking, short enough to read: the first and last of the pubkey.
+    /// Who is asking, short enough to read, and honest about how much that is
+    /// worth knowing.
     ///
-    /// The whole point of putting it on the row is that a person can tell one
-    /// requester from another, and sixty-four hex characters is not something
-    /// anybody compares. Eight and eight is.
+    /// Two different facts share this line. A request that came over a relay
+    /// carries the pubkey that signed it, which is proof: "from" is the right
+    /// word, and eight characters of each end is what makes it comparable at
+    /// all, since nobody reads sixty-four.
+    ///
+    /// A request from an app on this Mac carries a name the app chose. Any
+    /// program running as this user can read the daemon's token and claim any
+    /// name, so "from Plaza" would state something nobody checked, on the one
+    /// row in this application where a person is being asked to check
+    /// something. "Calling itself" is the same length and true.
     pub fn asker(self: *const Row, arena: std.mem.Allocator) []const u8 {
         const c = self.client();
-        if (c.len < 20) return if (c.len == 0) "unknown client" else c;
+        if (c.len == 0) return "unknown client";
+        if (self.local)
+            return std.fmt.allocPrint(arena, "an app on this Mac calling itself \"{s}\"", .{c}) catch c;
+        if (c.len < 20) return c;
         return std.fmt.allocPrint(arena, "from {s}…{s}", .{ c[0..8], c[c.len - 8 ..] }) catch c;
     }
 };
@@ -1675,6 +1693,7 @@ pub fn parsePending(model: *Model, body: []const u8) void {
             method: []const u8 = "",
             kind: i32 = -1,
             created_at: i64 = 0,
+            local: bool = false,
             client: []const u8 = "",
             preview: []const u8 = "",
         } = &.{},
@@ -1685,7 +1704,7 @@ pub fn parsePending(model: *Model, body: []const u8) void {
     var n: usize = 0;
     for (parsed.pending) |p| {
         if (n >= max_pending) break;
-        var row = Row{ .id = p.id, .kind = p.kind, .created_at = p.created_at };
+        var row = Row{ .id = p.id, .kind = p.kind, .created_at = p.created_at, .local = p.local };
         row.setMethod(p.method);
         row.setClient(p.client);
         row.setPreview(p.preview);

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -392,6 +392,10 @@ pub const Model = struct {
     /// Attached mode sets it at boot: the address came from the environment and
     /// is the operator's business.
     port_known: bool = false,
+    /// Whether this window has already started a daemon. Not the same question
+    /// as "is one running": another app may have started the one we are talking
+    /// to, and that is the ordinary case rather than a fallback.
+    spawned: bool = false,
     /// A `/setup` or `/unlock` POST is in flight (disables the submit button).
     submitting: bool = false,
     onboard_error_buf: [96]u8 = [_]u8{0} ** 96,
@@ -935,10 +939,35 @@ const Effects = NotaryApp.Effects;
 /// fails and the daemon says so.
 const managed_bind_address = "127.0.0.1:8787";
 
+/// Whether this window may start a daemon of its own, on a retry tick.
+///
+/// Split out because it is the rule the shared daemon turns on, and a rule
+/// worth being able to state without an event loop around it. Three ways to
+/// answer no, and each is a different mistake avoided:
+///
+///   - not managed: this window was pointed at somebody else's daemon on
+///     purpose, and starting a competing one is not ours to do;
+///   - already spawned: a second would race the first onto a port the first
+///     holds exclusively, and the loser exits while this window waits for it;
+///   - connected: something is already serving, which is the ordinary case now
+///     rather than a fallback. Another app may have started it, or the reader
+///     may have opened Notary before Plaza.
+fn shouldStartDaemon(managed: bool, spawned: bool, phase: Phase) bool {
+    if (!managed or spawned) return false;
+    return phase != .connected;
+}
+
+pub fn shouldStartDaemonForTest(managed: bool, spawned: bool, phase: Phase) bool {
+    return shouldStartDaemon(managed, spawned, phase);
+}
+
 fn spawnDaemon(model: *Model, fx: *Effects) void {
     model.phase = .starting;
-    // A restarted daemon gets a different port, so anything we knew is stale.
-    model.port_known = false;
+    // Recorded so the retry tick starts at most one daemon per window: a second
+    // would race the first onto a port the first holds exclusively, and the
+    // loser exits while this window waits for it. It gates only the AUTOMATIC
+    // spawn; Restart and the sign-out paths call this directly and are meant to.
+    model.spawned = true;
     fx.spawn(.{
         .key = daemon_key,
         .argv = &.{ model.daemonBin(), "--approval-http", managed_bind_address },
@@ -1187,11 +1216,18 @@ fn onUnauthorized(model: *Model, fx: *Effects) void {
 
 /// Boot command: in managed mode spawn the daemon; either way begin connecting.
 pub fn boot(model: *Model, fx: *Effects) void {
-    if (model.managed) {
-        spawnDaemon(model, fx);
-    } else {
-        model.phase = .connecting;
-    }
+    // Look before starting one. The daemon is shared now: it outlives the
+    // window that spawned it (only `/lock` ends it), another app on this
+    // machine may have started it, and the reader may have opened that app
+    // first. Spawning unconditionally would put a second daemon on a port the
+    // first one holds exclusively, and the loser would exit while this window
+    // waited for it.
+    //
+    // So connect first and let the retry path start one only if nothing
+    // answers. Attaching to a daemon somebody else started is the normal case,
+    // not a fallback: the alternative is signing the reader out of whatever was
+    // already using it.
+    model.phase = .connecting;
     attemptConnect(model, fx);
     // Keep the live relay status fresh while serving (the initial /info is a
     // one-shot; the pending poll doesn't carry relay state).
@@ -1303,6 +1339,12 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         .tick => |t| {
             if (t.outcome != .fired) return;
             if (model.phase == .daemon_exited) return; // wait for the Restart button
+            // Nothing answered on the well-known address, so there is no daemon
+            // to attach to and this window may start one. Only in managed mode,
+            // and only once: attached mode was pointed at somebody else's
+            // daemon on purpose, and a second spawn would race the first.
+            if (shouldStartDaemon(model.managed, model.spawned, model.phase))
+                spawnDaemon(model, fx);
             // A full reconnect attempt: re-read the token, then poll.
             attemptConnect(model, fx);
         },
@@ -1698,9 +1740,14 @@ fn loadConfig(model: *Model, io: std.Io, environ: *const std.process.Environ.Map
         model.setDaemonBin(bin);
         model.managed = true;
     }
-    // Attached mode talks to whatever the operator pointed us at, so the
-    // address above is already the answer. Managed mode waits to be told.
-    model.port_known = !model.managed;
+    // The address is known in BOTH modes now. Attached mode talks to whatever
+    // the operator pointed us at; managed mode used to wait to be told, because
+    // the daemon was given a kernel-chosen port and printed it back. A
+    // well-known port removes that wait, and removing it is what lets this
+    // window look for a daemon that is ALREADY running before starting one of
+    // its own.
+    model.port_known = true;
+    if (model.managed) model.setBaseUrl(managed_bind_address);
 
     if (environ.get("SIGNER_APPROVAL_TOKEN_FILE")) |path| {
         model.setTokenPath(path);

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -1071,11 +1071,16 @@ fn sendSetup(model: *Model, fx: *Effects) void {
     var url_buf: [128]u8 = undefined;
     const url = std.fmt.bufPrint(&url_buf, "{s}/setup", .{model.baseUrl()}) catch return;
     var body_buf: [768]u8 = undefined;
-    const Body = struct { passphrase: []const u8, secret: []const u8 };
+    const Body = struct { method: []const u8, passphrase: []const u8, secret: []const u8 };
     // Trim whitespace so a stray space or newline (the key field is a wrapping
     // textarea) can't corrupt a pasted nsec/hex secret.
     const secret = if (model.import_mode) std.mem.trim(u8, model.secret(), " \t\r\n") else "";
-    const body = std.fmt.bufPrint(&body_buf, "{f}", .{std.json.fmt(Body{ .passphrase = model.passphrase(), .secret = secret }, .{})}) catch return;
+    // Which one the reader chose, SAID rather than left to be guessed from an
+    // empty secret. The daemon used to read "no secret" as "make me a new key",
+    // so an import whose paste trimmed to nothing minted a fresh identity
+    // instead of failing. It refuses now, and this is the half that tells it.
+    const method = if (model.import_mode) "import" else "create";
+    const body = std.fmt.bufPrint(&body_buf, "{f}", .{std.json.fmt(Body{ .method = method, .passphrase = model.passphrase(), .secret = secret }, .{})}) catch return;
     const headers = [_]std.http.Header{
         .{ .name = "authorization", .value = model.auth() },
         .{ .name = "content-type", .value = "application/json" },

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -414,6 +414,12 @@ pub const Model = struct {
     /// as "is one running": another app may have started the one we are talking
     /// to, and that is the ordinary case rather than a fallback.
     spawned: bool = false,
+    /// Retry ticks in a row that have not reached a daemon.
+    ///
+    /// The only evidence this window gets that a DETACHED daemon has died. It
+    /// is no longer a child, so nothing reports its exit; a socket that stops
+    /// answering is the whole signal.
+    connect_failures: u8 = 0,
     /// A `/setup` or `/unlock` POST is in flight (disables the submit button).
     submitting: bool = false,
     onboard_error_buf: [96]u8 = [_]u8{0} ** 96,
@@ -970,13 +976,49 @@ const managed_bind_address = "127.0.0.1:8787";
 ///   - connected: something is already serving, which is the ordinary case now
 ///     rather than a fallback. Another app may have started it, or the reader
 ///     may have opened Notary before Plaza.
-fn shouldStartDaemon(managed: bool, spawned: bool, phase: Phase) bool {
-    if (!managed or spawned) return false;
-    return phase != .connected;
+fn shouldStartDaemon(managed: bool, spawned: bool, failures: u8, phase: Phase) bool {
+    if (!managed) return false;
+    if (phase == .connected) return false;
+    if (!spawned) return true;
+    // One was started from here, and it detached, so its death is not reported
+    // to this window any more: it stopped being a child the moment it forked.
+    // A run of ticks that reached nothing is the only evidence there is, and
+    // waiting for a run rather than acting on one failure is what keeps a
+    // daemon that is merely slow to bind from being raced by a second.
+    return failures >= respawn_after_failures;
 }
 
-pub fn shouldStartDaemonForTest(managed: bool, spawned: bool, phase: Phase) bool {
-    return shouldStartDaemon(managed, spawned, phase);
+/// How many silent retry ticks amount to "there is no daemon there".
+///
+/// Three, against a retry that backs off, so a daemon still starting is not
+/// competed with. The cost of guessing wrong is small in one direction only:
+/// the bind is exclusive, so a redundant daemon exits at once instead of
+/// quietly taking over the address.
+const respawn_after_failures: u8 = 3;
+
+pub fn shouldStartDaemonForTest(managed: bool, spawned: bool, failures: u8, phase: Phase) bool {
+    return shouldStartDaemon(managed, spawned, failures, phase);
+}
+
+/// Whether this exit is a daemon that detached, rather than one that failed.
+///
+/// A detaching daemon forks and its first process exits 0 immediately, so this
+/// arrives seconds after every successful start and means the opposite of what
+/// it looks like: the daemon is up, it is simply no longer this window's child.
+///
+/// A clean exit is therefore not news. Anything else is: the daemon binds its
+/// port BEFORE it forks, precisely so a port it could not get still fails here,
+/// while somebody is watching, instead of vanishing into a process nobody is
+/// attached to.
+///
+/// Liveness after this point is the HTTP connection, which is the honest
+/// measure anyway. The process being alive never meant it was answering.
+fn daemonDetached(exit: native_sdk.EffectExit) bool {
+    return exit.reason == .exited and exit.code == 0;
+}
+
+pub fn daemonDetachedForTest(reason: native_sdk.EffectExitReason, code: i32) bool {
+    return daemonDetached(.{ .key = 0, .reason = reason, .code = code });
 }
 
 fn spawnDaemon(model: *Model, fx: *Effects) void {
@@ -988,10 +1030,22 @@ fn spawnDaemon(model: *Model, fx: *Effects) void {
     model.spawned = true;
     fx.spawn(.{
         .key = daemon_key,
-        .argv = &.{ model.daemonBin(), "--approval-http", managed_bind_address },
+        // `--detach` is what makes this a shared service rather than this
+        // window's child. The SDK group-kills what it spawns when the app
+        // quits, which is right for a private helper and wrong here: close
+        // this window and every other app using the key would lose its signer
+        // mid-sentence, with nothing to see but a socket that stopped
+        // answering. The daemon forks itself out of reach instead, and ends
+        // itself when nobody has asked it for anything in a while.
+        .argv = &.{ model.daemonBin(), "--approval-http", managed_bind_address, "--detach" },
         .on_line = Effects.lineMsg(.daemon_line),
         .on_exit = Effects.exitMsg(.daemon_exited),
     });
+}
+
+/// Counts an attempt that reached nothing, and forgets the run once one lands.
+fn noteConnectFailure(model: *Model) void {
+    if (model.connect_failures < 255) model.connect_failures += 1;
 }
 
 /// One connection attempt: (re-)read the token file, then poll. Re-reading on
@@ -1285,6 +1339,13 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             // A cancel we initiated (restart / app quit) reports `.cancelled`.
             // That is expected teardown, not a crash to report.
             if (exit.reason == .cancelled) return;
+            // A detaching daemon exits its FIRST process the moment it has
+            // forked, and that exit is the success signal, not a failure: the
+            // daemon it left behind is the one now listening. Only a non-zero
+            // code says something actually went wrong, and the daemon is
+            // careful to bind before it forks so a bad port still lands here
+            // where somebody can be told about it.
+            if (daemonDetached(exit)) return;
             model.phase = .daemon_exited;
             model.setExitNote(exit);
             model.setAuth("");
@@ -1330,6 +1391,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
                 onUnauthorized(model, fx);
             } else {
                 // The daemon may still be coming up; try again shortly.
+                noteConnectFailure(model);
                 armRetry(fx);
             }
         },
@@ -1338,12 +1400,14 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             .ok => switch (r.status) {
                 200 => {
                     model.phase = .connected;
+                    model.connect_failures = 0; // something answered
                     parsePending(model, r.body);
                     pollPending(model, fx); // re-arm the long-poll chain
                 },
                 401 => onUnauthorized(model, fx),
                 else => {
                     model.phase = .disconnected;
+                    noteConnectFailure(model);
                     armRetry(fx);
                 },
             },
@@ -1352,6 +1416,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             .rejected => armRetry(fx),
             else => {
                 if (model.phase == .connected) model.phase = .disconnected;
+                noteConnectFailure(model);
                 armRetry(fx);
             },
         },
@@ -1366,8 +1431,10 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             // to attach to and this window may start one. Only in managed mode,
             // and only once: attached mode was pointed at somebody else's
             // daemon on purpose, and a second spawn would race the first.
-            if (shouldStartDaemon(model.managed, model.spawned, model.phase))
+            if (shouldStartDaemon(model.managed, model.spawned, model.connect_failures, model.phase)) {
+                model.connect_failures = 0; // this attempt gets its own run
                 spawnDaemon(model, fx);
+            }
             // A full reconnect attempt: re-read the token, then poll.
             attemptConnect(model, fx);
         },

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -420,6 +420,12 @@ pub const Model = struct {
     /// is no longer a child, so nothing reports its exit; a socket that stops
     /// answering is the whole signal.
     connect_failures: u8 = 0,
+    /// Whether anything has ever answered on this address.
+    ///
+    /// Separates "there is no daemon here" from "the daemon I was talking to
+    /// went quiet for a moment". Those need opposite responses and looked
+    /// identical to a window that had not spawned anything itself.
+    ever_connected: bool = false,
     /// A `/setup` or `/unlock` POST is in flight (disables the submit button).
     submitting: bool = false,
     onboard_error_buf: [96]u8 = [_]u8{0} ** 96,
@@ -976,15 +982,21 @@ const managed_bind_address = "127.0.0.1:8787";
 ///   - connected: something is already serving, which is the ordinary case now
 ///     rather than a fallback. Another app may have started it, or the reader
 ///     may have opened Notary before Plaza.
-fn shouldStartDaemon(managed: bool, spawned: bool, failures: u8, phase: Phase) bool {
+fn shouldStartDaemon(managed: bool, spawned: bool, ever_connected: bool, failures: u8, phase: Phase) bool {
     if (!managed) return false;
     if (phase == .connected) return false;
-    if (!spawned) return true;
-    // One was started from here, and it detached, so its death is not reported
-    // to this window any more: it stopped being a child the moment it forked.
-    // A run of ticks that reached nothing is the only evidence there is, and
-    // waiting for a run rather than acting on one failure is what keeps a
-    // daemon that is merely slow to bind from being raced by a second.
+    // Nothing has ever answered here and this window has started nothing: its
+    // turn, once an attempt has actually come back empty.
+    if (!spawned and !ever_connected) return failures >= 1;
+    // Otherwise something WAS there: either this window started it, or it
+    // attached to a daemon somebody else did. Either way its death is not
+    // reported here, because a detached daemon is nobody's child, so a run of
+    // ticks that reached nothing is the only evidence there is.
+    //
+    // Waiting for the run matters most in the ATTACHED case. A single dropped
+    // poll against a perfectly healthy daemon would otherwise start a second
+    // one, which loses the race for a port the first holds exclusively and
+    // exits, for no reason the reader could see.
     return failures >= respawn_after_failures;
 }
 
@@ -996,8 +1008,8 @@ fn shouldStartDaemon(managed: bool, spawned: bool, failures: u8, phase: Phase) b
 /// quietly taking over the address.
 const respawn_after_failures: u8 = 3;
 
-pub fn shouldStartDaemonForTest(managed: bool, spawned: bool, failures: u8, phase: Phase) bool {
-    return shouldStartDaemon(managed, spawned, failures, phase);
+pub fn shouldStartDaemonForTest(managed: bool, spawned: bool, ever_connected: bool, failures: u8, phase: Phase) bool {
+    return shouldStartDaemon(managed, spawned, ever_connected, failures, phase);
 }
 
 /// Whether this exit is a daemon that detached, rather than one that failed.
@@ -1401,6 +1413,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
                 200 => {
                     model.phase = .connected;
                     model.connect_failures = 0; // something answered
+                    model.ever_connected = true;
                     parsePending(model, r.body);
                     pollPending(model, fx); // re-arm the long-poll chain
                 },
@@ -1431,7 +1444,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             // to attach to and this window may start one. Only in managed mode,
             // and only once: attached mode was pointed at somebody else's
             // daemon on purpose, and a second spawn would race the first.
-            if (shouldStartDaemon(model.managed, model.spawned, model.connect_failures, model.phase)) {
+            if (shouldStartDaemon(model.managed, model.spawned, model.ever_connected, model.connect_failures, model.phase)) {
                 model.connect_failures = 0; // this attempt gets its own run
                 spawnDaemon(model, fx);
             }

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -268,6 +268,23 @@ test "an approval row says who is asking and what would be signed" {
     main.parsePending(&old, "{\"version\":1,\"pending\":[{\"id\":9,\"method\":\"sign_event\",\"kind\":1,\"created_at\":0}]}");
     const old_tree = try buildTree(arena_state.allocator(), &old);
     _ = try expectByText(old_tree.root, .text, "unknown client");
+
+    // An app on this Mac gets the other sentence. It named itself, and any
+    // program running as this user could have named itself the same, so the
+    // row says what happened rather than asserting an identity: this is the
+    // one screen in the application whose whole job is to be read carefully
+    // before somebody allows a signature under their name.
+    var here = Model{};
+    here.phase = .connected;
+    main.parsePending(&here,
+        \\{"version":1,"pending":[{"id":10,"method":"sign_event","kind":1,"created_at":0,
+        \\"local":true,"client":"plaza","preview":"gm"}]}
+    );
+    const here_tree = try buildTree(arena_state.allocator(), &here);
+    _ = try expectByText(here_tree.root, .text, "an app on this Mac calling itself \"plaza\"");
+
+    // And it must not be dressed up as proof of who is asking.
+    try testing.expect(findByText(here_tree.root, .text, "from plaza") == null);
 }
 
 test "a populated view renders rows and dispatches typed approve/deny" {

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -315,11 +315,17 @@ test "a populated view renders rows and dispatches typed approve/deny" {
         else => return error.WrongMessage,
     }
 
-    const always = try expectByText(tree.root, .button, "Always");
+    // "Until locked", not "Always". Answers live in the daemon's memory and
+    // nothing writes them down, so every one of them ends when the key does.
+    // A button that promised forever would be describing a durability this
+    // does not have, on the screen where somebody is deciding how much to
+    // trust an app.
+    const always = try expectByText(tree.root, .button, "Until locked");
     switch (tree.msgForPointer(always.id, .up).?) {
         .approve_always => |id| try testing.expectEqual(@as(u64, 42), id),
         else => return error.WrongMessage,
     }
+    try testing.expect(findByText(tree.root, .button, "Always") == null);
 
     const deny = try expectByText(tree.root, .button, "Deny");
     switch (tree.msgForPointer(deny.id, .up).?) {

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -71,22 +71,33 @@ test "a window looks for a daemon before starting one" {
     // exclusively: the loser exits, and this window waits for something that is
     // never coming while a perfectly good daemon is already serving.
 
-    // Nothing is answering and this window has started nothing: its turn.
-    try testing.expect(main.shouldStartDaemonForTest(true, false, 0, .connecting));
-    try testing.expect(main.shouldStartDaemonForTest(true, false, 0, .disconnected));
+    // Nothing is answering and this window has started nothing: its turn, once
+    // one attempt has actually come back empty. Not on the very first tick,
+    // when the first connect may still be in flight.
+    try testing.expect(!main.shouldStartDaemonForTest(true, false, false, 0, .connecting));
+    try testing.expect(main.shouldStartDaemonForTest(true, false, false, 1, .connecting));
+    try testing.expect(main.shouldStartDaemonForTest(true, false, false, 1, .disconnected));
+
+    // But a window that ATTACHED to somebody else's daemon must not start a
+    // second one over a single dropped poll: the new one loses the race for a
+    // port the first holds exclusively and exits, for no reason a reader could
+    // see. It waits for the same run of silence as one that spawned.
+    try testing.expect(!main.shouldStartDaemonForTest(true, false, true, 1, .disconnected));
+    try testing.expect(!main.shouldStartDaemonForTest(true, false, true, 2, .disconnected));
+    try testing.expect(main.shouldStartDaemonForTest(true, false, true, 3, .disconnected));
 
     // Something IS answering. Attaching to a daemon somebody else started is
     // the ordinary case, not a fallback.
-    try testing.expect(!main.shouldStartDaemonForTest(true, false, 0, .connected));
+    try testing.expect(!main.shouldStartDaemonForTest(true, false, false, 0, .connected));
 
     // Already started one. A second races the first onto a port held
     // exclusively, and the loser exits.
-    try testing.expect(!main.shouldStartDaemonForTest(true, true, 0, .connecting));
-    try testing.expect(!main.shouldStartDaemonForTest(true, true, 2, .connecting));
+    try testing.expect(!main.shouldStartDaemonForTest(true, true, false, 0, .connecting));
+    try testing.expect(!main.shouldStartDaemonForTest(true, true, false, 2, .connecting));
 
     // Attached mode was pointed at somebody else's daemon on purpose.
-    try testing.expect(!main.shouldStartDaemonForTest(false, false, 0, .connecting));
-    try testing.expect(!main.shouldStartDaemonForTest(false, false, 0, .disconnected));
+    try testing.expect(!main.shouldStartDaemonForTest(false, false, false, 0, .connecting));
+    try testing.expect(!main.shouldStartDaemonForTest(false, false, false, 0, .disconnected));
 }
 
 test "a detached daemon that dies is noticed by silence, since nothing reports it" {
@@ -99,14 +110,14 @@ test "a detached daemon that dies is noticed by silence, since nothing reports i
     // So a run of ticks that reached nothing is the only evidence there is,
     // and without this the window would retry a dead address forever while
     // refusing to start a replacement, because it had started one once.
-    try testing.expect(!main.shouldStartDaemonForTest(true, true, 2, .disconnected));
-    try testing.expect(main.shouldStartDaemonForTest(true, true, 3, .disconnected));
-    try testing.expect(main.shouldStartDaemonForTest(true, true, 200, .disconnected));
+    try testing.expect(!main.shouldStartDaemonForTest(true, true, false, 2, .disconnected));
+    try testing.expect(main.shouldStartDaemonForTest(true, true, false, 3, .disconnected));
+    try testing.expect(main.shouldStartDaemonForTest(true, true, false, 200, .disconnected));
 
     // Still not while something is answering, however long the run was.
-    try testing.expect(!main.shouldStartDaemonForTest(true, true, 200, .connected));
+    try testing.expect(!main.shouldStartDaemonForTest(true, true, false, 200, .connected));
     // And still never in attached mode: that daemon is somebody else's.
-    try testing.expect(!main.shouldStartDaemonForTest(false, true, 200, .disconnected));
+    try testing.expect(!main.shouldStartDaemonForTest(false, true, false, 200, .disconnected));
 }
 
 test "the window does not report a stopped signer when the daemon merely detached" {

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -72,20 +72,80 @@ test "a window looks for a daemon before starting one" {
     // never coming while a perfectly good daemon is already serving.
 
     // Nothing is answering and this window has started nothing: its turn.
-    try testing.expect(main.shouldStartDaemonForTest(true, false, .connecting));
-    try testing.expect(main.shouldStartDaemonForTest(true, false, .disconnected));
+    try testing.expect(main.shouldStartDaemonForTest(true, false, 0, .connecting));
+    try testing.expect(main.shouldStartDaemonForTest(true, false, 0, .disconnected));
 
     // Something IS answering. Attaching to a daemon somebody else started is
     // the ordinary case, not a fallback.
-    try testing.expect(!main.shouldStartDaemonForTest(true, false, .connected));
+    try testing.expect(!main.shouldStartDaemonForTest(true, false, 0, .connected));
 
     // Already started one. A second races the first onto a port held
     // exclusively, and the loser exits.
-    try testing.expect(!main.shouldStartDaemonForTest(true, true, .connecting));
+    try testing.expect(!main.shouldStartDaemonForTest(true, true, 0, .connecting));
+    try testing.expect(!main.shouldStartDaemonForTest(true, true, 2, .connecting));
 
     // Attached mode was pointed at somebody else's daemon on purpose.
-    try testing.expect(!main.shouldStartDaemonForTest(false, false, .connecting));
-    try testing.expect(!main.shouldStartDaemonForTest(false, false, .disconnected));
+    try testing.expect(!main.shouldStartDaemonForTest(false, false, 0, .connecting));
+    try testing.expect(!main.shouldStartDaemonForTest(false, false, 0, .disconnected));
+}
+
+test "a detached daemon that dies is noticed by silence, since nothing reports it" {
+    // The daemon this window starts forks itself out of the window's process
+    // group, so that closing this window does not take the signer away from
+    // every other app using it. The price is that its death is no longer
+    // reported here: it is not a child any more, and `.daemon_exited` arrived
+    // seconds after it STARTED.
+    //
+    // So a run of ticks that reached nothing is the only evidence there is,
+    // and without this the window would retry a dead address forever while
+    // refusing to start a replacement, because it had started one once.
+    try testing.expect(!main.shouldStartDaemonForTest(true, true, 2, .disconnected));
+    try testing.expect(main.shouldStartDaemonForTest(true, true, 3, .disconnected));
+    try testing.expect(main.shouldStartDaemonForTest(true, true, 200, .disconnected));
+
+    // Still not while something is answering, however long the run was.
+    try testing.expect(!main.shouldStartDaemonForTest(true, true, 200, .connected));
+    // And still never in attached mode: that daemon is somebody else's.
+    try testing.expect(!main.shouldStartDaemonForTest(false, true, 200, .disconnected));
+}
+
+test "the window does not report a stopped signer when the daemon merely detached" {
+    // Drives the message rather than the predicate. The predicate had a test
+    // and the wiring did not, so removing the guard changed nothing anybody
+    // could see: this is the assertion that the window still shows a working
+    // signer after the exit that every successful start produces.
+    var m = Model{};
+    m.phase = .connecting;
+    m.managed = true;
+    m.spawned = true;
+    main.update(&m, main.Msg{ .daemon_exited = .{ .key = 1, .reason = .exited, .code = 0 } }, undefined);
+    try testing.expect(m.phase != .daemon_exited);
+    try testing.expectEqual(main.Phase.connecting, m.phase);
+
+    // A real failure still is one. The daemon binds before it forks so that a
+    // port it could not get lands here, while somebody is watching.
+    var bad = Model{};
+    bad.phase = .connecting;
+    bad.managed = true;
+    bad.spawned = true;
+    main.update(&bad, main.Msg{ .daemon_exited = .{ .key = 1, .reason = .exited, .code = 1 } }, undefined);
+    try testing.expectEqual(main.Phase.daemon_exited, bad.phase);
+}
+
+test "a daemon that detached is not a daemon that failed" {
+    // A detaching daemon's first process exits 0 the moment it has forked, so
+    // this arrives after every successful start. Reading it as a crash would
+    // put the window into "Signer stopped" with a Restart button, seconds
+    // after the daemon came up perfectly.
+    try testing.expect(main.daemonDetachedForTest(.exited, 0));
+
+    // Everything else is real. The daemon binds its port BEFORE it forks
+    // precisely so a port it could not get still lands here, where somebody
+    // can be told, instead of vanishing into a process nobody is attached to.
+    try testing.expect(!main.daemonDetachedForTest(.exited, 1));
+    try testing.expect(!main.daemonDetachedForTest(.signaled, 0));
+    try testing.expect(!main.daemonDetachedForTest(.spawn_failed, 0));
+    try testing.expect(!main.daemonDetachedForTest(.rejected, 0));
 }
 
 test "parseInfo fills the header fields" {

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -63,6 +63,31 @@ fn expectByLabel(widget: canvas.Widget, kind: canvas.WidgetKind, label: []const 
 
 // ------------------------------------------------------------- parsing
 
+test "a window looks for a daemon before starting one" {
+    // The daemon is shared. It outlives the window that spawned it (only
+    // `/lock` ends it), another app on this machine may have started it, and
+    // the reader may have opened that app first. A window that spawned
+    // unconditionally would put a second daemon on a port the first holds
+    // exclusively: the loser exits, and this window waits for something that is
+    // never coming while a perfectly good daemon is already serving.
+
+    // Nothing is answering and this window has started nothing: its turn.
+    try testing.expect(main.shouldStartDaemonForTest(true, false, .connecting));
+    try testing.expect(main.shouldStartDaemonForTest(true, false, .disconnected));
+
+    // Something IS answering. Attaching to a daemon somebody else started is
+    // the ordinary case, not a fallback.
+    try testing.expect(!main.shouldStartDaemonForTest(true, false, .connected));
+
+    // Already started one. A second races the first onto a port held
+    // exclusively, and the loser exits.
+    try testing.expect(!main.shouldStartDaemonForTest(true, true, .connecting));
+
+    // Attached mode was pointed at somebody else's daemon on purpose.
+    try testing.expect(!main.shouldStartDaemonForTest(false, false, .connecting));
+    try testing.expect(!main.shouldStartDaemonForTest(false, false, .disconnected));
+}
+
 test "parseInfo fills the header fields" {
     var m = Model{};
     main.parseInfo(&m, "{\"pubkey\":\"aabbccddeeff00112233\",\"timeout_ms\":120000}");


### PR DESCRIPTION
Notary could sign for a client that reached it over a relay, and for nothing else. An app on the same machine had to go the long way round: publish a request to a public relay and wait for it to come back, to reach a daemon a few hundred microseconds away. This teaches it to answer the apps that are right here, and to be shared by more than one of them.

## Serving the local protocol

`nostr.signer_ipc` over the loopback server the window already used: `/pubkey`, `/setup`, the `/sign` and the batched NIP-44 pair. The shapes come from the library so every product speaks one protocol rather than each inventing its own.

Two things found while porting them:

`/setup` inferred create-versus-import from an empty secret, so a client that meant to import and sent nothing was given a **brand new identity**. The window always knew which the person had chosen; it just never said. Confirmed by removing the guard, which left a real encrypted key file on disk. It takes an explicit method now.

Kinds 14 and 15 are the unsigned rumors inside a NIP-59 gift wrap, and a signature on one destroys the deniability the scheme exists for. They were refused on the new path from the first commit. They were **not** refused on the relay path, so a client reaching the same key over a relay could still ask, and what it got was a prompt. That is worse than a hole: it teaches somebody to approve the one request that should never have been shown to them.

## Asking before an app uses the key

The local path had no gate at all: anything that could read the bearer token could sign in the account's name, silently, with nothing recorded.

Requests are answered per app now, by the permission store the relay side already uses, keyed on a name the app declares in a header. An answer covers one app, one method, and for a signature one event kind, because signing a note and signing a contact list are different risks. Encrypt and decrypt are separate: being allowed to write a message is not being allowed to read one.

Nothing blocks. The obvious implementation parks the caller until a person answers, and on this server that caller is one of eight handler threads while the window fetches the queue over the same eight — so eight unanswered requests would leave the window unable to fetch the very questions it was being asked to answer. It refuses now and leaves the question on the queue; the app asks again.

The row says **"an app on this Mac calling itself Plaza"**, never "from Plaza". A relay client proved it holds a key. A local one typed a word, and any program running as this user can type the same word.

## Being shared rather than owned

The toolkit group-kills the children it spawns when the app quits, which is right for a private helper and wrong for a shared one: close the window that happened to start the daemon and every other app loses its signer mid-sentence. The daemon forks itself out of reach instead. Measured both ways against a stand-in for the toolkit's teardown — undetached, the group kill lands; detached, both kills miss and it is still serving.

Nothing then ended it, and a keyholder nothing ends is a decrypted key resident until the machine is turned off. So it clocks out after fifteen minutes with no request, from either direction. `SIGNER_IDLE_EXIT_MS=0` keeps it up forever.

## An audit log

Nothing was recorded before. The daemon printed to stderr and the window's spawn discards that, so for anyone running this as an application there was no record of a single signature. Every use of the key now writes one line beside the key file, readable only by this user, including wrong passphrases and the key leaving via `/export`.

By the id of what was signed, never its content; by peer and count for a cipher batch, never the messages. A log that quotes what you wrote is a second copy of it in a file nothing else protects.

## What an adversarial review then found

Five lenses over the diff, three skeptics per finding. Everything it raised was verified in the code before anything changed. Nine held, all in the new parts:

- **"Allow once" granted nothing locally.** `.once` is never stored, because on the relay path the parked thread reads the answer off the slot; the local path has no parked thread, so the answer went nowhere and the app was re-prompted forever. Only "For a day" and "Until locked" worked.
- The bearer token was minted **before** the bind, so a daemon that lost the race for the port had already overwritten the running daemon's token and locked out every client.
- The 4 KiB body cap broke `/sign` for an ordinary note and made nonsense of the batched cipher endpoints.
- The idle clock counted only loopback, so a bunker serving a phone with no window open clocked out mid-conversation.
- Unanswered local questions never expired: thirty-two wedge the queue for good, relay approvals included.
- Every retry from an unapproved app wrote an audit line, so asking often enough would roll the log away.
- A rollover that **failed** wrote the new line over the oldest entries, and the file still parsed. Not a gap in a log, a forgery.
- The window started a rival daemon over a single dropped poll once it had attached to somebody else's.

Two probes came back clean during that pass, and both were missing tests rather than spare guards.

## What this does not do

`/decision` asks for the bearer token and nothing else, and any process running as this user can read it, so a hostile app can approve its own request. Nothing in a file can separate this daemon's window from anything else the same user runs. The gate buys separate, revocable answers for apps that behave, a person who can say no, and an audit line recording self-approval — and the code says so where the gate is, rather than claiming more.

## Verification

Unit tests throughout, and each guarantee removed to confirm a named test goes red. The lifecycle work was driven live rather than reasoned about: detach and idle-exit were both measured in a running daemon, in both directions, and the idle clock's first version survived its unit test and failed the live run.