### PR TITLE
Attach to the keyholder we were handed

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,9 +1,9 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
-### What's new in v0.10.4
+### What's new in v0.10.5
 
-**Fixed: turning off "answering your other devices" looked like it did nothing.** The switch wrote the setting correctly, but the window reads its state back from the daemon, and the daemon kept answering with the value it read when it started. So the switch flipped back a moment later and the setting looked dead, when it had in fact been saved.
+**Fixed: opening this window from an app left you unlocking the wrong keyholder.** An app that ships Notary starts its own keyholder and asks it to sign. This window went looking for a keyholder of its own instead: a well-known port when there was nothing there, and inside a packaged app a second keyholder started beside the first. So you typed your passphrase, this window said it was unlocked, and the app you opened it from was still sitting there with your key locked. Restarting did the same thing again.
 
-It still takes effect at the next start, because the relay connections are made once, with the key. What changed is that the window now tells you the truth about what it saved.
+An app can now hand this window the keyholder it is already using, and when it does, that one wins. One keyholder, shared, instead of two that cannot see each other.
 
-**And a setting that cannot be written is no longer reported as saved.** That write used to swallow its error and answer as though it had worked.
+The address arrives on the command line and the secret on the window's stdin, which is the same pair the keyholder itself takes and for the same reason: an address is not a secret, and a secret has no business on a command line where any program running as you can read it.

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.10.4",
+    .version = "0.10.5",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command", "clipboard" },

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -1797,6 +1797,44 @@ pub fn chooseDaemonBin(env_bin: ?[]const u8, bundled: ?[]const u8) ?[]const u8 {
     return bundled;
 }
 
+/// The keyholder an app that started this window handed over, if it did.
+///
+/// `--approval-http <addr>` on argv, and the bearer secret for it on stdin.
+/// Both or neither: an address with no secret cannot be used (every request
+/// needs the token), and a secret with no address has nothing to reach.
+///
+/// Reading stdin is gated on the flag ON PURPOSE. Started from Finder or a
+/// terminal there is nothing on stdin, and a read would block this window
+/// before it drew anything.
+const AttachedTo = struct { address: []const u8, secret: []const u8 };
+
+var g_attach_addr_buf: [128]u8 = undefined;
+var g_attach_secret_buf: [256]u8 = undefined;
+
+fn attachedAddress(io: std.Io, raw_args: anytype) ?AttachedTo {
+    var args = std.process.Args.Iterator.init(raw_args);
+    _ = args.skip(); // argv[0]
+    var addr: ?[]const u8 = null;
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--approval-http")) addr = args.next();
+    }
+    const a = addr orelse return null;
+    if (a.len == 0 or a.len > g_attach_addr_buf.len) return null;
+    @memcpy(g_attach_addr_buf[0..a.len], a);
+
+    var r = std.Io.File.stdin().reader(io, &g_attach_secret_buf);
+    const line = r.interface.takeDelimiterExclusive('\n') catch |err| switch (err) {
+        // The parent wrote the whole secret and closed, with no newline.
+        error.EndOfStream => r.interface.buffered(),
+        else => return null,
+    };
+    const secret = std.mem.trim(u8, line, " \t\r\n");
+    // Too short to be a secret anybody minted. Refusing beats attaching to a
+    // keyholder we cannot authenticate to and showing "connecting" forever.
+    if (secret.len < 16) return null;
+    return .{ .address = g_attach_addr_buf[0..a.len], .secret = secret };
+}
+
 /// Absolute path to a runnable `signer` sitting next to this executable, the
 /// layout a packaged app has (`…/Contents/MacOS/signer` beside the GUI binary),
 /// so a single download is self-contained. Returns null when there is no
@@ -1819,7 +1857,28 @@ fn bundledDaemonPath(io: std.Io, buf: []u8) ?[]const u8 {
 /// a `signer` bundled beside the app, or an overriding `SIGNER_BIN`. The token
 /// *contents* are read later through the effects channel, so a managed daemon
 /// that writes the file after we launch is picked up on retry.
-fn loadConfig(model: *Model, io: std.Io, environ: *const std.process.Environ.Map) void {
+fn loadConfig(model: *Model, io: std.Io, environ: *const std.process.Environ.Map, raw_args: anytype) void {
+    // An app that starts this window can hand it the keyholder it is ALREADY
+    // talking to, and when it does that keyholder wins over everything below.
+    //
+    // Without this the window went looking for a keyholder of its own: a
+    // well-known port in the dev tree, and in a packaged app a second daemon
+    // spawned beside the first. Either way it was never the one the app that
+    // opened it had the key in, so unlocking here unlocked nothing the app
+    // could use, and the app sat in guest mode with the key right there. A
+    // restart did it again. Reported from a real install.
+    //
+    // The address on argv, the secret on stdin: the same pair the daemon
+    // itself takes, and for the same reason. An address is not a secret, and a
+    // secret has no business in argv where `ps` prints it.
+    if (attachedAddress(io, raw_args)) |addr| {
+        model.setBaseUrl(addr.address);
+        model.setAuth(addr.secret);
+        model.managed = false;
+        model.port_known = true;
+        return;
+    }
+
     const address = environ.get("SIGNER_APPROVAL_HTTP") orelse default_address;
     model.setBaseUrl(address);
 
@@ -1848,7 +1907,7 @@ pub fn main(init: std.process.Init) !void {
     });
     defer app_state.destroy();
     app_state.model = initialModel();
-    loadConfig(&app_state.model, init.io, init.environ_map);
+    loadConfig(&app_state.model, init.io, init.environ_map, init.minimal.args);
 
     try runner.runWithOptions(app_state.app(), .{
         .app_name = "notary",


### PR DESCRIPTION
Reported from a real install: imported a key from the terminal, Notary picked it up, but Plaza stayed in guest mode. Restarting both changed nothing.

## What was happening

An app that ships Notary starts its own keyholder on a kernel-chosen port with a one-time secret handed down a pipe. This window went looking for a keyholder of its own regardless:

| | how it looked for one |
|---|---|
| dev tree | `SIGNER_APPROVAL_HTTP`, or `127.0.0.1:8787` where nothing was listening |
| packaged app | found `signer` beside it, went managed, and **started a second keyholder** |

Neither is the one the app has the key in. So the reader pressed "Bring your key", typed their passphrase, and this window reported an unlocked signer while the app that opened it still had a locked one. Restarting did the same thing again, because it does the same thing every time.

## The fix

An app may hand this window the keyholder it is already using, and when it does, that one wins over everything else.

`--approval-http <addr>` on argv, the bearer secret on **stdin**. That is the same pair the daemon itself takes and for the same reason: an address is not a secret, and a secret has no business in argv where `ps` prints it to every program running as this user.

Both or neither. An address with no secret cannot authenticate a single request; a secret with no address has nothing to reach. Reading stdin is gated on the flag deliberately, since a window started from Finder has nothing on stdin and an ungated read would block before it drew anything.

## Verified against the reproduction

I reproduced the report in a disposable home (an encrypted key at rest, Plaza launched) and confirmed after the fix:

```
window argv:  --approval-http 127.0.0.1:56945
signer 9914   TCP 127.0.0.1:56945 (LISTEN)
```

One keyholder in the process list, not two, and the window showing **"Locked / Unlock your signer"** for the app's own key.

Plaza needs the matching change to pass those two things, plus a `NOTARY_REF` bump.