### PR TITLE
Name the config file where the usage text names everything else

### DIFF
--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -105,6 +105,9 @@ const usage =
     \\                         $HOME/.zig-nostr-signer.log; empty turns it off)
     \\  SIGNER_IDLE_EXIT_MS    exit after this long with no request (default:
     \\                         900000, fifteen minutes; 0 stays up forever)
+    \\  SIGNER_CONF_FILE       where this daemon's own settings live (default:
+    \\                         $HOME/.zig-nostr-signer.conf), currently just
+    \\                         whether it answers clients over relays
     \\
     \\Subcommands:
     \\  import                 paste an existing nsec, read from the terminal


### PR DESCRIPTION
`SIGNER_CONF_FILE` was added with the setting it holds and never listed beside the other environment variables, so the one place a person goes to find out what this daemon reads did not mention it.

Found by running the packaged binary and reading its own help, rather than the source.