### PR TITLE
The signer decides who it serves, not the app that started it

### DIFF
--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -4,7 +4,8 @@
 //! Deliberately tiny (fixed routes, no keep-alive, no chunked encoding) to keep
 //! the key-holding daemon's attack surface small:
 //!
-//!   GET  /info              {"state":..,"pubkey":..,"bunker":..,"relays":[{"url":..,"status":..}],"timeout_ms":N}
+//!   GET  /info              {"state":..,"pubkey":..,"bunker":..,"serve_relays":bool,"relays":[..],"timeout_ms":N}
+//!   POST /relays            {"on":bool} → whether to answer clients over relays
 //!   POST /setup             {"passphrase":..,"secret":..?} → create/import a key
 //!   POST /unlock            {"passphrase":..} → decrypt the key file
 //!   POST /lock              → clear sessions and exit, keeping the key
@@ -54,6 +55,12 @@ pub const Info = struct {
     /// Live per-relay status, parallel to `relays` (the relay threads update it,
     /// `/info` reads it). Null in headless mode, where nothing serves `/info`.
     relay_status: ?[]std.atomic.Value(u8) = null,
+    /// Whether this daemon answers clients over relays, and where that answer
+    /// is written down. The setting belongs to the KEYHOLDER: an app that
+    /// embeds Notary starts it and asks for nothing, because whether the key
+    /// serves other devices is not a client's decision.
+    serve_relays: bool = false,
+    conf_file: []const u8 = "",
 };
 
 pub const Server = struct {
@@ -423,6 +430,8 @@ fn handleConn(self: *Server, io: std.Io, stream: net.Stream) !void {
         return handleSetup(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/forget"))
         return handleForget(self, io, w, body);
+    if (eql(method, "POST") and eql(path, "/relays"))
+        return handleRelays(self, io, w, body);
     if (eql(method, "POST") and eql(path, "/lock"))
         return handleLock(self, io, w);
     if (eql(method, "POST") and eql(path, "/export"))
@@ -567,6 +576,54 @@ fn handleDecision(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8
     return respond(w, 200, j);
 }
 
+/// Whether the reader has asked this keyholder to answer other devices.
+///
+/// One line in a file this daemon owns, beside the key. Off when the file is
+/// missing or unreadable, because the safe reading of "I could not tell" is not
+/// to put the process holding a key on the network.
+pub fn readServeRelays(gpa: std.mem.Allocator, io: std.Io, path: []const u8) bool {
+    const raw = std.Io.Dir.cwd().readFileAlloc(io, path, gpa, std.Io.Limit.limited(4096)) catch return false;
+    defer gpa.free(raw);
+    var lines = std.mem.splitScalar(u8, raw, '\n');
+    while (lines.next()) |line| {
+        const eq = std.mem.indexOfScalar(u8, line, '=') orelse continue;
+        if (!std.mem.eql(u8, std.mem.trim(u8, line[0..eq], " \t"), "serve_relays")) continue;
+        return std.mem.eql(u8, std.mem.trim(u8, line[eq + 1 ..], " \t\r"), "on");
+    }
+    return false;
+}
+
+/// Writes that answer back. Best effort: a setting that cannot be saved is
+/// still worth honouring for this run, and saying so is the window's job.
+pub fn writeServeRelays(io: std.Io, path: []const u8, on: bool) void {
+    std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = path,
+        .data = if (on) "serve_relays=on\n" else "serve_relays=off\n",
+        .flags = .{ .truncate = true, .permissions = std.Io.File.Permissions.fromMode(0o600) },
+    }) catch {};
+}
+
+/// POST /relays: whether this keyholder answers clients over relays.
+///
+/// The setting belongs here rather than in whatever app started this daemon. An
+/// app that embeds Notary is a client, and whether the key serves other devices
+/// is not a client's decision to make or to store.
+///
+/// Written now, applied on the next start: relay threads are created once, with
+/// the key, so a running daemon cannot grow or drop them. The window says so
+/// rather than pretending the switch was immediate.
+fn handleRelays(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) !void {
+    const Body = struct { on: bool = false };
+    const parsed = std.json.parseFromSlice(Body, self.gpa, body, .{ .ignore_unknown_fields = true }) catch
+        return respond(w, 400, bad_request);
+    defer parsed.deinit();
+
+    if (self.info.conf_file.len == 0) return respond(w, 409, "{\"error\":\"no config file\"}");
+    writeServeRelays(io, self.info.conf_file, parsed.value.on);
+    note(self, io, .{ .what = "relays", .outcome = if (parsed.value.on) "on" else "off" });
+    return respond(w, 200, if (parsed.value.on) "{\"ok\":true,\"on\":true}" else "{\"ok\":true,\"on\":false}");
+}
+
 fn handleInfo(self: *Server, io: std.Io, w: *std.Io.Writer) !void {
     // Ask the disk before answering. This is the poll the window sits on while
     // it is waiting to be set up or unlocked, so it is the one place that can
@@ -595,7 +652,7 @@ fn handleInfo(self: *Server, io: std.Io, w: *std.Io.Writer) !void {
     defer json.deinit(self.gpa);
     // Relay URLs and the bunker URI carry no JSON metacharacters (the URI
     // percent-encodes relay params), so they are emitted without escaping.
-    const head = try std.fmt.allocPrint(self.gpa, "{{\"state\":\"{s}\",\"pubkey\":\"{s}\",\"bunker\":\"{s}\",\"timeout_ms\":{d},\"relays\":[", .{ state_str, pubkey, bunker, self.info.timeout_ms });
+    const head = try std.fmt.allocPrint(self.gpa, "{{\"state\":\"{s}\",\"pubkey\":\"{s}\",\"bunker\":\"{s}\",\"timeout_ms\":{d},\"serve_relays\":{s},\"relays\":[", .{ state_str, pubkey, bunker, self.info.timeout_ms, if (self.info.serve_relays) "true" else "false" });
     defer self.gpa.free(head);
     try json.appendSlice(self.gpa, head);
     for (self.info.relays, 0..) |relay, i| {
@@ -2205,4 +2262,37 @@ test "a one-shot answer covers only the question it answered" {
     _ = broker.snapshot(&q);
     try testing.expect(broker.resolveFor(q[0].id, .approve, .once, 1_000_000));
     try testing.expect(broker.takeOneShot(plaza, .sign_event, 7, 1_000_000 + Broker.one_shot_ms) == null);
+}
+
+test "the keyholder owns whether it answers other devices" {
+    // The setting used to live in the app that started this daemon, which made
+    // a client responsible for a keyholder's policy. It belongs here: an app
+    // that embeds Notary spawns it and asks for nothing.
+    const gpa = testing.allocator;
+    const io = testing.io;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const path = try std.fmt.allocPrint(gpa, ".zig-cache/tmp/{s}/signer.conf", .{tmp.sub_path});
+    defer gpa.free(path);
+
+    // Missing means off. The safe reading of "I could not tell" is not to put
+    // the process holding a key on the network.
+    try testing.expect(!readServeRelays(gpa, io, path));
+
+    writeServeRelays(io, path, true);
+    try testing.expect(readServeRelays(gpa, io, path));
+    writeServeRelays(io, path, false);
+    try testing.expect(!readServeRelays(gpa, io, path));
+
+    // Only this user reads what the keyholder was told to do.
+    writeServeRelays(io, path, true);
+    const st = try std.Io.Dir.cwd().statFile(io, path, .{});
+    try testing.expectEqual(@as(std.posix.mode_t, 0), st.permissions.toMode() & 0o077);
+
+    // Anything unrecognised is off, not "probably on".
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = "serve_relays=yes please\n" });
+    try testing.expect(!readServeRelays(gpa, io, path));
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = "something_else=on\n" });
+    try testing.expect(!readServeRelays(gpa, io, path));
 }

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -52,6 +52,7 @@ fn idleExitMs() i64 {
 }
 
 const default_key_file = ".zig-nostr-signer.key";
+const default_conf_file = ".zig-nostr-signer.conf";
 // What the GUI serves on when the reader has not chosen. THREE, not one.
 //
 // A signer on a single relay is a signer that stops signing when that relay
@@ -154,20 +155,19 @@ pub fn main(init: std.process.Init) !void {
     // `SIGNER_APPROVAL_HTTP`. Parse argv here so the slice lives for the process
     // (GUI/relay mode never returns).
     var approval_addr = getEnv("SIGNER_APPROVAL_HTTP");
-    // `--serve-relays` is what separates the two things this daemon can be.
+    // Whether this daemon also answers clients over relays.
     //
-    // EMBEDDED, without it: the private keyholder of the one app that started
-    // it, reachable only down the pipe it was handed, and on no relay at all.
-    // Nothing outside that app can ask it for anything.
+    // The FLAG is an override for a terminal. The answer normally comes from
+    // this daemon's own config file, and that is the point rather than a
+    // convenience: whether the keyholder serves other devices is the
+    // keyholder's decision, not something the app that happened to start it
+    // gets to choose. An app embedding Notary spawns it and asks for nothing.
     //
-    // STANDALONE, with it: a bunker on real relays, where clients are NIP-46
-    // clients and prove who they are with their own keypair. That is the only
-    // place a stranger's request belongs, and it is the only mode that needs a
-    // network.
-    //
-    // Being both at once is what this flag exists to prevent. A daemon serving
-    // relays AND a local app is a keyholder with a public door, which is the
-    // shape nobody has made safe on the desktop.
+    // Serving relays is not a second door to guard. A client that reaches this
+    // over a relay is a NIP-46 client and proves who it is with its own
+    // keypair, which is the one identity here that cannot be forged. What the
+    // setting is really about is that turning it on puts the process holding
+    // the key on the network at all.
     var serve_relays = false;
     var args = std.process.Args.Iterator.init(init.minimal.args);
     _ = args.skip(); // argv[0]
@@ -203,21 +203,27 @@ pub fn main(init: std.process.Init) !void {
 /// first-run key onboarding over it, then serve with the resulting key. The
 /// broker and server live in this frame, which never returns (it tail-calls the
 /// forever-serving `runRelays`), so their addresses are stable for the process.
-fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8, policy_config: *const PolicyConfig, serve_relays: bool) noreturn {
+fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8, policy_config: *const PolicyConfig, forced_relays: bool) noreturn {
     const hp = parseHostPort(addr) orelse
         fail("SIGNER_APPROVAL_HTTP must be host:port, e.g. 127.0.0.1:0");
 
     // Turnkey defaults so a fresh download needs no configuration.
     const key_file = getEnv("SIGNER_KEY_FILE") orelse resolveHome(gpa, default_key_file);
+    // The flag forces it on; otherwise this daemon's own config decides. An app
+    // that embeds Notary passes nothing and gets whatever the reader chose in
+    // Notary's window, which is where a question about signing belongs.
+    const conf_path = getEnv("SIGNER_CONF_FILE") orelse resolveHome(gpa, default_conf_file);
+
+    var startup = std.Io.Threaded.init(gpa, .{});
+    defer startup.deinit();
+    const io = startup.io();
+
+    const serve_relays = forced_relays or approval_http.readServeRelays(gpa, io, conf_path);
     var relays: std.ArrayList([]const u8) = .empty;
     if (serve_relays) {
         parseRelays(gpa, &relays, getEnv("SIGNER_RELAYS") orelse default_gui_relays);
         if (relays.items.len == 0) fail("SIGNER_RELAYS contained no relay URLs");
     }
-
-    var startup = std.Io.Threaded.init(gpa, .{});
-    defer startup.deinit();
-    const io = startup.io();
 
     // No key file yet → the GUI must create one; an encrypted file present →
     // the GUI must unlock it.
@@ -261,7 +267,7 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
         .token = secret,
         .log = &g_audit,
         .idle_exit_ms = idleExitMs(),
-        .info = .{ .relays = relays.items, .timeout_ms = broker_storage.timeout_ms, .secret = conn_secret, .relay_status = relay_status },
+        .info = .{ .relays = relays.items, .timeout_ms = broker_storage.timeout_ms, .secret = conn_secret, .relay_status = relay_status, .serve_relays = serve_relays, .conf_file = conf_path },
         .clients = &g_authorized_clients,
         .host = hp.host,
         .port = hp.port,

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -74,6 +74,17 @@
     </column>
     <separator/>
   </if>
+  <if test="{show_serving}">
+    <column gap="6" padding="16">
+      <text foreground="text_muted">Other devices</text>
+      <row gap="8" cross="center">
+        <text grow="1" wrap="true">{serve_relays_line}</text>
+        <button on-press="toggle_relays">{serve_relays_action}</button>
+      </row>
+      <text foreground="text_muted" wrap="true">{serve_relays_hint}</text>
+    </column>
+    <separator/>
+  </if>
   <if test="{show_relays}">
     <column gap="6" padding="16">
       <text foreground="text_muted">Relays</text>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -130,6 +130,7 @@ const clipboard_key: u64 = 7;
 /// rejected while the first is still in flight.
 const command_clipboard_key: u64 = 17;
 const info_refresh_key: u64 = 16; // periodic /info re-poll (distinct from the initial info_key)
+const relays_key: u64 = 17; // POST /relays
 const decision_key_base: u64 = 8;
 const decision_key_slots: u64 = 8;
 const retry_timer_key: u64 = 100;
@@ -310,6 +311,11 @@ pub const Model = struct {
     daemon_bin_len: usize = 0,
     /// True when `SIGNER_BIN` is set: the app spawns and supervises the daemon.
     managed: bool = false,
+    /// Whether this keyholder answers clients over relays, as the daemon
+    /// reports it. The setting lives with the key rather than with whatever app
+    /// started the daemon: an app that embeds Notary is a client, and whether
+    /// the key serves other devices is not a client's decision.
+    serve_relays: bool = false,
 
     // The bearer header value, built from the secret this window minted.
     auth_buf: [96]u8 = [_]u8{0} ** 96,
@@ -736,6 +742,25 @@ pub const Model = struct {
         return std.fmt.allocPrint(arena, "{s}…{s}", .{ pk[0..10], pk[pk.len - 8 ..] }) catch pk[0..20];
     }
 
+    pub fn serve_relays_line(self: *const Model) []const u8 {
+        return if (self.serve_relays)
+            "Answering your other devices over relays."
+        else
+            "Signing only for the app that started me.";
+    }
+
+    pub fn serve_relays_action(self: *const Model) []const u8 {
+        return if (self.serve_relays) "Stop" else "Start";
+    }
+
+    /// Says WHEN, because relay threads are created once with the key, so a
+    /// running daemon cannot grow or drop them. A switch that looks like it did
+    /// something and did not is worse than one that says so.
+    pub fn serve_relays_hint(self: *const Model) []const u8 {
+        _ = self;
+        return "Takes effect the next time the signer starts. Your other clients connect with the link above.";
+    }
+
     fn setPubkey(self: *Model, pk: []const u8) void {
         const n = @min(pk.len, self.pubkey_buf.len);
         @memcpy(self.pubkey_buf[0..n], pk[0..n]);
@@ -879,6 +904,10 @@ pub const Msg = union(enum) {
     info: native_sdk.EffectResponse,
     pending: native_sdk.EffectResponse,
     decided: native_sdk.EffectResponse,
+    /// The reader asked this keyholder to start, or stop, answering other
+    /// devices over relays.
+    toggle_relays,
+    relays_set: native_sdk.EffectResponse,
     tick: native_sdk.EffectTimer,
     // Four answers rather than two, Amber's shape: "not now", "for a while"
     // and "stop asking" are each one press, because a prompt with only yes and
@@ -1056,6 +1085,27 @@ fn pollPending(model: *Model, fx: *Effects) void {
         .headers = &headers,
         .timeout_ms = 35_000,
         .on_response = Effects.responseMsg(.pending),
+    });
+}
+
+/// Tells the daemon whether to answer clients over relays.
+fn sendServeRelays(model: *Model, fx: *Effects, on: bool) void {
+    var url_buf: [128]u8 = undefined;
+    const url = std.fmt.bufPrint(&url_buf, "{s}/relays", .{model.baseUrl()}) catch return;
+    var body_buf: [24]u8 = undefined;
+    const body = std.fmt.bufPrint(&body_buf, "{{\"on\":{s}}}", .{if (on) "true" else "false"}) catch return;
+    const headers = [_]std.http.Header{
+        .{ .name = "authorization", .value = model.auth() },
+        .{ .name = "content-type", .value = "application/json" },
+    };
+    fx.fetch(.{
+        .key = relays_key,
+        .method = .POST,
+        .url = url,
+        .headers = &headers,
+        .body = body,
+        .timeout_ms = 5_000,
+        .on_response = Effects.responseMsg(.relays_set),
     });
 }
 
@@ -1341,6 +1391,14 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
         },
 
         // The poll chain reflects the removal; nothing else to do on ack.
+        .toggle_relays => {
+            const want = !model.serve_relays;
+            model.serve_relays = want; // optimistic; the next /info confirms it
+            sendServeRelays(model, fx, want);
+        },
+        // The daemon owns the answer; this only re-reads it.
+        .relays_set => fetchInfo(model, fx),
+
         .decided => {},
 
         .tick => |t| {
@@ -1654,6 +1712,7 @@ pub fn parseInfo(model: *Model, body: []const u8) void {
         pubkey: []const u8 = "",
         bunker: []const u8 = "",
         timeout_ms: u64 = 0,
+        serve_relays: bool = false,
         relays: []const struct { url: []const u8 = "", status: []const u8 = "" } = &.{},
     };
     const parsed = std.json.parseFromSliceLeaky(Info, fba.allocator(), body, .{ .ignore_unknown_fields = true }) catch return;
@@ -1661,6 +1720,7 @@ pub fn parseInfo(model: *Model, body: []const u8) void {
     model.setPubkey(parsed.pubkey);
     model.setBunker(parsed.bunker);
     model.setRelays(parsed.relays);
+    model.serve_relays = parsed.serve_relays;
     model.timeout_ms = parsed.timeout_ms;
 }
 


### PR DESCRIPTION
Whether the keyholder answers other devices over relays was a setting in the app that spawned it. That made a client responsible for a keyholder's policy, which is backwards: an app that embeds Notary *is* a client, and whether the key serves other devices is not a client's decision to make or to store.

It belongs with the key. The daemon reads its own config file, beside the key, readable only by this user. An embedding app passes no flag, stores no preference, and has no opinion. `--serve-relays` survives as an override for a terminal.

Notary's own window shows it, and the daemon owns the answer: the toggle posts, the daemon writes, and the next `/info` is what the screen believes. A window keeping its own copy would eventually disagree with the thing actually signing, and the disagreement would be invisible.

It says **when**, too. Relay threads are created once, with the key, so a running daemon cannot grow or drop them and the switch lands on the next start.

Missing or unreadable config means off: the safe reading of "I could not tell" is not to put the process holding a key on the network.