### PR TITLE
The relay switch says what it saved

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
-### What's new in v0.10.3
+### What's new in v0.10.4
 
-**Fixed: the import command named the wrong app.** This window ships inside Plaza as well as on its own. Started from Plaza, it still told you to run `/Applications/Notary.app/Contents/MacOS/signer import`, which is not on your Mac at all unless you also installed Notary separately. It now names the signer it actually ships beside, so the command works for the app you opened it from.
+**Fixed: turning off "answering your other devices" looked like it did nothing.** The switch wrote the setting correctly, but the window reads its state back from the daemon, and the daemon kept answering with the value it read when it started. So the switch flipped back a moment later and the setting looked dead, when it had in fact been saved.
+
+It still takes effect at the next start, because the relay connections are made once, with the key. What changed is that the window now tells you the truth about what it saved.
+
+**And a setting that cannot be written is no longer reported as saved.** That write used to swallow its error and answer as though it had worked.

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -610,14 +610,19 @@ pub fn readServeRelays(gpa: std.mem.Allocator, io: std.Io, path: []const u8) boo
     return false;
 }
 
-/// Writes that answer back. Best effort: a setting that cannot be saved is
-/// still worth honouring for this run, and saying so is the window's job.
-pub fn writeServeRelays(io: std.Io, path: []const u8, on: bool) void {
+/// Writes that answer back, reporting whether it landed.
+///
+/// It used to swallow the error and its comment said the setting was "still
+/// worth honouring for this run". Neither half was true: this setting only ever
+/// applies at the next start, so a write that failed changes nothing at all,
+/// and the window was told 200 either way.
+pub fn writeServeRelays(io: std.Io, path: []const u8, on: bool) bool {
     std.Io.Dir.cwd().writeFile(io, .{
         .sub_path = path,
         .data = if (on) "serve_relays=on\n" else "serve_relays=off\n",
         .flags = .{ .truncate = true, .permissions = std.Io.File.Permissions.fromMode(0o600) },
-    }) catch {};
+    }) catch return false;
+    return true;
 }
 
 /// POST /relays: whether this keyholder answers clients over relays.
@@ -636,7 +641,15 @@ fn handleRelays(self: *Server, io: std.Io, w: *std.Io.Writer, body: []const u8) 
     defer parsed.deinit();
 
     if (self.info.conf_file.len == 0) return respond(w, 409, "{\"error\":\"no config file\"}");
-    writeServeRelays(io, self.info.conf_file, parsed.value.on);
+    if (!writeServeRelays(io, self.info.conf_file, parsed.value.on)) {
+        note(self, io, .{ .what = "relays", .outcome = "not saved" });
+        return respond(w, 500, "{\"error\":\"could not save that setting\"}");
+    }
+    // What /info reports from here on. Without this it kept answering with the
+    // value read at STARTUP, so the window asked, was told the old answer, and
+    // put its switch back: the setting really was saved and the reader was
+    // shown that it was not.
+    self.info.serve_relays = parsed.value.on;
     note(self, io, .{ .what = "relays", .outcome = if (parsed.value.on) "on" else "off" });
     return respond(w, 200, if (parsed.value.on) "{\"ok\":true,\"on\":true}" else "{\"ok\":true,\"on\":false}");
 }
@@ -2369,6 +2382,86 @@ test "a one-shot answer covers only the question it answered" {
     try testing.expect(broker.takeOneShot(plaza, .sign_event, 7, 1_000_000 + Broker.one_shot_ms) == null);
 }
 
+test "turning the relay answer off is what /info says next" {
+    // The window shows its switch from /info. That used to answer with the
+    // value read at STARTUP, so pressing Stop wrote the file, the window asked,
+    // was told the old answer, and put the switch back. The setting really was
+    // saved and the reader was shown that it was not.
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try std.fmt.allocPrint(gpa, ".zig-cache/tmp/{s}/signer.conf", .{tmp.sub_path});
+    defer gpa.free(path);
+
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    var server = Server{
+        .gpa = gpa,
+        .broker = &broker,
+        .gate = &gate,
+        .token = "t",
+        // Started with it on, which is the state the bug needed.
+        .info = .{ .relays = &.{}, .timeout_ms = 1000, .serve_relays = true, .conf_file = path },
+        .host = "127.0.0.1",
+        .port = 0,
+    };
+
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleRelays(&server, io, &out.writer, "{\"on\":false}");
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "200") != null);
+    }
+
+    // On disk, for the next start.
+    try testing.expect(!readServeRelays(gpa, io, path));
+
+    // AND in what the window is about to be told.
+    {
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleInfo(&server, io, &out.writer);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "\"serve_relays\":false") != null);
+    }
+}
+
+test "a setting that could not be saved is not reported as saved" {
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    var server = Server{
+        .gpa = gpa,
+        .broker = &broker,
+        .gate = &gate,
+        .token = "t",
+        // A directory that is not there, so the write cannot land.
+        .info = .{ .relays = &.{}, .timeout_ms = 1000, .serve_relays = true, .conf_file = ".zig-cache/tmp/nope-not-here/signer.conf" },
+        .host = "127.0.0.1",
+        .port = 0,
+    };
+
+    var out = std.Io.Writer.Allocating.init(gpa);
+    defer out.deinit();
+    try handleRelays(&server, io, &out.writer, "{\"on\":false}");
+    var body = out.toArrayList();
+    defer body.deinit(gpa);
+    try testing.expect(std.mem.indexOf(u8, body.items, "500") != null);
+    // And the daemon did not quietly change its mind either.
+    try testing.expect(server.info.serve_relays);
+}
+
 test "the keyholder owns whether it answers other devices" {
     // The setting used to live in the app that started this daemon, which made
     // a client responsible for a keyholder's policy. It belongs here: an app
@@ -2385,13 +2478,13 @@ test "the keyholder owns whether it answers other devices" {
     // the process holding a key on the network.
     try testing.expect(!readServeRelays(gpa, io, path));
 
-    writeServeRelays(io, path, true);
+    _ = writeServeRelays(io, path, true);
     try testing.expect(readServeRelays(gpa, io, path));
-    writeServeRelays(io, path, false);
+    _ = writeServeRelays(io, path, false);
     try testing.expect(!readServeRelays(gpa, io, path));
 
     // Only this user reads what the keyholder was told to do.
-    writeServeRelays(io, path, true);
+    _ = writeServeRelays(io, path, true);
     const st = try std.Io.Dir.cwd().statFile(io, path, .{});
     try testing.expectEqual(@as(std.posix.mode_t, 0), st.permissions.toMode() & 0o077);
 

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.10.3",
+    .version = "0.10.4",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command", "clipboard" },


### PR DESCRIPTION
Reported from the app: pressing **Stop** on "answering your other devices" appeared to do nothing.

It did do something. The setting was written to the config file correctly and the next start would have honoured it. But the window reads its state back from `/info`, and `/info` answered with `self.info.serve_relays`, the value this daemon read **at startup**. So the window flipped its switch, asked, was told the old answer, and flipped it back.

The reader was shown that a setting had not been saved when it had. That is the worst version of this bug: the state on disk and the state on screen disagreed, and the screen was wrong.

`/relays` now updates what `/info` reports, so the readback agrees with the disk.

It still takes effect at the next start, because relay threads are created once, with the key. That part was honest already and the hint text still says so.

## Also

`writeServeRelays` swallowed its error and the handler answered 200 regardless, so a setting that could not be written was reported as saved. Its comment claimed the setting was "still worth honouring for this run", which was never true for a switch that only applies at the next start. It reports now, and a failed write answers 500 with the daemon's own state left alone.

## Verification

The existing test covered reading and writing the file but never the HTTP round trip, which is where the bug was. Two new tests drive it. Removing the readback turns exactly one red:

```
error: 'approval_http.test.turning the relay answer off is what /info says next' failed
Build Summary: 71/72 tests passed (1 failed)
```