### PR TITLE
Notary is 0.10.1

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,12 +1,22 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
-### What's new in v0.9.2
+### What's new in v0.10.1
 
-**The passphrase field no longer shows the passphrase.** Both setup screens and the backup panel drew every character as you typed it, which is the wrong default for something people type in a cafe, on a call, or into a screen recording. They draw stars now, with an eye beside the field for the times you want to read back what you typed.
+**Notary can sign for the app it is shipped inside**, not only for clients that reach it over a relay. The two are deliberately not the same daemon.
 
-It starts hidden every launch, and goes back to hidden after each send. Hiding it also keeps the characters out of the name the window publishes for that field, which is where anything on your Mac with accessibility access could have read them.
+Which app may ask is settled by construction rather than by a credential. The daemon is started *by* the app it signs for and handed a one-time secret on its stdin. That channel has no name, no path and no port, so nothing else on your Mac can reach it, and holding it is the whole of the proof.
 
-One rough edge, and it belongs to the toolkit rather than to Notary: replacing selected text with exactly as many characters leaves the typed ones on screen until your next keystroke. Reveal the field if you want to edit the middle of a passphrase.
+This replaces a token in a `0600` file. Measured on a Mac: a file like that separates *users*, not apps, so every app you run could read it. A process's arguments and its environment leak the same way. A pipe from a parent does not.
+
+**Two modes, never both.** Run Notary on its own and it is a bunker on real relays, where a client proves who it is with its own keypair. Started by an app that ships it, it serves only that app and connects to no relay. A keyholder that any local app can reach would have to answer "which app is this", and on the desktop nothing can.
+
+Whether it *also* answers your other devices is Notary's own setting, in Notary's window, stored beside the key. The app that starts it has no say and stores nothing.
+
+**One key, one keyholder.** Two processes cannot share a decrypted key, so a second Notary is refused instead of asking for your passphrase again. The refusal is decided before the passphrase is read, so a correct one is never reported as wrong.
+
+**An audit log**, beside the key and readable only by you: every use of the key, wrong passphrases, exports, and clients you let in. By the id of what was signed, never its content; by peer and count for a batch of messages, never the messages.
+
+**Fixed:** setup could mint a new key over an import that arrived empty, giving you a brand new identity instead of the one you meant to bring. Gift-wrap rumors (kinds 14 and 15) were refused on one path and shown to you as a prompt on the other. Unanswered local requests could fill the approval queue and stop every other request, including those from relays.
 
 ### Install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,33 @@ jobs:
       - name: Check formatting
         run: zig fmt --check .
 
+  # The release page's notes are a hand-written file, and v0.10.0 shipped with
+  # v0.9.2's text in it: the release commit bumped the versions and the
+  # changelog and forgot this one, and nothing anywhere noticed. Whoever reads
+  # that page is told about a release that is not the one they are downloading.
+  #
+  # So the version has to appear in the notes. It is one grep, it runs on every
+  # push, and it fails the moment a bump and its notes disagree.
+  release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: The release notes name the version being released
+        run: |
+          version="$(sed -n 's/^ *\.version = "\(.*\)",$/\1/p' gui/app.zon | head -1)"
+          [ -n "$version" ] || { echo "could not read the version from gui/app.zon"; exit 1; }
+          if ! grep -qF "What's new in v$version" .github/RELEASE_NOTES.md; then
+            echo "gui/app.zon says $version, but .github/RELEASE_NOTES.md does not say"
+            echo "\"What's new in v$version\". The release page takes its text from that"
+            echo "file, so publishing now would describe a different release."
+            echo
+            echo "It currently says:"
+            grep -n "What's new in" .github/RELEASE_NOTES.md || echo "  (nothing)"
+            exit 1
+          fi
+          echo "release notes are for v$version"
+
   # The GUI (Native SDK): macOS only, via the native CLI.
   gui:
     runs-on: macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-08-28
+
+### Changed
+
+- **Whether this keyholder answers other devices is Notary's setting, not the
+  starting app's.** It was a switch in the app that spawned the daemon, which
+  made a client responsible for a keyholder's policy and had it storing a
+  preference about a key it deliberately knows nothing about.
+
+  The daemon reads its own config file, beside its own key, readable only by
+  this user. An app that embeds Notary passes no flag and has no opinion.
+  `--serve-relays` remains as an override for a terminal.
+
+  Notary's window shows it and the daemon owns the answer: the toggle posts, the
+  daemon writes, and the next `/info` is what the screen believes. A window
+  keeping its own copy would eventually disagree with the thing actually
+  signing, and the disagreement would be invisible.
+
+  It says WHEN, too: relay threads are created once, with the key, so a running
+  daemon cannot grow or drop them and the switch lands on the next start.
+
+  Missing or unreadable config means off. The safe reading of "I could not tell"
+  is not to put the process holding a key on the network.
+
+
 ## [0.10.0] - 2026-08-28
 
 Notary can now sign for the app it is shipped inside, not only for clients that

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.10.0",
+    .version = "0.10.1",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command", "clipboard" },


### PR DESCRIPTION
Cuts 0.10.1 so the release carries #79: whether this keyholder answers other devices is Notary's own setting, read from its own config file beside its own key, rather than a switch in whatever app started the daemon.

Plaza's release workflow pins a Notary tag, and 0.10.0 was cut before that landed.