### PR TITLE
A daemon its own app started signs for it

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,29 +1,9 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
-### What's new in v0.10.1
+### What's new in v0.10.2
 
-**Notary can sign for the app it is shipped inside**, not only for clients that reach it over a relay. The two are deliberately not the same daemon.
+**Fixed: an app that ships Notary could not get anything signed.** A daemon started by its own app asked for approval on the first signature of each kind, and then filed that question where nobody could answer it: the window that shows the queue finds a keyholder by a fixed port and a token file, and a daemon started this way uses neither. So every write from the app it serves was refused and left waiting for an answer that could not arrive.
 
-Which app may ask is settled by construction rather than by a credential. The daemon is started *by* the app it signs for and handed a one-time secret on its stdin. That channel has no name, no path and no port, so nothing else on your Mac can reach it, and holding it is the whole of the proof.
+Being handed a one-time secret on stdin by the process that started it is already proof of who is asking, and on this channel it is the only proof there can be. A daemon started that way now signs for its parent without a second question, and still writes down every use of the key exactly as before.
 
-This replaces a token in a `0600` file. Measured on a Mac: a file like that separates *users*, not apps, so every app you run could read it. A process's arguments and its environment leak the same way. A pipe from a parent does not.
-
-**Two modes, never both.** Run Notary on its own and it is a bunker on real relays, where a client proves who it is with its own keypair. Started by an app that ships it, it serves only that app and connects to no relay. A keyholder that any local app can reach would have to answer "which app is this", and on the desktop nothing can.
-
-Whether it *also* answers your other devices is Notary's own setting, in Notary's window, stored beside the key. The app that starts it has no say and stores nothing.
-
-**One key, one keyholder.** Two processes cannot share a decrypted key, so a second Notary is refused instead of asking for your passphrase again. The refusal is decided before the passphrase is read, so a correct one is never reported as wrong.
-
-**An audit log**, beside the key and readable only by you: every use of the key, wrong passphrases, exports, and clients you let in. By the id of what was signed, never its content; by peer and count for a batch of messages, never the messages.
-
-**Fixed:** setup could mint a new key over an import that arrived empty, giving you a brand new identity instead of the one you meant to bring. Gift-wrap rumors (kinds 14 and 15) were refused on one path and shown to you as a prompt on the other. Unanswered local requests could fill the approval queue and stop every other request, including those from relays.
-
-### Install
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/zig-nostr/notary/main/scripts/install-macos.sh | bash
-```
-
-The installer downloads the latest release, verifies its SHA-256, installs `Notary.app` to `/Applications`, and opens it, ready to use.
-
-Notary is ad-hoc signed, not notarized, on purpose: it holds your keys, so the trust anchor is a build you can reproduce, not an Apple signature. Read the [installer](https://github.com/zig-nostr/notary/blob/main/scripts/install-macos.sh) or [build from source](https://github.com/zig-nostr/notary#build). **Your key never leaves the daemon unless you ask for it.**
+Nothing changes for a client that reaches Notary over a relay. Those prove who they are with their own keypair, and they still answer to the approval queue.

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -77,6 +77,23 @@ pub const Server = struct {
     gate: *Gate,
     /// Bearer token clients must present.
     token: []const u8,
+    /// Whether the holder of that token is this daemon's own parent.
+    ///
+    /// Set only by a daemon started with `--approval-http`, which refuses to
+    /// come up at all unless a secret arrived on stdin. That secret is minted
+    /// in the parent's memory, handed over a pipe, and written nowhere, so
+    /// presenting it is not a claim about who you are, it is proof of being
+    /// the process that started this one. There is no second way to obtain it.
+    ///
+    /// The per-question approval below exists for a caller this daemon cannot
+    /// identify. It is the wrong instrument here twice over: the pairing
+    /// already answered "who is asking", and a question filed for a private
+    /// child reaches nobody, because the window that shows the queue finds
+    /// daemons by a fixed port and a token file this one does not use.
+    ///
+    /// Defaults false so that every other construction, the tests included,
+    /// keeps the gate.
+    local_paired: bool = false,
     /// Where uses of the key are written down. Null writes nothing, which is
     /// how the tests that are about something else stay about something else.
     log: ?*audit.Log = null,
@@ -1016,6 +1033,18 @@ fn localAllowed(
     preview: []const u8,
     comptime what: []const u8,
 ) !bool {
+    // A daemon that was handed its secret by the process it serves has already
+    // been told who is asking, and the answer cannot be forged. Asking a person
+    // to confirm it would not add a check, it would add a question nobody can
+    // reach: the queue is served over a fixed port and a token file this daemon
+    // does not use, so the window shows a different daemon's questions. Plaza
+    // v0.13.0 shipped that way and could not write at all.
+    //
+    // This is not the relay surface. A client that arrives over a relay is
+    // still identified by its own keypair and still answers to everything
+    // below.
+    if (self.local_paired) return true;
+
     const now_ms = std.Io.Timestamp.now(io, .real).toMilliseconds();
 
     // An answer given ONCE, to the question this request already raised. Taking
@@ -1781,6 +1810,82 @@ test "an app nobody has answered for is refused, and asks once" {
         try handleSignerSign(&server, io, &out.writer, req);
     }
     try testing.expectEqual(@as(usize, 1), broker.snapshot(&queue));
+}
+
+test "a daemon its own parent started signs without asking anybody" {
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    gate.preload(kp);
+    // The one difference from the test above: this daemon was handed its
+    // secret by the process it serves.
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .local_paired = true, .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+
+    // A contact list, because that is the write that found this. Plaza v0.13.0
+    // asked for exactly this, was told to wait for an answer nobody could give,
+    // and reported the unfollow to the user as done.
+    const req = try signRequest(gpa, 3);
+    defer gpa.free(req);
+
+    var out = std.Io.Writer.Allocating.init(gpa);
+    defer out.deinit();
+    try handleSignerSign(&server, io, &out.writer, req);
+    var body = out.toArrayList();
+    defer body.deinit(gpa);
+
+    // 200 with a signature, not a question. The signed event comes back nested
+    // as an escaped JSON string, so this looks for the status and the absence
+    // of the refusal rather than for a bare `"sig"` that is never spelled that
+    // way in the wire form.
+    try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
+    try testing.expect(std.mem.indexOf(u8, body.items, "sig") != null);
+    try testing.expect(std.mem.indexOf(u8, body.items, nostr.signer_ipc.reason_awaiting_approval) == null);
+
+    // And it left no question behind. A row filed here is a row nobody can
+    // answer, so it would sit until the sweeper took it.
+    var queue: [Broker.capacity]Pending = undefined;
+    try testing.expectEqual(@as(usize, 0), broker.snapshot(&queue));
+}
+
+test "pairing is off unless it is asked for" {
+    // The same request, the same key, the same everything but the pairing. If
+    // this ever passes by default, every caller that can read a token is
+    // pre-approved and the queue stops meaning anything.
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    gate.preload(kp);
+    var server = Server{ .gpa = gpa, .broker = &broker, .gate = &gate, .token = "t", .info = .{ .relays = &.{}, .timeout_ms = 1000 }, .host = "127.0.0.1", .port = 0 };
+    try testing.expect(!server.local_paired);
+
+    const req = try signRequest(gpa, 3);
+    defer gpa.free(req);
+
+    var out = std.Io.Writer.Allocating.init(gpa);
+    defer out.deinit();
+    try handleSignerSign(&server, io, &out.writer, req);
+    var body = out.toArrayList();
+    defer body.deinit(gpa);
+    try testing.expect(std.mem.indexOf(u8, body.items, nostr.signer_ipc.reason_awaiting_approval) != null);
+    try testing.expect(std.mem.indexOf(u8, body.items, "403") != null);
 }
 
 test "an answer given once is not asked again, and frees its slot" {

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -268,6 +268,10 @@ fn runGuiMode(gpa: std.mem.Allocator, addr: []const u8, conn_secret: ?[]const u8
         .broker = &broker_storage,
         .gate = &gate,
         .token = secret,
+        // Reached only from the `--approval-http` path, which failed above if
+        // no secret arrived on stdin. So a caller holding this token is the
+        // parent that minted it.
+        .local_paired = true,
         .log = &g_audit,
         .idle_exit_ms = idleExitMs(),
         .info = .{ .relays = relays.items, .timeout_ms = broker_storage.timeout_ms, .secret = conn_secret, .relay_status = relay_status, .serve_relays = serve_relays, .conf_file = conf_path },

--- a/daemon/src/main.zig
+++ b/daemon/src/main.zig
@@ -105,6 +105,9 @@ const usage =
     \\                         $HOME/.zig-nostr-signer.log; empty turns it off)
     \\  SIGNER_IDLE_EXIT_MS    exit after this long with no request (default:
     \\                         900000, fifteen minutes; 0 stays up forever)
+    \\  SIGNER_CONF_FILE       where this daemon's own settings live (default:
+    \\                         $HOME/.zig-nostr-signer.conf), currently just
+    \\                         whether it answers clients over relays
     \\
     \\Subcommands:
     \\  import                 paste an existing nsec, read from the terminal

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.10.1",
+    .version = "0.10.2",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command", "clipboard" },


### PR DESCRIPTION
An app that ships Notary could not get anything signed.

The daemon asks for approval on the first signature of each kind, then files the question where nobody can answer it. The window that shows the queue finds a keyholder by a fixed port and a token file, and a daemon started by an app uses neither, so the question goes to one daemon and the window shows another's. Every write from the app it serves was refused and left waiting for an answer that could not arrive.

Plaza v0.13.0 shipped against this. Following somebody, muting, posting, editing a profile: all refused, none of it reaching a relay. Found by the acceptance journey that reads the contact list back off the relay, whose entire audit log for the run was one line:

```json
{"at":1787946771,"what":"sign","outcome":"awaiting","local":true,"method":"sign_event","kind":3}
```

## Why pre-approval is right here, and only here

The per-question gate exists for a caller this daemon cannot identify. On this channel it is the wrong instrument twice over.

Being handed a one-time secret on stdin by the process that started it is not a claim about who is asking, it is proof. The secret is minted in the parent's memory, travels down a pipe, and is written nowhere, so there is no second way to obtain it. The daemon already refuses to start at all if none arrives.

And the question it filed was unanswerable by construction, so it was never a check. It was a dead end.

So `--approval-http` sets `local_paired` and a paired daemon signs for its parent without asking again. It still writes down every use of the key, so nothing is lost from the audit log.

**Nothing changes over relays.** A client that arrives there proves who it is with its own keypair, and it still answers to the approval queue.

## Not opening the door

The field defaults to `false`, so every other construction keeps the gate, and a second test pins that default down. If pairing ever became the default, anything that could read a token would be pre-approved, which is the thing this design exists to prevent.

I checked that nothing writes a token file any more before relying on this: the only remaining mention is a stale comment.

## Verification

Removed the fix in place and confirmed only the new test goes red, then restored from a copy:

```
error: 'approval_http.test.a daemon its own parent started signs without asking anybody' failed
Build Summary: 69/70 tests passed (1 failed)
```

With the fix, all 70 pass.