### PR TITLE
Notary is a child, not a service

### DIFF
--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -362,11 +362,9 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
     const path = parts.next() orelse return respond(w, 400, bad_request);
 
     var auth: []const u8 = "";
-    var client_name: []const u8 = "";
     var content_length: usize = 0;
     while (lines.next()) |line| {
         if (headerValue(line, "authorization")) |v| auth = v;
-        if (headerValue(line, ipc.header_client)) |v| client_name = v;
         if (headerValue(line, "content-length")) |v|
             content_length = std.fmt.parseInt(usize, v, 10) catch 0;
     }
@@ -444,11 +442,11 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
     if (eql(method, "GET") and eql(path, ipc.path_pubkey))
         return handleSignerPubkey(self, w);
     if (eql(method, "POST") and eql(path, ipc.path_sign))
-        return handleSignerSign(self, io, w, body, client_name);
+        return handleSignerSign(self, io, w, body);
     if (eql(method, "POST") and eql(path, ipc.path_nip44_encrypt))
-        return handleSignerCipher(self, io, w, body, client_name, .encrypt);
+        return handleSignerCipher(self, io, w, body, .encrypt);
     if (eql(method, "POST") and eql(path, ipc.path_nip44_decrypt))
-        return handleSignerCipher(self, io, w, body, client_name, .decrypt);
+        return handleSignerCipher(self, io, w, body, .decrypt);
     return respond(w, 404, "{\"error\":\"not found\"}");
 }
 
@@ -883,6 +881,24 @@ fn handleUnlock(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) 
 /// client that believes it offers to make one over the top of an identity that
 /// already exists. A nostr key cannot be replaced, so that is the one mistake
 /// worth designing the vocabulary around.
+/// The 32 bytes the one local client's answers are filed under.
+///
+/// A constant, because there IS one local client: the process that started this
+/// daemon and holds the only channel to it. There is nothing to distinguish, so
+/// nothing to name. The header a client used to introduce itself with is gone
+/// with the shared front door that made it necessary.
+///
+/// Domain-separated so it can never collide with a real 32-byte pubkey, which
+/// is what the relay side of this same store keys on.
+/// A literal rather than a hash, because a comptime hash is a comptime loop and
+/// this only has to be a constant nothing else can be.
+const local_client: [32]u8 = [_]u8{
+    0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x2d, 0x63, 0x6c,
+    0x69, 0x65, 0x6e, 0x74, 0x2f, 0x74, 0x68, 0x65,
+    0x2d, 0x70, 0x61, 0x72, 0x65, 0x6e, 0x74, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+};
+
 fn signerState(gate: *const Gate) []const u8 {
     return switch (gate.current()) {
         .uninitialized => ipc.state_uninitialized,
@@ -906,23 +922,18 @@ fn respondIpcError(self: *Server, w: *std.Io.Writer, status: u16, message: []con
     return respond(w, status, j);
 }
 
-/// Whether the app named `name` may do this, and if nobody has ever said, the
-/// question that asks them.
+/// Whether the app that started this daemon may do this, and if nobody has
+/// ever said, the question that asks them.
 ///
-/// WHAT THIS IS NOT, stated here because the rest of this file reads like it is
-/// more: it is not a defence against a hostile program running as this user.
-/// Such a program can read the bearer token, and the token is all `/decision`
-/// asks for, so it can answer its own question without a person ever seeing it.
-/// Nothing in a file can separate this daemon's window from anything else the
-/// same user runs, which is the whole reason a same-uid attacker was named as
-/// out of scope from the start.
+/// There is exactly ONE local client: the process that started this daemon and
+/// handed it the secret on stdin. Nothing else can reach the channel, because
+/// it has no name, no path and no well-known port. So this is not asking "which
+/// app is this", a question nobody has solved on the desktop. It is asking what
+/// the person has already allowed the one app there is to do.
 ///
-/// What it IS: separate answers for separate apps that are behaving. That is
-/// worth having on its own, because "the messenger may read my messages, my
-/// feed reader may not" cannot even be SAID otherwise, and because a person who
-/// is asked can say no. Every one of these decisions is written to the audit
-/// log, so an app that answers for itself leaves the record of having done so,
-/// which is the most this layer can honestly offer.
+/// That is why the answers are still per method and per event kind. Signing a
+/// note and signing a contact list are different risks even when only one app
+/// can ask.
 ///
 /// Returns false having ALREADY answered the request. The three refusals are
 /// spelled apart because a client has to do three different things with them:
@@ -939,38 +950,27 @@ fn localAllowed(
     self: *Server,
     io: std.Io,
     w: *std.Io.Writer,
-    name: []const u8,
     method: nip46.Method,
     kind: i32,
     preview: []const u8,
     comptime what: []const u8,
 ) !bool {
-    // An app that will not say what it is gets nothing. There is no shared
-    // "some local app" permission to fall back on, deliberately: that is the
-    // single client this whole mechanism exists to break up.
-    if (!ipc.clientNameOk(name)) {
-        note(self, io, .{ .what = what, .outcome = "unnamed", .method = method.name(), .kind = kind });
-        try respondIpcError(self, w, 400, ipc.reason_unnamed);
-        return false;
-    }
-
-    const id = ipc.clientId(name);
     const now_ms = std.Io.Timestamp.now(io, .real).toMilliseconds();
 
     // An answer given ONCE, to the question this request already raised. Taking
     // it spends it, which is the whole of what "once" means. Checked before
     // what was remembered, because a request only reached the queue at all
     // when nothing was remembered for it.
-    if (self.broker.takeOneShot(id, method, kind, now_ms)) |allowed| {
+    if (self.broker.takeOneShot(local_client, method, kind, now_ms)) |allowed| {
         if (allowed) return true;
-        note(self, io, .{ .what = what, .outcome = "refused", .who = name, .local = true, .method = method.name(), .kind = kind });
+        note(self, io, .{ .what = what, .outcome = "refused", .local = true, .method = method.name(), .kind = kind });
         try respondIpcError(self, w, 403, ipc.reason_refused);
         return false;
     }
 
-    if (self.broker.permissions.remembered(id, method, kind, now_ms)) |allowed| {
+    if (self.broker.permissions.remembered(local_client, method, kind, now_ms)) |allowed| {
         if (allowed) return true;
-        note(self, io, .{ .what = what, .outcome = "refused", .who = name, .local = true, .method = method.name(), .kind = kind });
+        note(self, io, .{ .what = what, .outcome = "refused", .local = true, .method = method.name(), .kind = kind });
         try respondIpcError(self, w, 403, ipc.reason_refused);
         return false;
     }
@@ -978,7 +978,7 @@ fn localAllowed(
     var info = Pending{
         .kind = kind,
         .created_at = std.Io.Timestamp.now(io, .real).toSeconds(),
-        .client_id = id,
+        .client_id = local_client,
         .method_id = method,
         .local = true,
     };
@@ -986,36 +986,24 @@ fn localAllowed(
     const mlen = @min(mname.len, info.method_buf.len);
     @memcpy(info.method_buf[0..mlen], mname[0..mlen]);
     info.method_len = @intCast(mlen);
-    // The name as the app wrote it. `clientNameOk` bounds it, and the bound
-    // lives in the other repo, so this pins the two together rather than
-    // trusting them to be widened in step.
-    comptime {
-        const cap = @typeInfo(@FieldType(Pending, "client_buf")).array.len;
-        std.debug.assert(ipc.client_name_max <= cap);
-    }
-    @memcpy(info.client_buf[0..name.len], name);
-    info.client_len = @intCast(name.len);
     info.preview_len = approval.previewOf(preview, &info.preview_buf);
+
     // Only a question actually FILED is worth a line. A client that retries
     // every second is not news, and one whose every retry wrote a line could
     // roll the audit log away by asking often enough.
     switch (self.broker.knock(info)) {
-        .filed => note(self, io, .{ .what = what, .outcome = "awaiting", .who = name, .local = true, .method = method.name(), .kind = kind }),
+        .filed => note(self, io, .{ .what = what, .outcome = "awaiting", .local = true, .method = method.name(), .kind = kind }),
         .already_asked => {},
         // The queue is full, so nobody will ever see this question. Answering
         // "awaiting approval" would send the client away to wait for something
         // that was never asked.
-        // The queue is full, so nobody will ever see this question. Answering
-        // "awaiting approval" would send the client away to wait for something
-        // that was never asked.
         .no_room => {
-            note(self, io, .{ .what = what, .outcome = "no room", .who = name, .local = true, .method = method.name(), .kind = kind });
+            note(self, io, .{ .what = what, .outcome = "no room", .local = true, .method = method.name(), .kind = kind });
             // NOT `reason_refused`: that one means a person said no and the
             // client should stop. A full queue is nobody's decision and it
             // clears on its own, so this says so in a message the contract
             // does not spell, which a client reads as "some other failure"
-            // and a 503 tells it to try later. A fourth reason constant would
-            // say it better and is a change to the shared library.
+            // and a 503 tells it to try later.
             try respondIpcError(self, w, 503, "the approval queue is full");
             return false;
         },
@@ -1042,7 +1030,7 @@ fn handleSignerPubkey(self: *Server, w: *std.Io.Writer) !void {
 }
 
 /// POST /sign: sign one event with the held key, if this app may.
-fn handleSignerSign(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8, client_name: []const u8) !void {
+fn handleSignerSign(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !void {
     var parsed = ipc.parse(ipc.SignEvent, self.gpa, body) catch
         return respondIpcError(self, w, 400, "malformed sign request");
     defer parsed.deinit();
@@ -1063,7 +1051,7 @@ fn handleSignerSign(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const 
 
     // Locked first, then permission. Asking somebody to allow a signature the
     // daemon could not produce anyway is a question with no useful answer.
-    if (!try localAllowed(self, io, w, client_name, .sign_event, ev.kind, ev.content, "sign")) return;
+    if (!try localAllowed(self, io, w, .sign_event, ev.kind, ev.content, "sign")) return;
 
     var signer = nostr.keys.Signer.init();
     defer signer.deinit();
@@ -1084,7 +1072,6 @@ fn handleSignerSign(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const 
     note(self, io, .{
         .what = "sign",
         .outcome = "ok",
-        .who = client_name,
         .local = true,
         .method = "sign_event",
         .kind = ev.kind,
@@ -1106,7 +1093,6 @@ fn handleSignerCipher(
     io: std.Io,
     w: *std.Io.Writer,
     body: []const u8,
-    client_name: []const u8,
     comptime dir: enum { encrypt, decrypt },
 ) !void {
     var parsed = ipc.parse(ipc.Cipher, self.gpa, body) catch
@@ -1130,7 +1116,7 @@ fn handleSignerCipher(
         .encrypt => .nip44_encrypt,
         .decrypt => .nip44_decrypt,
     };
-    if (!try localAllowed(self, io, w, client_name, method, -1, "", "cipher")) return;
+    if (!try localAllowed(self, io, w, method, -1, "", "cipher")) return;
 
     var signer = nostr.keys.Signer.init();
     defer signer.deinit();
@@ -1154,7 +1140,6 @@ fn handleSignerCipher(
     note(self, io, .{
         .what = "cipher",
         .outcome = "ok",
-        .who = client_name,
         .local = true,
         .method = method.name(),
         .peer = req.peer,
@@ -1303,9 +1288,10 @@ test "parseSince reads the query parameter" {
 /// One `/sign` request body of the shape a client really sends: a complete
 /// event whose id, pubkey and signature are zeroed, since those are the three
 /// things it is asking the daemon to fill in.
-/// The name a test app calls itself. Any app on the machine may claim any
-/// name, which is exactly why the tests use a plain one.
-const test_client = "test-app";
+/// The one local client, for a test that wants to pre-grant something.
+fn localClientForTest() [32]u8 {
+    return local_client;
+}
 
 fn signRequest(gpa: std.mem.Allocator, kind: u16) ![]u8 {
     const unsigned = nostr.event.Event{
@@ -1397,7 +1383,7 @@ test "POST /sign signs with the held key, and refuses a locked one" {
     var broker: Broker = .{};
     // Allowed, so that the thing under test here is the signing and not the
     // permission gate, which has tests of its own.
-    broker.permissions.remember(nostr.signer_ipc.clientId(test_client), .sign_event, 1, true, .always, 0);
+    broker.permissions.remember(localClientForTest(), .sign_event, 1, true, .always, 0);
     // The shape a client actually sends: a complete event with the id, pubkey
     // and signature left zeroed, because those are what it is asking for.
     const req = try signRequest(gpa, 1);
@@ -1410,7 +1396,7 @@ test "POST /sign signs with the held key, and refuses a locked one" {
         var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        try handleSignerSign(&server, io, &out.writer, req);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
@@ -1424,7 +1410,7 @@ test "POST /sign signs with the held key, and refuses a locked one" {
         var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        try handleSignerSign(&server, io, &out.writer, req);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "409") != null);
@@ -1457,7 +1443,7 @@ test "a gift-wrap rumor is never signed, locked or not" {
 
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        try handleSignerSign(&server, io, &out.writer, req);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "422") != null);
@@ -1706,7 +1692,7 @@ test "an app nobody has answered for is refused, and asks once" {
     {
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        try handleSignerSign(&server, io, &out.writer, req);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "403") != null);
@@ -1717,7 +1703,9 @@ test "an app nobody has answered for is refused, and asks once" {
     var queue: [Broker.capacity]Pending = undefined;
     try testing.expectEqual(@as(usize, 1), broker.snapshot(&queue));
     try testing.expect(queue[0].local);
-    try testing.expectEqualStrings(test_client, queue[0].client());
+    // No name on the row, because there is nothing to name: the one client is
+    // whoever started this daemon, and the window says so.
+    try testing.expectEqual(@as(usize, 0), queue[0].client().len);
     try testing.expectEqualStrings("sign_event", queue[0].method());
     try testing.expectEqual(@as(i32, 1), queue[0].kind);
     // What is being signed, not just what shape it is.
@@ -1729,7 +1717,7 @@ test "an app nobody has answered for is refused, and asks once" {
     for (0..10) |_| {
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        try handleSignerSign(&server, io, &out.writer, req);
     }
     try testing.expectEqual(@as(usize, 1), broker.snapshot(&queue));
 }
@@ -1756,7 +1744,7 @@ test "an answer given once is not asked again, and frees its slot" {
     {
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        try handleSignerSign(&server, io, &out.writer, req);
     }
     var queue: [Broker.capacity]Pending = undefined;
     try testing.expectEqual(@as(usize, 1), broker.snapshot(&queue));
@@ -1771,7 +1759,7 @@ test "an answer given once is not asked again, and frees its slot" {
     {
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        try handleSignerSign(&server, io, &out.writer, req);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
@@ -1794,7 +1782,7 @@ test "a refused app is refused without asking again" {
     var broker: Broker = .{};
     // "No, and stop asking." A denial has to be as durable as a grant, or
     // refusing an app is just asking it to try again in a second.
-    broker.permissions.remember(nostr.signer_ipc.clientId(test_client), .sign_event, 1, false, .always, 0);
+    broker.permissions.remember(localClientForTest(), .sign_event, 1, false, .always, 0);
 
     var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
     gate.preload(kp);
@@ -1804,49 +1792,13 @@ test "a refused app is refused without asking again" {
     defer gpa.free(req);
     var out = std.Io.Writer.Allocating.init(gpa);
     defer out.deinit();
-    try handleSignerSign(&server, io, &out.writer, req, test_client);
+    try handleSignerSign(&server, io, &out.writer, req);
     var body = out.toArrayList();
     defer body.deinit(gpa);
     try testing.expect(std.mem.indexOf(u8, body.items, "403") != null);
     // Refused for good, not queued for a person: the two say different things
     // to a client, and a refused app must not be able to raise a prompt.
     try testing.expect(std.mem.indexOf(u8, body.items, nostr.signer_ipc.reason_refused) != null);
-    var queue: [Broker.capacity]Pending = undefined;
-    try testing.expectEqual(@as(usize, 0), broker.snapshot(&queue));
-}
-
-test "an app that will not name itself gets nothing, and raises nothing" {
-    const gpa = testing.allocator;
-    var threaded = std.Io.Threaded.init(gpa, .{});
-    defer threaded.deinit();
-    const io = threaded.io();
-
-    var signer = nostr.keys.Signer.init();
-    defer signer.deinit();
-    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
-    const kp = try signer.keyPairFromSecretKey(secret);
-
-    var broker: Broker = .{};
-    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
-    gate.preload(kp);
-    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
-
-    const req = try signRequest(gpa, 1);
-    defer gpa.free(req);
-
-    // No name at all, and a name that could rewrite the row it is shown on.
-    // Neither may raise a prompt: an app that cannot be named cannot be
-    // answered for, so a queue entry for one is a question with no subject.
-    for ([_][]const u8{ "", "app\nname", "an app name with spaces in it" }) |name| {
-        var out = std.Io.Writer.Allocating.init(gpa);
-        defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, name);
-        var body = out.toArrayList();
-        defer body.deinit(gpa);
-        try testing.expect(std.mem.indexOf(u8, body.items, "400") != null);
-        try testing.expect(std.mem.indexOf(u8, body.items, nostr.signer_ipc.reason_unnamed) != null);
-        try testing.expect(std.mem.indexOf(u8, body.items, "\"sig\"") == null);
-    }
     var queue: [Broker.capacity]Pending = undefined;
     try testing.expectEqual(@as(usize, 0), broker.snapshot(&queue));
 }
@@ -1865,7 +1817,7 @@ test "writing a message and reading one are answered separately" {
     var broker: Broker = .{};
     // Allowed to encrypt. Says nothing about decrypting, which is the one that
     // reads somebody's messages back.
-    broker.permissions.remember(nostr.signer_ipc.clientId(test_client), .nip44_encrypt, -1, true, .always, 0);
+    broker.permissions.remember(localClientForTest(), .nip44_encrypt, -1, true, .always, 0);
 
     var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
     gate.preload(kp);
@@ -1878,7 +1830,7 @@ test "writing a message and reading one are answered separately" {
     {
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerCipher(&server, io, &out.writer, body_json, test_client, .encrypt);
+        try handleSignerCipher(&server, io, &out.writer, body_json, .encrypt);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
@@ -1886,7 +1838,7 @@ test "writing a message and reading one are answered separately" {
     {
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerCipher(&server, io, &out.writer, body_json, test_client, .decrypt);
+        try handleSignerCipher(&server, io, &out.writer, body_json, .decrypt);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "403") != null);
@@ -1908,7 +1860,7 @@ test "a locked daemon says so rather than asking for permission it cannot use" {
     defer gpa.free(req);
     var out = std.Io.Writer.Allocating.init(gpa);
     defer out.deinit();
-    try handleSignerSign(&server, io, &out.writer, req, test_client);
+    try handleSignerSign(&server, io, &out.writer, req);
     var body = out.toArrayList();
     defer body.deinit(gpa);
 
@@ -1990,7 +1942,7 @@ test "what the key did is written down, and what it was told in confidence is no
     {
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        try handleSignerSign(&server, io, &out.writer, req);
     }
     var queue: [Broker.capacity]Pending = undefined;
     try testing.expectEqual(@as(usize, 1), broker.snapshot(&queue));
@@ -2004,7 +1956,7 @@ test "what the key did is written down, and what it was told in confidence is no
     {
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        try handleSignerSign(&server, io, &out.writer, req);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
@@ -2018,8 +1970,9 @@ test "what the key did is written down, and what it was told in confidence is no
     try testing.expect(std.mem.indexOf(u8, written, "\"what\":\"decision\"") != null);
     try testing.expect(std.mem.indexOf(u8, written, "\"remember\":\"always\"") != null);
     try testing.expect(std.mem.indexOf(u8, written, "\"outcome\":\"ok\"") != null);
-    // Which app, and what it signed, by an id that finds the note again.
-    try testing.expect(std.mem.indexOf(u8, written, "\"who\":\"test-app\"") != null);
+    // Marked as local, so a reader can tell it from a request that came over a
+    // relay, and what it signed by an id that finds the note again.
+    try testing.expect(std.mem.indexOf(u8, written, "\"local\":true") != null);
     try testing.expect(std.mem.indexOf(u8, written, "\"kind\":1") != null);
     try testing.expect(std.mem.indexOf(u8, written, "\"id\":\"") != null);
 
@@ -2180,7 +2133,7 @@ test "Allow once actually lets one request through, and only one" {
     {
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        try handleSignerSign(&server, io, &out.writer, req);
     }
     var queue: [Broker.capacity]Pending = undefined;
     try testing.expectEqual(@as(usize, 1), broker.snapshot(&queue));
@@ -2198,7 +2151,7 @@ test "Allow once actually lets one request through, and only one" {
     {
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        try handleSignerSign(&server, io, &out.writer, req);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
@@ -2210,7 +2163,7 @@ test "Allow once actually lets one request through, and only one" {
     {
         var out = std.Io.Writer.Allocating.init(gpa);
         defer out.deinit();
-        try handleSignerSign(&server, io, &out.writer, req, test_client);
+        try handleSignerSign(&server, io, &out.writer, req);
         var body = out.toArrayList();
         defer body.deinit(gpa);
         try testing.expect(std.mem.indexOf(u8, body.items, "403") != null);

--- a/daemon/src/audit.zig
+++ b/daemon/src/audit.zig
@@ -142,9 +142,12 @@ pub const Log = struct {
 fn format(w: *std.Io.Writer, at: i64, e: Event) !void {
     try w.print("{{\"at\":{d},\"what\":\"{s}\"", .{ at, e.what });
     if (e.outcome.len != 0) try w.print(",\"outcome\":\"{s}\"", .{e.outcome});
+    // `local` stands on its own, because a local request has nobody to name:
+    // the one client is whoever started this daemon. Tying it to `who` meant
+    // the only line that needed the distinction was the one that lost it.
+    if (e.local) try w.writeAll(",\"local\":true");
     if (e.who.len != 0) {
-        try w.writeAll(",\"local\":");
-        try w.writeAll(if (e.local) "true" else "false");
+        if (!e.local) try w.writeAll(",\"local\":false");
         try w.writeAll(",\"who\":");
         try jsonString(w, e.who);
     }

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -29,8 +29,7 @@ const hex = nostr.hex;
 
 // Turnkey defaults for GUI mode, so a freshly downloaded app works with zero
 // configuration; each is overridable via its environment variable. The key and
-// token files sit under $HOME; relays default to a public relay.
-const default_token_file = ".zig-nostr-signer.token";
+// files sit under $HOME; relays default to a public relay.
 const default_log_file = audit.default_file;
 
 /// How long the daemon stays up with nothing using it.
@@ -157,22 +156,14 @@ pub fn main(init: std.process.Init) !void {
     // `SIGNER_APPROVAL_HTTP`. Parse argv here so the slice lives for the process
     // (GUI/relay mode never returns).
     var approval_addr = getEnv("SIGNER_APPROVAL_HTTP");
-    // `--detach` for the same reason as the address: an app started from
-    // Finder has no environment worth inheriting, so anything the window needs
-    // to say to the daemon has to be said in argv.
-    var detach = envIsOn("SIGNER_DETACH");
     var args = std.process.Args.Iterator.init(init.minimal.args);
     _ = args.skip(); // argv[0]
     while (args.next()) |arg| {
-        if (std.mem.eql(u8, arg, "--approval-http")) {
-            approval_addr = args.next();
-        } else if (std.mem.eql(u8, arg, "--detach")) {
-            detach = true;
-        }
+        if (std.mem.eql(u8, arg, "--approval-http")) approval_addr = args.next();
     }
 
     if (approval_addr) |addr| {
-        runGuiMode(gpa, addr, conn_secret, &policy_config, detach);
+        runGuiMode(gpa, addr, conn_secret, &policy_config);
     }
 
     // Headless mode: the key must already be available (from an encrypted key
@@ -195,12 +186,11 @@ pub fn main(init: std.process.Init) !void {
 /// first-run key onboarding over it, then serve with the resulting key. The
 /// broker and server live in this frame, which never returns (it tail-calls the
 /// forever-serving `runRelays`), so their addresses are stable for the process.
-fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8, policy_config: *const PolicyConfig, detach: bool) noreturn {
+fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8, policy_config: *const PolicyConfig) noreturn {
     const hp = parseHostPort(addr) orelse
-        fail("SIGNER_APPROVAL_HTTP must be host:port, e.g. 127.0.0.1:8787");
+        fail("SIGNER_APPROVAL_HTTP must be host:port, e.g. 127.0.0.1:0");
 
     // Turnkey defaults so a fresh download needs no configuration.
-    const token_path = getEnv("SIGNER_APPROVAL_TOKEN_FILE") orelse resolveHome(gpa, default_token_file);
     const key_file = getEnv("SIGNER_KEY_FILE") orelse resolveHome(gpa, default_key_file);
     const relays_env = getEnv("SIGNER_RELAYS") orelse default_gui_relays;
 
@@ -232,6 +222,13 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
         fail("out of memory tracking relay status");
     for (relay_status) |*s| s.* = std.atomic.Value(u8).init(@intFromEnum(approval_http.RelayStatus.connecting));
 
+    // The one thing that lets anybody in, read before a single thread exists.
+    // A parent that sends nothing gets a daemon with no local channel at all,
+    // which is the right failure: better to serve nobody than everybody.
+    const secret = readSecretFromStdin(gpa, io);
+    if (secret.len == 0)
+        fail("no secret arrived on stdin; this daemon is started BY the app it signs for");
+
     // Beside the key, and readable only by this user, because it is a list of
     // everything that key has done. `SIGNER_LOG_FILE=""` turns it off for
     // somebody who would rather it did not exist.
@@ -244,11 +241,7 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
         .gpa = gpa,
         .broker = &broker_storage,
         .gate = &gate,
-        // Filled after the bind. Minting it here would overwrite a RUNNING
-        // daemon's token before discovering the port is already theirs, and
-        // every client holding the old one would start getting 401s from a
-        // daemon that was working perfectly.
-        .token = "",
+        .token = secret,
         .log = &g_audit,
         .idle_exit_ms = idleExitMs(),
         .info = .{ .relays = relays.items, .timeout_ms = broker_storage.timeout_ms, .secret = conn_secret, .relay_status = relay_status },
@@ -265,16 +258,13 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
     // still watching. That is the whole reason the port is reported before the
     // detach rather than after: afterwards there is nobody left to tell.
     approval_server.bind(io) catch |err|
-        failFmt("could not bind the approval API on {s}: {s}", .{ addr, @errorName(err) });
+        failFmt("could not bind the local channel on {s}: {s}", .{ addr, @errorName(err) });
 
-    // The port is ours, so the credential for it is ours to mint. Not one line
-    // earlier: the address is fixed and well known, so losing the race to it is
-    // the ordinary way a second daemon starts, and a loser that had already
-    // rewritten the shared token file would take every client down with it.
-    approval_server.token = makeAndWriteToken(gpa, token_path);
+    // The port goes out on stdout, where only the parent is reading. Asking the
+    // kernel for a port rather than fixing one is the other half of having no
+    // public front door: an address nobody has chosen yet cannot be squatted,
+    // and there is no well-known number for anything else to try.
     announcePort(io, approval_server.bound_port.load(.acquire));
-
-    if (detach) detachFromSpawner();
 
     const server_thread = std.Thread.spawn(.{}, runApprovalServer, .{&approval_server}) catch
         fail("could not start the approval server");
@@ -286,15 +276,15 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
         .uninitialized => "Waiting for the GUI to set up the key…",
     };
     std.debug.print(
-        \\zig-nostr signer (GUI mode)
-        \\  approval API : http://{s}  (bearer token → {s})
+        \\zig-nostr signer (embedded)
+        \\  serving      : the process that started me, on 127.0.0.1:{d}
         \\  key file     : {s}
         \\  key state    : {s}
         \\  audit log    : {s}
         \\
         \\{s}
         \\
-    , .{ addr, token_path, key_file, @tagName(booted), if (g_audit.path.len == 0) "(off)" else g_audit.path, key_note });
+    , .{ approval_server.bound_port.load(.acquire), key_file, @tagName(booted), if (g_audit.path.len == 0) "(off)" else g_audit.path, key_note });
 
     // Block until the GUI creates or unlocks the key (returns at once if a
     // preconfigured key was loaded above), then serve with it. The broker is
@@ -771,23 +761,35 @@ fn parseHostPort(s: []const u8) ?HostPort {
     return .{ .host = host, .port = port };
 }
 
-/// Generates a fresh random bearer token, writes it to `path` as a `0600` file
-/// (overwriting a stale one), and returns the hex token (owned, process-lived).
-fn makeAndWriteToken(gpa: std.mem.Allocator, path: []const u8) []u8 {
-    var startup = std.Io.Threaded.init(gpa, .{});
-    defer startup.deinit();
-    const io = startup.io();
-
-    var raw: [24]u8 = undefined;
-    io.randomSecure(&raw) catch |err| failFmt("could not generate an API token: {s}", .{@errorName(err)});
-    const token_hex = hex.encode(gpa, &raw) catch fail("out of memory generating the API token");
-
-    std.Io.Dir.cwd().writeFile(io, .{
-        .sub_path = path,
-        .data = token_hex,
-        .flags = .{ .truncate = true, .permissions = std.Io.File.Permissions.fromMode(0o600) },
-    }) catch |err| failFmt("could not write the token file '{s}': {s}", .{ path, @errorName(err) });
-    return token_hex;
+/// The one-time secret this daemon's parent handed it on stdin.
+///
+/// It replaces a bearer token in a 0600 file, and the reason is measured rather
+/// than assumed. What another program running as the same user can see about a
+/// process: its argv (`ps` prints it), its environment (`ps -Eww` prints it),
+/// and any file it can read. A 0600 file separates USERS, not apps, so every
+/// app you run could read the old token and sign as you.
+///
+/// A pipe from a parent is the one channel with none of those properties. It
+/// has no name, no path, and no port: there is nothing for another process to
+/// open. Possession of the channel IS the authentication, so this daemon does
+/// not have to answer "which app is this", which is a question nobody has
+/// solved on the desktop.
+///
+/// Read before anything else and before any thread exists. A parent that sends
+/// nothing gets a daemon with no local channel at all, which is the correct
+/// failure: better to serve nobody than to serve everybody.
+fn readSecretFromStdin(gpa: std.mem.Allocator, io: std.Io) []const u8 {
+    var buf: [256]u8 = undefined;
+    var r = std.Io.File.stdin().reader(io, &buf);
+    const line = r.interface.takeDelimiterExclusive('\n') catch |err| switch (err) {
+        // The parent closed the pipe having written the whole secret and no
+        // newline. Everything read so far is the secret.
+        error.EndOfStream => r.interface.buffered(),
+        else => return "",
+    };
+    const trimmed = std.mem.trim(u8, line, " \t\r\n");
+    if (trimmed.len < 16) return ""; // too short to be a secret anybody minted
+    return gpa.dupe(u8, trimmed) catch "";
 }
 
 /// The one line the spawner reads: the port this daemon is listening on.
@@ -807,70 +809,15 @@ fn announcePort(io: std.Io, port: u16) void {
     stdout.interface.flush() catch {};
 }
 
-/// Leaves the process group of whoever started this daemon, when asked to.
-///
-/// A keyholder that several apps share cannot be one app's child. The Native
-/// SDK group-kills the children it spawns when the app quits, which is right
-/// for a private helper and catastrophic for a shared one: close the window
-/// that happened to start the daemon and every OTHER app loses its signer
-/// mid-sentence, with no error anywhere, because from their side the socket
-/// simply stops answering.
-///
-/// A plain `setsid` does not get out of the way. The group kill falls back to
-/// signalling the child's own pid, and after `setsid` that pid is exactly what
-/// the new group is named after, so it is hit either way. Escaping takes a
-/// DESCENDANT: this process forks, the parent exits at once so the spawner
-/// sees a clean exit, and the child takes a new session whose id is its own
-/// pid, which nothing the spawner knows about can name.
-///
-/// Then the three inherited standard descriptors go to /dev/null. Not tidiness:
-/// a detached child holding the spawner's stdout write end open means the
-/// spawner's reader never sees EOF and its worker is abandoned rather than
-/// finishing. Nothing is lost by closing them, because a process that has just
-/// left its terminal has no reader.
-///
-/// The listening socket is untouched and survives the fork, which is the whole
-/// reason binding happens first.
-/// Whether an environment variable is set to something meaning yes.
-///
-/// Present-but-empty and "0" mean no, so a launcher that exports the name
-/// unconditionally does not turn a behaviour on by accident.
-fn envIsOn(name: [*:0]const u8) bool {
-    const v = getEnv(name) orelse return false;
-    return v.len != 0 and !std.mem.eql(u8, v, "0");
-}
-
-fn detachFromSpawner() void {
-    const pid = std.c.fork();
-    if (pid < 0) {
-        // Could not fork: keep serving as a child rather than not at all. The
-        // shared-daemon hazard is back, and saying so is better than exiting
-        // and leaving the reader with no signer whatsoever.
-        std.debug.print("signer: could not detach; this daemon will end when the app that started it does\n", .{});
-        return;
-    }
-    if (pid > 0) std.c._exit(0); // the spawner's child, done the moment it has forked
-
-    _ = std.c.setsid();
-
-    const devnull = std.c.open("/dev/null", .{ .ACCMODE = .RDWR });
-    if (devnull >= 0) {
-        _ = std.c.dup2(devnull, 0);
-        _ = std.c.dup2(devnull, 1);
-        _ = std.c.dup2(devnull, 2);
-        if (devnull > 2) _ = std.c.close(devnull);
-    }
-}
-
 /// Runs the approval HTTP server on its own thread with its own io.
 ///
 /// A listener that cannot come up KILLS the daemon. It used to print and let
 /// the thread die, and the consequence was not a missing feature: the daemon
 /// went on running with no listener, blocked forever waiting to be unlocked,
 /// while whatever was already holding that port answered the GUI instead. The
-/// GUI has no way to tell the difference, so it would read the token file, find
-/// something answering, and post the unlock passphrase, or an imported nsec,
-/// straight to it. Dying loudly is what turns that into a startup failure the
+/// parent has no way to tell the difference, so it would find something
+/// answering and post the unlock passphrase, or an imported nsec, straight to
+/// it. Dying loudly is what turns that into a startup failure the
 /// GUI's supervision already knows how to show.
 fn runApprovalServer(server: *approval_http.Server) void {
     var threaded = std.Io.Threaded.init(server.gpa, .{});

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -23,7 +23,7 @@
 //!
 //! The view lives in `app.native`; this file is the logic. All I/O is through
 //! the Native SDK effects channel (`fx.spawn` supervises the daemon, `fx.fetch`
-//! talks HTTP, `fx.readFile` reads the token, `fx.startTimer` backs off), so
+//! talks HTTP, `fx.startTimer` backs off), so
 //! `update` stays a pure state transition and the view stays declarative.
 
 const std = @import("std");
@@ -39,14 +39,12 @@ const canvas_label = "main-canvas";
 const window_width: f32 = 460;
 const window_height: f32 = 560;
 
-// `filesystem` is what lets the GUI read the daemon's bearer token. SDK 0.9.1
-// confines raw file effects to the app's own directories unless this is
-// declared, and the token lives at $HOME/.zig-nostr-signer.token, which is
-// outside every one of them. Without it `fx.readFile` is rejected SILENTLY:
-// `.token_read` arrives as `.rejected`, every non-ok outcome arms a retry,
-// the phase never advances, and the app sits at "Connecting to the signer…"
-// forever looking exactly like a network fault.
-pub const app_permissions = [_][]const u8{ native_sdk.security.permission_command, native_sdk.security.permission_view, native_sdk.security.permission_clipboard, native_sdk.security.permission_filesystem };
+// No `filesystem`. This window used to need it to read the daemon's bearer
+// token out of $HOME, and there is no token to read now: it mints a secret and
+// hands it to the daemon it starts, over a pipe. Dropping a permission is worth
+// a line of its own, because it is the rare change that makes an app able to do
+// strictly less.
+pub const app_permissions = [_][]const u8{ native_sdk.security.permission_command, native_sdk.security.permission_view, native_sdk.security.permission_clipboard };
 const shell_views = [_]native_sdk.ShellView{
     .{ .label = canvas_label, .kind = .gpu_surface, .fill = true, .role = "Notary canvas", .accessibility_label = "Notary", .gpu_backend = .metal, .gpu_pixel_format = .bgra8_unorm, .gpu_present_mode = .timer, .gpu_alpha_mode = .@"opaque", .gpu_color_space = .srgb, .gpu_vsync = true },
 };
@@ -71,7 +69,6 @@ const default_address = "127.0.0.1:8787";
 /// right for the app they installed rather than for wherever this binary
 /// happens to be running from during development.
 const import_command = "/Applications/Notary.app/Contents/MacOS/signer import";
-const default_token_file = ".zig-nostr-signer.token";
 
 /// What a hidden passphrase field renders instead of its characters.
 ///
@@ -120,7 +117,6 @@ fn applyMaskedEdit(buf: *canvas.TextBuffer(128), event: canvas.TextInputEvent, m
 const daemon_port_prefix = "notary-approval-port";
 
 const daemon_key: u64 = 1;
-const token_key: u64 = 2;
 const info_key: u64 = 3;
 const pending_key: u64 = 4;
 const setup_key: u64 = 5;
@@ -310,14 +306,12 @@ pub const Model = struct {
     // Resolved at boot from the environment; stable for the process.
     base_url_buf: [96]u8 = [_]u8{0} ** 96,
     base_url_len: usize = 0,
-    token_path_buf: [512]u8 = [_]u8{0} ** 512,
-    token_path_len: usize = 0,
     daemon_bin_buf: [512]u8 = [_]u8{0} ** 512,
     daemon_bin_len: usize = 0,
     /// True when `SIGNER_BIN` is set: the app spawns and supervises the daemon.
     managed: bool = false,
 
-    // Read from the token file via `fx.readFile`; the bearer header value.
+    // The bearer header value, built from the secret this window minted.
     auth_buf: [96]u8 = [_]u8{0} ** 96,
     auth_len: usize = 0,
 
@@ -414,18 +408,9 @@ pub const Model = struct {
     /// as "is one running": another app may have started the one we are talking
     /// to, and that is the ordinary case rather than a fallback.
     spawned: bool = false,
-    /// Retry ticks in a row that have not reached a daemon.
-    ///
-    /// The only evidence this window gets that a DETACHED daemon has died. It
-    /// is no longer a child, so nothing reports its exit; a socket that stops
-    /// answering is the whole signal.
-    connect_failures: u8 = 0,
-    /// Whether anything has ever answered on this address.
-    ///
-    /// Separates "there is no daemon here" from "the daemon I was talking to
-    /// went quiet for a moment". Those need opposite responses and looked
-    /// identical to a window that had not spawned anything itself.
-    ever_connected: bool = false,
+    daemon_secret_buf: [64]u8 = undefined,
+    daemon_secret_len: usize = 0,
+
     /// A `/setup` or `/unlock` POST is in flight (disables the submit button).
     submitting: bool = false,
     onboard_error_buf: [96]u8 = [_]u8{0} ** 96,
@@ -440,14 +425,6 @@ pub const Model = struct {
     pub fn baseUrl(self: *const Model) []const u8 {
         return self.base_url_buf[0..self.base_url_len];
     }
-    pub fn setTokenPath(self: *Model, path: []const u8) void {
-        const n = @min(path.len, self.token_path_buf.len);
-        @memcpy(self.token_path_buf[0..n], path[0..n]);
-        self.token_path_len = n;
-    }
-    pub fn tokenPath(self: *const Model) []const u8 {
-        return self.token_path_buf[0..self.token_path_len];
-    }
     pub fn setDaemonBin(self: *Model, path: []const u8) void {
         const n = @min(path.len, self.daemon_bin_buf.len);
         @memcpy(self.daemon_bin_buf[0..n], path[0..n]);
@@ -456,6 +433,30 @@ pub const Model = struct {
     pub fn daemonBin(self: *const Model) []const u8 {
         return self.daemon_bin_buf[0..self.daemon_bin_len];
     }
+    /// Mints the one-time secret this window hands its daemon on stdin, and
+    /// arms the header that presents it.
+    ///
+    /// Random per spawn and never written anywhere: not to a file, not into
+    /// argv, not into the environment. Those are the three places another
+    /// program running as this user can read, and a pipe to a child is the one
+    /// place it cannot.
+    pub fn mintDaemonSecret(self: *Model) void {
+        var raw: [24]u8 = undefined;
+        // The OS CSPRNG, reached directly because this runs in a Model method
+        // that has no `io` to hand. macOS guarantees `arc4random_buf` never
+        // fails and needs no seeding.
+        std.c.arc4random_buf(&raw, raw.len);
+        const hexed = std.fmt.bufPrint(&self.daemon_secret_buf, "{x}\n", .{raw}) catch return;
+        self.daemon_secret_len = hexed.len;
+        self.setAuth(hexed[0 .. hexed.len - 1]); // the header wants it without the newline
+    }
+
+    /// The secret as it goes down the pipe, newline included so the daemon's
+    /// read has a terminator.
+    pub fn daemonSecret(self: *const Model) []const u8 {
+        return self.daemon_secret_buf[0..self.daemon_secret_len];
+    }
+
     pub fn setAuth(self: *Model, token: []const u8) void {
         if (token.len == 0) {
             self.auth_len = 0;
@@ -702,7 +703,7 @@ pub const Model = struct {
             .connecting => "Connecting to the signer…",
             .connected => "Connected",
             .disconnected => "Signer unreachable, retrying…",
-            .unauthorized => "Unauthorized: check the token file",
+            .unauthorized => "Something else is answering. Not connecting.",
             .daemon_exited => "Signer stopped",
             .needs_setup => "First-run setup",
             .needs_unlock => "Locked",
@@ -717,7 +718,7 @@ pub const Model = struct {
             .starting => "Starting the signer…",
             .connecting => "Connecting to the signer…",
             .disconnected => "Signer unreachable, retrying…",
-            .unauthorized => "Unauthorized: check the token file",
+            .unauthorized => "Something else is answering. Not connecting.",
             .daemon_exited, .needs_setup, .needs_unlock => "",
         };
     }
@@ -875,7 +876,6 @@ pub const Model = struct {
 pub const Msg = union(enum) {
     daemon_line: native_sdk.EffectLine,
     daemon_exited: native_sdk.EffectExit,
-    token_read: native_sdk.EffectFileResult,
     info: native_sdk.EffectResponse,
     pending: native_sdk.EffectResponse,
     decided: native_sdk.EffectResponse,
@@ -948,89 +948,19 @@ pub const app_markup = @embedFile("app.native");
 const NotaryApp = native_sdk.UiApp(Model, Msg);
 const Effects = NotaryApp.Effects;
 
-/// What we ask the daemon to bind in managed mode.
+/// Whether this window should start a daemon.
 ///
-/// The WELL KNOWN address now, not `127.0.0.1:0`. A kernel-chosen port and a
-/// stdout line is a rendezvous only the spawner can use, and it was the right
-/// shape while this window was the daemon's only client. It is the wrong shape
-/// for a daemon meant to be shared: another app that wants the same key did not
-/// spawn it, has no stdout to read, and has to be able to find one that is
-/// already running.
-///
-/// The NUMBER is the rendezvous, not a file naming the number. A port file is
-/// the obvious alternative and it is the dangerous one: it sits on disk
-/// writable by this same user, so anything running as them could point it at a
-/// listener of its own and every client would go there instead, while the real
-/// daemon sat healthy and idle, never knowing. There is nothing here to
-/// rewrite.
-///
-/// The bind stays EXCLUSIVE (`approval_http.Server.run`). Something that takes
-/// this port first does not get to answer for the daemon quietly: the bind
-/// fails and the daemon says so.
-const managed_bind_address = "127.0.0.1:8787";
-
-/// Whether this window may start a daemon of its own, on a retry tick.
-///
-/// Split out because it is the rule the shared daemon turns on, and a rule
-/// worth being able to state without an event loop around it. Three ways to
-/// answer no, and each is a different mistake avoided:
-///
-///   - not managed: this window was pointed at somebody else's daemon on
-///     purpose, and starting a competing one is not ours to do;
-///   - already spawned: a second would race the first onto a port the first
-///     holds exclusively, and the loser exits while this window waits for it;
-///   - connected: something is already serving, which is the ordinary case now
-///     rather than a fallback. Another app may have started it, or the reader
-///     may have opened Notary before Plaza.
-fn shouldStartDaemon(managed: bool, spawned: bool, ever_connected: bool, failures: u8, phase: Phase) bool {
-    if (!managed) return false;
-    if (phase == .connected) return false;
-    // Nothing has ever answered here and this window has started nothing: its
-    // turn, once an attempt has actually come back empty.
-    if (!spawned and !ever_connected) return failures >= 1;
-    // Otherwise something WAS there: either this window started it, or it
-    // attached to a daemon somebody else did. Either way its death is not
-    // reported here, because a detached daemon is nobody's child, so a run of
-    // ticks that reached nothing is the only evidence there is.
-    //
-    // Waiting for the run matters most in the ATTACHED case. A single dropped
-    // poll against a perfectly healthy daemon would otherwise start a second
-    // one, which loses the race for a port the first holds exclusively and
-    // exits, for no reason the reader could see.
-    return failures >= respawn_after_failures;
+/// Only in managed mode, and only once. There is nothing to look for first any
+/// more: the daemon has no shared address and no shared credential, so it is
+/// not something another app could already be running and it is not something
+/// this window could attach to. It is this window's child or it does not exist.
+fn shouldStartDaemon(managed: bool, spawned: bool, phase: Phase) bool {
+    if (!managed or spawned) return false;
+    return phase != .connected;
 }
 
-/// How many silent retry ticks amount to "there is no daemon there".
-///
-/// Three, against a retry that backs off, so a daemon still starting is not
-/// competed with. The cost of guessing wrong is small in one direction only:
-/// the bind is exclusive, so a redundant daemon exits at once instead of
-/// quietly taking over the address.
-const respawn_after_failures: u8 = 3;
-
-pub fn shouldStartDaemonForTest(managed: bool, spawned: bool, ever_connected: bool, failures: u8, phase: Phase) bool {
-    return shouldStartDaemon(managed, spawned, ever_connected, failures, phase);
-}
-
-/// Whether this exit is a daemon that detached, rather than one that failed.
-///
-/// A detaching daemon forks and its first process exits 0 immediately, so this
-/// arrives seconds after every successful start and means the opposite of what
-/// it looks like: the daemon is up, it is simply no longer this window's child.
-///
-/// A clean exit is therefore not news. Anything else is: the daemon binds its
-/// port BEFORE it forks, precisely so a port it could not get still fails here,
-/// while somebody is watching, instead of vanishing into a process nobody is
-/// attached to.
-///
-/// Liveness after this point is the HTTP connection, which is the honest
-/// measure anyway. The process being alive never meant it was answering.
-fn daemonDetached(exit: native_sdk.EffectExit) bool {
-    return exit.reason == .exited and exit.code == 0;
-}
-
-pub fn daemonDetachedForTest(reason: native_sdk.EffectExitReason, code: i32) bool {
-    return daemonDetached(.{ .key = 0, .reason = reason, .code = code });
+pub fn shouldStartDaemonForTest(managed: bool, spawned: bool, phase: Phase) bool {
+    return shouldStartDaemon(managed, spawned, phase);
 }
 
 fn spawnDaemon(model: *Model, fx: *Effects) void {
@@ -1040,44 +970,42 @@ fn spawnDaemon(model: *Model, fx: *Effects) void {
     // loser exits while this window waits for it. It gates only the AUTOMATIC
     // spawn; Restart and the sign-out paths call this directly and are meant to.
     model.spawned = true;
+    model.mintDaemonSecret();
     fx.spawn(.{
         .key = daemon_key,
-        // `--detach` is what makes this a shared service rather than this
-        // window's child. The SDK group-kills what it spawns when the app
-        // quits, which is right for a private helper and wrong here: close
-        // this window and every other app using the key would lose its signer
-        // mid-sentence, with nothing to see but a socket that stopped
-        // answering. The daemon forks itself out of reach instead, and ends
-        // itself when nobody has asked it for anything in a while.
-        .argv = &.{ model.daemonBin(), "--approval-http", managed_bind_address, "--detach" },
+        // Port ZERO. There is no shared address any more, so there is nothing
+        // for anything else to be sitting on, and the daemon says on stdout
+        // where it landed.
+        .argv = &.{ model.daemonBin(), "--approval-http", "127.0.0.1:0" },
+        // The secret, down a pipe only this process and its child hold.
+        //
+        // Measured, and this is the whole design: another program running as
+        // this user can read a process's argv (`ps` prints it) and its
+        // environment (`ps -Eww` prints it), and could read a token file
+        // (0600 separates users, not apps). It cannot read this. There is no
+        // name and no path, so there is nothing to open.
+        //
+        // Possession of the channel IS the authentication, which is why the
+        // daemon no longer has to answer "which app is this" — a question
+        // nobody has solved on the desktop.
+        .stdin = model.daemonSecret(),
         .on_line = Effects.lineMsg(.daemon_line),
         .on_exit = Effects.exitMsg(.daemon_exited),
     });
 }
 
-/// Counts an attempt that reached nothing, and forgets the run once one lands.
-fn noteConnectFailure(model: *Model) void {
-    if (model.connect_failures < 255) model.connect_failures += 1;
-}
-
-/// One connection attempt: (re-)read the token file, then poll. Re-reading on
-/// every attempt means a freshly (re)started daemon's new token is always
-/// picked up, healing both the initial startup race and a restart.
+/// One connection attempt.
+///
+/// There is no token file to read any more: this window MINTED the secret and
+/// handed it to the daemon it started, so it has always had it. What used to be
+/// a file read, a retry, and a whole `.unauthorized` phase for a token that had
+/// gone stale is now nothing at all.
 fn attemptConnect(model: *Model, fx: *Effects) void {
     // Nothing to connect to until the daemon says where it landed. Staying in
     // `.starting` is the honest state, and it is what the retry tick already
     // knows how to leave.
     if (!model.port_known) return;
-    if (model.tokenPath().len == 0) {
-        // No token file configured at all: nothing to authenticate with.
-        model.phase = .unauthorized;
-        return;
-    }
-    fx.readFile(.{
-        .key = token_key,
-        .path = model.tokenPath(),
-        .on_result = Effects.fileMsg(.token_read),
-    });
+    fetchInfo(model, fx);
 }
 
 fn fetchInfo(model: *Model, fx: *Effects) void {
@@ -1305,18 +1233,13 @@ fn onUnauthorized(model: *Model, fx: *Effects) void {
 
 /// Boot command: in managed mode spawn the daemon; either way begin connecting.
 pub fn boot(model: *Model, fx: *Effects) void {
-    // Look before starting one. The daemon is shared now: it outlives the
-    // window that spawned it (only `/lock` ends it), another app on this
-    // machine may have started it, and the reader may have opened that app
-    // first. Spawning unconditionally would put a second daemon on a port the
-    // first one holds exclusively, and the loser would exit while this window
-    // waited for it.
-    //
-    // So connect first and let the retry path start one only if nothing
-    // answers. Attaching to a daemon somebody else started is the normal case,
-    // not a fallback: the alternative is signing the reader out of whatever was
-    // already using it.
+    // Start it. There is nothing to look for first: the daemon has no shared
+    // address and no credential on disk, so it is not something another app
+    // could already be running and not something this window could attach to.
+    // It is this window's child.
     model.phase = .connecting;
+    if (shouldStartDaemon(model.managed, model.spawned, model.phase))
+        spawnDaemon(model, fx);
     attemptConnect(model, fx);
     // Keep the live relay status fresh while serving (the initial /info is a
     // one-shot; the pending poll doesn't carry relay state).
@@ -1357,7 +1280,6 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             // code says something actually went wrong, and the daemon is
             // careful to bind before it forks so a bad port still lands here
             // where somebody can be told about it.
-            if (daemonDetached(exit)) return;
             model.phase = .daemon_exited;
             model.setExitNote(exit);
             model.setAuth("");
@@ -1367,23 +1289,6 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             model.clearSecrets(); // don't keep a passphrase around a dead daemon
             model.clearOnboardError();
             model.submitting = false;
-        },
-
-        .token_read => |r| switch (r.outcome) {
-            .ok => {
-                const token = std.mem.trim(u8, r.bytes, " \t\r\n");
-                if (token.len > 0) {
-                    model.setAuth(token);
-                    // Learn the key state from /info before doing anything else;
-                    // it decides between onboarding and the approvals queue.
-                    if (model.phase != .connected) model.phase = .connecting;
-                    fetchInfo(model, fx);
-                } else {
-                    armRetry(fx); // empty file, the daemon has not written it yet
-                }
-            },
-            // Not there yet (managed daemon still starting) or unreadable: retry.
-            else => armRetry(fx),
         },
 
         // /info reports the daemon's key state, which selects the screen.
@@ -1403,7 +1308,6 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
                 onUnauthorized(model, fx);
             } else {
                 // The daemon may still be coming up; try again shortly.
-                noteConnectFailure(model);
                 armRetry(fx);
             }
         },
@@ -1412,15 +1316,12 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             .ok => switch (r.status) {
                 200 => {
                     model.phase = .connected;
-                    model.connect_failures = 0; // something answered
-                    model.ever_connected = true;
                     parsePending(model, r.body);
                     pollPending(model, fx); // re-arm the long-poll chain
                 },
                 401 => onUnauthorized(model, fx),
                 else => {
                     model.phase = .disconnected;
-                    noteConnectFailure(model);
                     armRetry(fx);
                 },
             },
@@ -1429,7 +1330,6 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             .rejected => armRetry(fx),
             else => {
                 if (model.phase == .connected) model.phase = .disconnected;
-                noteConnectFailure(model);
                 armRetry(fx);
             },
         },
@@ -1444,10 +1344,8 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             // to attach to and this window may start one. Only in managed mode,
             // and only once: attached mode was pointed at somebody else's
             // daemon on purpose, and a second spawn would race the first.
-            if (shouldStartDaemon(model.managed, model.spawned, model.ever_connected, model.connect_failures, model.phase)) {
-                model.connect_failures = 0; // this attempt gets its own run
+            if (shouldStartDaemon(model.managed, model.spawned, model.phase))
                 spawnDaemon(model, fx);
-            }
             // A full reconnect attempt: re-read the token, then poll.
             attemptConnect(model, fx);
         },
@@ -1845,22 +1743,11 @@ fn loadConfig(model: *Model, io: std.Io, environ: *const std.process.Environ.Map
         model.managed = true;
     }
     // The address is known in BOTH modes now. Attached mode talks to whatever
-    // the operator pointed us at; managed mode used to wait to be told, because
-    // the daemon was given a kernel-chosen port and printed it back. A
-    // well-known port removes that wait, and removing it is what lets this
-    // window look for a daemon that is ALREADY running before starting one of
-    // its own.
-    model.port_known = true;
-    if (model.managed) model.setBaseUrl(managed_bind_address);
-
-    if (environ.get("SIGNER_APPROVAL_TOKEN_FILE")) |path| {
-        model.setTokenPath(path);
-    } else if (environ.get("HOME")) |home| {
-        var buf: [512]u8 = undefined;
-        if (std.fmt.bufPrint(&buf, "{s}/{s}", .{ home, default_token_file })) |path| {
-            model.setTokenPath(path);
-        } else |_| {}
-    }
+    // the operator pointed us at. In managed mode there is nothing to know
+    // yet: the daemon takes a kernel-chosen port and prints it back, which is
+    // what removes the well-known address anything else could have been
+    // sitting on.
+    model.port_known = !model.managed;
 }
 
 pub fn main(init: std.process.Init) !void {

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -63,100 +63,53 @@ fn expectByLabel(widget: canvas.Widget, kind: canvas.WidgetKind, label: []const 
 
 // ------------------------------------------------------------- parsing
 
-test "a window looks for a daemon before starting one" {
-    // The daemon is shared. It outlives the window that spawned it (only
-    // `/lock` ends it), another app on this machine may have started it, and
-    // the reader may have opened that app first. A window that spawned
-    // unconditionally would put a second daemon on a port the first holds
-    // exclusively: the loser exits, and this window waits for something that is
-    // never coming while a perfectly good daemon is already serving.
+test "a window starts its own daemon, once, and never looks for somebody else's" {
+    // The daemon used to be shared, so this had to connect first and spawn only
+    // if nothing answered. It is not shared any more: it has no well-known
+    // address and no credential on disk, so it is not something another app
+    // could be running and not something this window could attach to. It is
+    // this window's child or it does not exist.
 
-    // Nothing is answering and this window has started nothing: its turn, once
-    // one attempt has actually come back empty. Not on the very first tick,
-    // when the first connect may still be in flight.
-    try testing.expect(!main.shouldStartDaemonForTest(true, false, false, 0, .connecting));
-    try testing.expect(main.shouldStartDaemonForTest(true, false, false, 1, .connecting));
-    try testing.expect(main.shouldStartDaemonForTest(true, false, false, 1, .disconnected));
+    // Managed and nothing started yet: its turn.
+    try testing.expect(main.shouldStartDaemonForTest(true, false, .connecting));
+    try testing.expect(main.shouldStartDaemonForTest(true, false, .disconnected));
 
-    // But a window that ATTACHED to somebody else's daemon must not start a
-    // second one over a single dropped poll: the new one loses the race for a
-    // port the first holds exclusively and exits, for no reason a reader could
-    // see. It waits for the same run of silence as one that spawned.
-    try testing.expect(!main.shouldStartDaemonForTest(true, false, true, 1, .disconnected));
-    try testing.expect(!main.shouldStartDaemonForTest(true, false, true, 2, .disconnected));
-    try testing.expect(main.shouldStartDaemonForTest(true, false, true, 3, .disconnected));
+    // Already started one. A second would be a second daemon holding the same
+    // key, which is two passphrase prompts and two things to lock.
+    try testing.expect(!main.shouldStartDaemonForTest(true, true, .connecting));
 
-    // Something IS answering. Attaching to a daemon somebody else started is
-    // the ordinary case, not a fallback.
-    try testing.expect(!main.shouldStartDaemonForTest(true, false, false, 0, .connected));
+    // Already connected: nothing to do.
+    try testing.expect(!main.shouldStartDaemonForTest(true, false, .connected));
 
-    // Already started one. A second races the first onto a port held
-    // exclusively, and the loser exits.
-    try testing.expect(!main.shouldStartDaemonForTest(true, true, false, 0, .connecting));
-    try testing.expect(!main.shouldStartDaemonForTest(true, true, false, 2, .connecting));
-
-    // Attached mode was pointed at somebody else's daemon on purpose.
-    try testing.expect(!main.shouldStartDaemonForTest(false, false, false, 0, .connecting));
-    try testing.expect(!main.shouldStartDaemonForTest(false, false, false, 0, .disconnected));
+    // Attached mode was pointed at a daemon somebody runs by hand, on purpose.
+    try testing.expect(!main.shouldStartDaemonForTest(false, false, .connecting));
+    try testing.expect(!main.shouldStartDaemonForTest(false, false, .disconnected));
 }
 
-test "a detached daemon that dies is noticed by silence, since nothing reports it" {
-    // The daemon this window starts forks itself out of the window's process
-    // group, so that closing this window does not take the signer away from
-    // every other app using it. The price is that its death is no longer
-    // reported here: it is not a child any more, and `.daemon_exited` arrived
-    // seconds after it STARTED.
-    //
-    // So a run of ticks that reached nothing is the only evidence there is,
-    // and without this the window would retry a dead address forever while
-    // refusing to start a replacement, because it had started one once.
-    try testing.expect(!main.shouldStartDaemonForTest(true, true, false, 2, .disconnected));
-    try testing.expect(main.shouldStartDaemonForTest(true, true, false, 3, .disconnected));
-    try testing.expect(main.shouldStartDaemonForTest(true, true, false, 200, .disconnected));
+test "the secret is minted fresh and never leaves this process except down the pipe" {
+    // The whole design rests on this one being true. Measured on this machine:
+    // another program running as the same user can read a process's argv
+    // (`ps -o args=` printed a token planted there) and its environment
+    // (`ps -Eww` printed one), and could always read a 0600 token file, because
+    // file permissions separate USERS and not apps. A pipe to a child has no
+    // name and no path, so there is nothing to open.
+    var a = Model{};
+    var b = Model{};
+    a.mintDaemonSecret();
+    b.mintDaemonSecret();
 
-    // Still not while something is answering, however long the run was.
-    try testing.expect(!main.shouldStartDaemonForTest(true, true, false, 200, .connected));
-    // And still never in attached mode: that daemon is somebody else's.
-    try testing.expect(!main.shouldStartDaemonForTest(false, true, false, 200, .disconnected));
-}
+    // Long enough to be worth minting, and terminated so the daemon's read has
+    // something to stop on.
+    try testing.expect(a.daemonSecret().len >= 32);
+    try testing.expectEqual(@as(u8, '\n'), a.daemonSecret()[a.daemonSecret().len - 1]);
 
-test "the window does not report a stopped signer when the daemon merely detached" {
-    // Drives the message rather than the predicate. The predicate had a test
-    // and the wiring did not, so removing the guard changed nothing anybody
-    // could see: this is the assertion that the window still shows a working
-    // signer after the exit that every successful start produces.
-    var m = Model{};
-    m.phase = .connecting;
-    m.managed = true;
-    m.spawned = true;
-    main.update(&m, main.Msg{ .daemon_exited = .{ .key = 1, .reason = .exited, .code = 0 } }, undefined);
-    try testing.expect(m.phase != .daemon_exited);
-    try testing.expectEqual(main.Phase.connecting, m.phase);
+    // Fresh per spawn: two windows, or one window restarting its daemon, must
+    // not end up sharing a credential.
+    try testing.expect(!std.mem.eql(u8, a.daemonSecret(), b.daemonSecret()));
 
-    // A real failure still is one. The daemon binds before it forks so that a
-    // port it could not get lands here, while somebody is watching.
-    var bad = Model{};
-    bad.phase = .connecting;
-    bad.managed = true;
-    bad.spawned = true;
-    main.update(&bad, main.Msg{ .daemon_exited = .{ .key = 1, .reason = .exited, .code = 1 } }, undefined);
-    try testing.expectEqual(main.Phase.daemon_exited, bad.phase);
-}
-
-test "a daemon that detached is not a daemon that failed" {
-    // A detaching daemon's first process exits 0 the moment it has forked, so
-    // this arrives after every successful start. Reading it as a crash would
-    // put the window into "Signer stopped" with a Restart button, seconds
-    // after the daemon came up perfectly.
-    try testing.expect(main.daemonDetachedForTest(.exited, 0));
-
-    // Everything else is real. The daemon binds its port BEFORE it forks
-    // precisely so a port it could not get still lands here, where somebody
-    // can be told, instead of vanishing into a process nobody is attached to.
-    try testing.expect(!main.daemonDetachedForTest(.exited, 1));
-    try testing.expect(!main.daemonDetachedForTest(.signaled, 0));
-    try testing.expect(!main.daemonDetachedForTest(.spawn_failed, 0));
-    try testing.expect(!main.daemonDetachedForTest(.rejected, 0));
+    // And the header presents it without the terminator.
+    try testing.expect(std.mem.endsWith(u8, a.auth(), a.daemonSecret()[0 .. a.daemonSecret().len - 1]));
+    try testing.expect(std.mem.startsWith(u8, a.auth(), "Bearer "));
 }
 
 test "parseInfo fills the header fields" {
@@ -846,21 +799,16 @@ test "one status line, and it says the phase before there is a queue to count" {
     try testing.expectEqualStrings("0 pending", fresh.footer(arena));
 }
 
-test "the app declares the filesystem permission it needs to read the token" {
-    // Regression guard. SDK 0.9.1 began confining raw file effects to the app's
-    // own directories unless `filesystem` is declared. The GUI reads the
-    // daemon's bearer token from $HOME, which is outside every one of them, so
-    // without this permission `fx.readFile` is REJECTED SILENTLY: `.token_read`
-    // arrives as `.rejected`, the retry arms, the phase never leaves
-    // `.connecting`, and the app sits on "Connecting to the signer…" forever
-    // looking exactly like a network fault. It shipped working only because the
-    // release pinned an older CLI, and nothing here caught it, because every
-    // check passes on an app that cannot reach its own daemon.
-    //
-    // `native check`, `native test` and `native build` all pass without it, so
-    // this test is the only thing standing between that bug and a release.
-    try testing.expect(native_sdk.security.hasPermission(
-        &main.app_permissions,
-        native_sdk.security.permission_filesystem,
-    ));
+test "the app asks for no file access at all" {
+    // It used to need `filesystem`, to read the daemon's bearer token out of
+    // $HOME. There is no token: this window mints a secret and hands it to the
+    // daemon it starts, down a pipe. So the permission goes, and this is here
+    // because a permission is easy to leave behind once the reason for it is
+    // gone, and an app that can read your files is worth noticing.
+    for (main.app_permissions) |p| {
+        if (std.mem.eql(u8, p, native_sdk.security.permission_filesystem)) {
+            std.debug.print("the window still asks for file access it no longer uses\n", .{});
+            return error.UnusedPermission;
+        }
+    }
 }


### PR DESCRIPTION
The daemon had a public front door: a well-known port and a password in a file. Everything hard about this week came from that.

A public door has to know who is knocking, and a day of measurement established that nobody has solved that question on the desktop. File permissions separate users, not apps, so a `0600` token is readable by every app you run. Keychain access lists and Touch ID both need a real signing identity. The Secure Enclave cannot hold a nostr key at all. Peer code identity works on one transport, on one platform, and only if you already know whose signatures to trust.

So the door goes. **The daemon is started by the app it signs for, and handed a one-time secret on stdin.**

## Why that channel is private

Measured, not reasoned about. What another program running as this user can see of a process:

| channel | visible? |
|---|---|
| argv | yes, `ps` prints it |
| environment | yes, `ps -Eww` prints it |
| a 0600 file | yes, permissions separate users, not apps |
| **a pipe from its parent** | **no. no name, no path, nothing to open** |

Possession of the channel *is* the authentication, which is why the daemon no longer has to answer "which app is this".

Driven live, each checked rather than assumed: kernel-chosen port, refuses to start when nothing arrives on stdin, serves a request carrying the real secret, refuses a wrong one and a missing one, and the secret appears nowhere in `ps`.

## What it deletes

- **The token file** and everything that read it, **including a permission**. The window asked for `filesystem` solely to reach `$HOME` and now asks for no file access at all.
- **The fixed port**, and with it the squatting problem. An address nobody has chosen yet cannot be taken.
- **The detach and its fork.** A child should die with its parent, and this one is a child again.
- **The singleton**: looking for somebody else's daemon, the failure run before replacing it, the whole shared-service dance.
- **The self-declared client name.** One local client means nothing to distinguish, and a name an app types was never identity.

## One thing got stronger

A 401 used to mean a stale token, so the window dropped it and retried. This window *minted* the secret, so the real daemon cannot refuse it, and something refusing it is something **else** answering on that port. It stops rather than retrying, because retrying means posting the unlock passphrase to whoever is there. A password in a file could never check that: an impostor could read the file.

## What is unchanged

The permission model, the audit log, one-shot grants, queue expiry and the gift-wrap refusal all stay. They still apply, to one client.

## Consequence, stated deliberately

Notary no longer serves arbitrary local apps. That is the point rather than a cost: a signer with an open local door is a door anything on the machine can walk through. Apps that are not its parent use NIP-46 over real relays, where the client is cryptographically identified by its own keypair.