### PR TITLE
The import command names the app it is running in

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,9 +1,5 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
-### What's new in v0.10.2
+### What's new in v0.10.3
 
-**Fixed: an app that ships Notary could not get anything signed.** A daemon started by its own app asked for approval on the first signature of each kind, and then filed that question where nobody could answer it: the window that shows the queue finds a keyholder by a fixed port and a token file, and a daemon started this way uses neither. So every write from the app it serves was refused and left waiting for an answer that could not arrive.
-
-Being handed a one-time secret on stdin by the process that started it is already proof of who is asking, and on this channel it is the only proof there can be. A daemon started that way now signs for its parent without a second question, and still writes down every use of the key exactly as before.
-
-Nothing changes for a client that reaches Notary over a relay. Those prove who they are with their own keypair, and they still answer to the approval queue.
+**Fixed: the import command named the wrong app.** This window ships inside Plaza as well as on its own. Started from Plaza, it still told you to run `/Applications/Notary.app/Contents/MacOS/signer import`, which is not on your Mac at all unless you also installed Notary separately. It now names the signer it actually ships beside, so the command works for the app you opened it from.

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.10.2",
+    .version = "0.10.3",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command", "clipboard" },

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -309,6 +309,9 @@ pub const Model = struct {
     base_url_len: usize = 0,
     daemon_bin_buf: [512]u8 = [_]u8{0} ** 512,
     daemon_bin_len: usize = 0,
+    /// `<that binary> import`, composed once the real path is known.
+    import_cmd_buf: [576]u8 = [_]u8{0} ** 576,
+    import_cmd_len: usize = 0,
     /// True when `SIGNER_BIN` is set: the app spawns and supervises the daemon.
     managed: bool = false,
     /// Whether this keyholder answers clients over relays, as the daemon
@@ -435,6 +438,11 @@ pub const Model = struct {
         const n = @min(path.len, self.daemon_bin_buf.len);
         @memcpy(self.daemon_bin_buf[0..n], path[0..n]);
         self.daemon_bin_len = n;
+        // The terminal card names THIS binary from here on. Composed where the
+        // path arrives rather than read later, so the card and the Copy button
+        // cannot disagree about what they are offering.
+        const cmd = std.fmt.bufPrint(&self.import_cmd_buf, "{s} import", .{self.daemon_bin_buf[0..n]}) catch "";
+        self.import_cmd_len = cmd.len;
     }
     pub fn daemonBin(self: *const Model) []const u8 {
         return self.daemon_bin_buf[0..self.daemon_bin_len];
@@ -534,8 +542,21 @@ pub const Model = struct {
     // -- onboarding view bindings --
 
     pub fn import_command_text(self: *const Model) []const u8 {
-        _ = self;
-        return import_command;
+        return self.importCommand();
+    }
+    /// The command that takes a key without it passing through this window.
+    ///
+    /// This window ships inside more than one app. Started from Plaza, the
+    /// signer beside it is Plaza's, and naming Notary's sends a reader to a
+    /// path that does not exist on their Mac unless they also installed Notary
+    /// on its own. So the real neighbour wins whenever there is one.
+    ///
+    /// The constant stays for the case it was written for: a dev build with no
+    /// sibling, where a path derived from the build cache would be useless and
+    /// the installed app is the right guess.
+    pub fn importCommand(self: *const Model) []const u8 {
+        if (self.import_cmd_len == 0) return import_command;
+        return self.import_cmd_buf[0..self.import_cmd_len];
     }
     /// "Copy", or the confirmation, on the terminal card's own button.
     pub fn command_copy_label(self: *const Model) []const u8 {
@@ -1446,7 +1467,7 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
 
         .copy_command => fx.writeClipboard(.{
             .key = command_clipboard_key,
-            .text = import_command,
+            .text = model.importCommand(),
             .on_result = Effects.clipboardMsg(.command_copied_result),
         }),
         .command_copied_result => |result| {

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -766,13 +766,36 @@ test "the terminal path is offered beside the paste field, not instead of it" {
             .copy_command => {},
             else => return error.WrongMessage,
         }
-        // The command names the INSTALLED binary. A path derived from argv[0]
-        // would be right in development and wrong for everybody else.
+        // With no signer beside this binary there is nothing better to name, so
+        // it names the installed app. A path derived from a build cache would
+        // be right in development and useless to everybody else.
         _ = try expectByText(tree.root, .text, "/Applications/Notary.app/Contents/MacOS/signer import");
         // And it says to reopen, because the import writes the key for the next
         // launch rather than handing it to a daemon it cannot reach.
         _ = try expectByText(tree.root, .text, "Run it, then reopen Notary to pick the key up.");
     }
+}
+
+test "the terminal card names the signer this window actually ships with" {
+    // This window ships inside Plaza too. Started from there, the signer beside
+    // it is Plaza's, and naming Notary's sent a reader to a path that is not on
+    // their Mac at all unless they installed Notary separately. Reported from a
+    // real install of Plaza v0.13.1.
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var model = main.initialModel();
+    model.phase = .needs_setup;
+    model.import_mode = true;
+    model.setDaemonBin("/Applications/Plaza.app/Contents/MacOS/signer");
+
+    const tree = try buildTree(arena, &model);
+    _ = try expectByText(tree.root, .text, "/Applications/Plaza.app/Contents/MacOS/signer import");
+
+    // And the button copies what the card shows. They read from one place, so
+    // they cannot offer different commands.
+    try testing.expectEqualStrings("/Applications/Plaza.app/Contents/MacOS/signer import", model.importCommand());
 }
 
 test "one status line, and it says the phase before there is a queue to count" {


### PR DESCRIPTION
Reported from a real install of Plaza v0.13.1: installing Plaza alone, opening the key window and following the terminal instruction gives a path that does not exist on the machine.

This window ships inside Plaza as well as on its own, and it offered:

```
/Applications/Notary.app/Contents/MacOS/signer import
```

which is only there if Notary was also installed separately.

The signer sits beside this binary, and `loadConfig` already resolves that path in order to run it, so the card names it. The text and the Copy button now read from one place, so they cannot offer different commands.

The old constant stays for exactly the case its comment described, a dev build with no sibling where a path out of the build cache would be right for nobody. It is the fallback now rather than the only answer, and the existing test still covers it.

Verified by putting the constant back and confirming only the new test goes red:

```
Build Summary: 7/9 steps succeeded (1 failed); 36/37 tests passed (1 failed)
error: 'tests.test.the terminal card names the signer this window actually ships with' failed
```

With the fix, 37/37.

Plaza needs a `NOTARY_REF` bump to pick this up, since the window ships inside it.