### PR TITLE
One key, one keyholder, and two things it can be

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,22 @@ Notary is split into two processes on purpose, so the secret key stays isolated
 from the user interface:
 
 - **[`daemon/`](daemon)**: the headless NIP-46 signer ("bunker"). It holds the
-  encrypted key, connects to your relays, and in GUI mode serves a
-  **loopback-only** approval API. It runs standalone as a CLI for advanced users,
-  or supervised by the GUI.
+  encrypted key and is one of two things, never both:
+
+  **Standalone**, run by this app: a bunker on real relays, where a client
+  proves who it is with its own keypair. That is where a request from another
+  machine, or from somebody else's client, belongs.
+
+  **Embedded**, started by an app that ships Notary: the private keyholder of
+  that one app. It talks to its parent down a pipe it was handed at startup, on
+  a port the kernel chose, and connects to no relay. Nothing else on the machine
+  can reach it, because there is no name, no path and no well-known port to
+  reach.
+
+  Not both at once, deliberately. A keyholder that any local app can reach has
+  to answer "which app is this", and on the desktop nothing can: file
+  permissions separate users, not apps, so a credential in a file is readable by
+  every app you run.
 - **[`gui/`](gui)**: the native desktop approver, built with the
   [Native SDK](https://github.com/vercel-labs/native) (declarative markup plus
   Zig, rendered natively: no WebView, no Electron). It shows each pending

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -860,6 +860,10 @@ fn handleUnlock(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) 
         return switch (err) {
             error.BadPassphrase => respond(w, 401, "{\"error\":\"bad passphrase\"}"),
             error.NotLocked => respond(w, 409, "{\"error\":\"not locked\"}"),
+            // Not the reader's mistake, and not something a passphrase fixes.
+            // Another Notary on this Mac has this key open; two processes
+            // cannot share a decrypted key, so one of them has to close.
+            error.AlreadyOpenElsewhere => respond(w, 409, "{\"error\":\"another Notary already has this key open\"}"),
             else => respond(w, 500, "{\"error\":\"could not unlock\"}"),
         };
     };

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -102,8 +102,6 @@ const usage =
     \\  SIGNER_INIT            if set, create/import an encrypted key file and exit
     \\  SIGNER_LOG_FILE        where uses of the key are written down (default:
     \\                         $HOME/.zig-nostr-signer.log; empty turns it off)
-    \\  SIGNER_DETACH          if set, leave the starting app's process group, so
-    \\                         the daemon outlives it and can be shared
     \\  SIGNER_IDLE_EXIT_MS    exit after this long with no request (default:
     \\                         900000, fifteen minutes; 0 stays up forever)
     \\
@@ -156,14 +154,33 @@ pub fn main(init: std.process.Init) !void {
     // `SIGNER_APPROVAL_HTTP`. Parse argv here so the slice lives for the process
     // (GUI/relay mode never returns).
     var approval_addr = getEnv("SIGNER_APPROVAL_HTTP");
+    // `--serve-relays` is what separates the two things this daemon can be.
+    //
+    // EMBEDDED, without it: the private keyholder of the one app that started
+    // it, reachable only down the pipe it was handed, and on no relay at all.
+    // Nothing outside that app can ask it for anything.
+    //
+    // STANDALONE, with it: a bunker on real relays, where clients are NIP-46
+    // clients and prove who they are with their own keypair. That is the only
+    // place a stranger's request belongs, and it is the only mode that needs a
+    // network.
+    //
+    // Being both at once is what this flag exists to prevent. A daemon serving
+    // relays AND a local app is a keyholder with a public door, which is the
+    // shape nobody has made safe on the desktop.
+    var serve_relays = false;
     var args = std.process.Args.Iterator.init(init.minimal.args);
     _ = args.skip(); // argv[0]
     while (args.next()) |arg| {
-        if (std.mem.eql(u8, arg, "--approval-http")) approval_addr = args.next();
+        if (std.mem.eql(u8, arg, "--approval-http")) {
+            approval_addr = args.next();
+        } else if (std.mem.eql(u8, arg, "--serve-relays")) {
+            serve_relays = true;
+        }
     }
 
     if (approval_addr) |addr| {
-        runGuiMode(gpa, addr, conn_secret, &policy_config);
+        runGuiMode(gpa, addr, conn_secret, &policy_config, serve_relays);
     }
 
     // Headless mode: the key must already be available (from an encrypted key
@@ -186,17 +203,17 @@ pub fn main(init: std.process.Init) !void {
 /// first-run key onboarding over it, then serve with the resulting key. The
 /// broker and server live in this frame, which never returns (it tail-calls the
 /// forever-serving `runRelays`), so their addresses are stable for the process.
-fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8, policy_config: *const PolicyConfig) noreturn {
+fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8, policy_config: *const PolicyConfig, serve_relays: bool) noreturn {
     const hp = parseHostPort(addr) orelse
         fail("SIGNER_APPROVAL_HTTP must be host:port, e.g. 127.0.0.1:0");
 
     // Turnkey defaults so a fresh download needs no configuration.
     const key_file = getEnv("SIGNER_KEY_FILE") orelse resolveHome(gpa, default_key_file);
-    const relays_env = getEnv("SIGNER_RELAYS") orelse default_gui_relays;
-
     var relays: std.ArrayList([]const u8) = .empty;
-    parseRelays(gpa, &relays, relays_env);
-    if (relays.items.len == 0) fail("SIGNER_RELAYS contained no relay URLs");
+    if (serve_relays) {
+        parseRelays(gpa, &relays, getEnv("SIGNER_RELAYS") orelse default_gui_relays);
+        if (relays.items.len == 0) fail("SIGNER_RELAYS contained no relay URLs");
+    }
 
     var startup = std.Io.Threaded.init(gpa, .{});
     defer startup.deinit();
@@ -290,6 +307,13 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
     // preconfigured key was loaded above), then serve with it. The broker is
     // already live, so approvals work the moment serving starts.
     const secret_key = gate.waitUnlocked(io);
+    if (!serve_relays) {
+        // Embedded. There is nothing to serve but the app that started this,
+        // and that is already being served on the other thread. Park here so
+        // the process lives as long as its parent does rather than falling out
+        // of a function that promised never to return.
+        while (true) io.sleep(std.Io.Duration.fromSeconds(3600), .awake) catch {};
+    }
     runRelays(gpa, relays.items, secret_key, conn_secret, policy_config, &broker_storage, relay_status);
 }
 

--- a/daemon/src/onboarding.zig
+++ b/daemon/src/onboarding.zig
@@ -33,7 +33,13 @@ pub const State = enum(u8) {
 };
 
 pub const SetupError = error{ AlreadyInitialized, EmptyPassphrase, InvalidSecretKey, EncryptFailed, WriteFailed };
-pub const UnlockError = error{ NotLocked, BadPassphrase, ReadFailed };
+pub const UnlockError = error{
+    /// Another daemon on this machine already holds this key open.
+    AlreadyOpenElsewhere,
+    NotLocked,
+    BadPassphrase,
+    ReadFailed,
+};
 
 /// Coordinates the key-less boot with the setup/unlock handlers. Lives in the
 /// daemon's `main` frame (which never returns), so the HTTP server may hold a
@@ -44,6 +50,10 @@ pub const Gate = struct {
     dir: Dir,
     /// Encrypted key-file path within `dir`.
     key_file: []const u8,
+    /// Held open while this daemon has the key unlocked, so a second daemon
+    /// cannot open the same key. Released by the OS when this process ends,
+    /// however it ends.
+    lock_file: ?std.Io.File = null,
 
     /// `State` as a plain integer for atomic access.
     state: std.atomic.Value(u8),
@@ -116,8 +126,34 @@ pub const Gate = struct {
     /// Decrypts the existing key file with `passphrase`. On success the gate is
     /// `unlocked` and holds the key + public key. Only valid from the `locked`
     /// state; a wrong passphrase leaves it `locked` for a retry.
+    /// Whether some OTHER daemon already holds this key unlocked.
+    ///
+    /// One keyholder per key, and the reason is not tidiness. A standalone
+    /// Notary serving relays and an embedded one serving an app are two
+    /// processes, so they cannot share a decrypted key: each would ask for the
+    /// passphrase, each would hold a copy in memory, and the reader would have
+    /// no way to tell which one a prompt came from.
+    ///
+    /// An advisory lock on the key file, taken while the key is open and
+    /// released when the process ends, however it ends. Advisory is enough: the
+    /// thing it coordinates is our own two modes, not an attacker, and an
+    /// attacker with the run of this machine was never held off by a lock.
+    fn takeKeyLock(self: *Gate, io: std.Io) bool {
+        if (self.lock_file != null) return true;
+        const f = self.dir.createFile(io, self.key_file, .{
+            .truncate = false,
+            .lock = .exclusive,
+            .lock_nonblocking = true,
+        }) catch return false;
+        self.lock_file = f;
+        return true;
+    }
+
     pub fn unlock(self: *Gate, io: std.Io, passphrase: []const u8) UnlockError!void {
         if (self.current() != .locked) return error.NotLocked;
+        // Before the passphrase is even checked, so somebody who typed it
+        // correctly is not told it was wrong.
+        if (!self.takeKeyLock(io)) return error.AlreadyOpenElsewhere;
 
         const ncryptsec = keystore.readKeyFile(self.gpa, io, self.dir, self.key_file) catch
             return error.ReadFailed;
@@ -384,4 +420,37 @@ test "rescan never moves a gate that already holds a key" {
     var locked = Gate.init(gpa, tmp.dir, key_name, .locked);
     locked.rescan(io);
     try testing.expectEqual(State.locked, locked.current());
+}
+
+test "two daemons cannot hold one key open" {
+    // A standalone Notary serving relays and an embedded one serving an app are
+    // two processes, so they cannot share a decrypted key. Without this each
+    // would ask for the passphrase, each would hold a copy in memory, and a
+    // prompt would give the reader no way to tell which one it came from.
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const secret = [_]u8{0xC1} ** 32;
+    const passphrase = "correct horse battery staple";
+    const ncryptsec = try keystore.encryptKey(gpa, io, secret, passphrase, .known_secure);
+    defer gpa.free(ncryptsec);
+    try keystore.writeNewKeyFile(io, tmp.dir, "key.ncryptsec", ncryptsec);
+
+    var first = Gate.init(gpa, tmp.dir, "key.ncryptsec", .locked);
+    try first.unlock(io, passphrase);
+    try testing.expectEqual(State.unlocked, first.current());
+
+    // The second is refused, and for the RIGHT reason: the passphrase is
+    // correct, so saying it was wrong would send somebody hunting for a
+    // password that is fine.
+    var second = Gate.init(gpa, tmp.dir, "key.ncryptsec", .locked);
+    try testing.expectError(error.AlreadyOpenElsewhere, second.unlock(io, passphrase));
+    try testing.expectEqual(State.locked, second.current());
+
+    // The check runs BEFORE the passphrase is read, so a wrong one gets the
+    // same answer rather than telling a caller which of the two it got wrong.
+    var third = Gate.init(gpa, tmp.dir, "key.ncryptsec", .locked);
+    try testing.expectError(error.AlreadyOpenElsewhere, third.unlock(io, "not the passphrase"));
 }

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -976,7 +976,13 @@ fn spawnDaemon(model: *Model, fx: *Effects) void {
         // Port ZERO. There is no shared address any more, so there is nothing
         // for anything else to be sitting on, and the daemon says on stdout
         // where it landed.
-        .argv = &.{ model.daemonBin(), "--approval-http", "127.0.0.1:0" },
+        // `--serve-relays`: this is the STANDALONE Notary, so its daemon is a
+        // bunker on real relays, where a client proves who it is with its own
+        // keypair. An app that embeds Notary starts the same binary WITHOUT
+        // this flag and gets a keyholder that serves only that app, on no relay
+        // at all. Being both at once is a keyholder with a public door, which
+        // is the shape nobody has made safe on the desktop.
+        .argv = &.{ model.daemonBin(), "--approval-http", "127.0.0.1:0", "--serve-relays" },
         // The secret, down a pipe only this process and its child hold.
         //
         // Measured, and this is the whole design: another program running as

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -812,3 +812,22 @@ test "the app asks for no file access at all" {
         }
     }
 }
+
+test "the standalone window asks for a bunker, an embedded one does not" {
+    // The one flag that separates the two things this daemon can be. Notary's
+    // own window is the standalone case: its daemon is a bunker on real relays,
+    // where a client proves who it is with its own keypair.
+    //
+    // An app that embeds Notary starts the same binary without the flag and
+    // gets a keyholder that serves only that app, down a pipe, on no relay.
+    // Serving both at once is a keyholder with a public door, which is the
+    // shape nobody has made safe on the desktop.
+    const src = @embedFile("main.zig");
+    const spawn_at = std.mem.indexOf(u8, src, ".argv = &.{ model.daemonBin()").?;
+    const line_end = std.mem.indexOfScalarPos(u8, src, spawn_at, '\n').?;
+    const argv = src[spawn_at..line_end];
+    try testing.expect(std.mem.indexOf(u8, argv, "--serve-relays") != null);
+    // And a kernel-chosen port, because a well-known one is something else can
+    // be sitting on first.
+    try testing.expect(std.mem.indexOf(u8, argv, "127.0.0.1:0") != null);
+}


### PR DESCRIPTION
Notary is two products sharing a binary, and until now nothing said which one a given process was.

**Embedded**, the default: the private keyholder of the app that started it, reachable only down the pipe it was handed, on no relay at all. Nothing outside that app can ask it for anything.

**Standalone**, with `--serve-relays`: a bunker on real relays, where a client is a NIP-46 client and proves who it is with its own keypair. That is the only place a stranger's request belongs, and the only mode that needs a network.

Being both at once is what the flag exists to prevent. A daemon serving relays *and* a local app is a keyholder with a public door, and a public door has to answer "which app is this" — which nobody has made safe on the desktop. That is now a settled position rather than an open question, and it is written down.

## One key, one keyholder

Two processes cannot share a decrypted key. Without a guard, a standalone Notary and an embedded one would both ask for the passphrase, both hold a copy in memory, and a prompt would give the reader no way to tell which one it came from.

An advisory lock on the key file, held while the key is open and released by the OS however the process ends.

The lock is taken **before** the passphrase is checked, and that ordering is the point. Somebody who typed the right passphrase must not be told it was wrong, and a wrong one must not get a different answer either, or the refusal becomes a way to ask which of the two things went wrong. The test drives both.

Advisory is enough: what it coordinates is our own two modes, and an attacker with the run of this machine was never going to be held off by a lock.