### PR TITLE
The key controls are their own section

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,9 +1,15 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
-### What's new in v0.10.5
+### What's new in v0.10.6
 
-**Fixed: opening this window from an app left you unlocking the wrong keyholder.** An app that ships Notary starts its own keyholder and asks it to sign. This window went looking for a keyholder of its own instead: a well-known port when there was nothing there, and inside a packaged app a second keyholder started beside the first. So you typed your passphrase, this window said it was unlocked, and the app you opened it from was still sitting there with your key locked. Restarting did the same thing again.
+**Fixed: signing out and backing up your key had disappeared.** Both controls lived inside the card that shows the connection link, so a keyholder that publishes no link, which is every keyholder an app starts, showed neither. The only key control left was the one that deletes it. They are their own section now: whether you have a link to hand out and whether you can sign out are different questions.
 
-An app can now hand this window the keyholder it is already using, and when it does, that one wins. One keyholder, shared, instead of two that cannot see each other.
+**Fixed: the Sign out button did nothing when an app opened this window.** It refused whenever this window was not the one that started the keyholder, which is the case most people ever see. It signs out now, and the app that owns the keyholder starts a fresh one, locked.
 
-The address arrives on the command line and the secret on the window's stdin, which is the same pair the keyholder itself takes and for the same reason: an address is not a secret, and a secret has no business on a command line where any program running as you can read it.
+**Fixed: "delete my key" could start a second keyholder.** When an app had handed its keyholder over, removing the key started another one of our own, on real relays, and replaced the secret this window uses so it could never reach the app's keyholder again. It hands back to the app instead.
+
+**Fixed: a keyholder on no relays offered a connection link that went nowhere.** A `bunker://` link names the relays to reach a signer on. Built from an empty list it names nothing, and it was being shown as something to copy.
+
+**Fixed: this window now closes itself** once the app that opened it got what it asked for, and tells that app whether a key was made here or brought.
+
+**Clearer wording** in the section about signing for other apps, which used to promise a link in the state that has no link.

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -671,7 +671,13 @@ fn handleInfo(self: *Server, io: std.Io, w: *std.Io.Writer) !void {
     // the GUI shows and copies it, building it here keeps the canonical NIP-46
     // format (and the connection secret) in the daemon.
     const pubkey = if (state == .unlocked) self.gate.pubkeyHex() else "";
-    const bunker_uri: ?[]u8 = if (state == .unlocked)
+    // A bunker URI NAMES the relays a client should reach this keyholder on, so
+    // one built from an empty list names nothing: `bunker://<pubkey>` and no way
+    // to get there. It was still being handed to the window, which showed it as
+    // though it were a link worth copying. A keyholder that answers no relays
+    // has no connection string, and saying so by sending none is the honest
+    // form: the window already hides the card when there is nothing to show.
+    const bunker_uri: ?[]u8 = if (state == .unlocked and self.info.relays.len > 0)
         nip46.buildBunkerUri(self.gpa, self.gate.pubkey(), self.info.relays, self.info.secret) catch null
     else
         null;
@@ -2380,6 +2386,68 @@ test "a one-shot answer covers only the question it answered" {
     _ = broker.snapshot(&q);
     try testing.expect(broker.resolveFor(q[0].id, .approve, .once, 1_000_000));
     try testing.expect(broker.takeOneShot(plaza, .sign_event, 7, 1_000_000 + Broker.one_shot_ms) == null);
+}
+
+test "a keyholder on no relays offers no connection string" {
+    // `bunker://<pubkey>` with no relay after it is not a link, it is a pubkey
+    // with a scheme on the front. Nothing can reach a signer with it. The window
+    // was showing it as something to copy, on a keyholder started by an app,
+    // which is the one case where there are no relays by design.
+    const gpa = testing.allocator;
+    var threaded = std.Io.Threaded.init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var signer = nostr.keys.Signer.init();
+    defer signer.deinit();
+    const secret = try nostr.hex.decodeFixed(32, "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef");
+    const kp = try signer.keyPairFromSecretKey(secret);
+
+    var broker: Broker = .{};
+    var gate = Gate.init(gpa, std.Io.Dir.cwd(), "unused.ncryptsec", .uninitialized);
+    gate.preload(kp);
+
+    // Unlocked, holding the key, and answering nobody over relays.
+    {
+        var server = Server{
+            .gpa = gpa,
+            .broker = &broker,
+            .gate = &gate,
+            .token = "t",
+            .info = .{ .relays = &.{}, .timeout_ms = 1000 },
+            .host = "127.0.0.1",
+            .port = 0,
+        };
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleInfo(&server, io, &out.writer);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "\"bunker\":\"\"") != null);
+        // The pubkey is still reported: whose key it is was never the secret.
+        try testing.expect(std.mem.indexOf(u8, body.items, "\"pubkey\":\"dff1d77f") != null);
+    }
+
+    // And with a relay to name, the link comes back.
+    {
+        const relays = [_][]const u8{"wss://relay.example.com"};
+        var server = Server{
+            .gpa = gpa,
+            .broker = &broker,
+            .gate = &gate,
+            .token = "t",
+            .info = .{ .relays = &relays, .timeout_ms = 1000 },
+            .host = "127.0.0.1",
+            .port = 0,
+        };
+        var out = std.Io.Writer.Allocating.init(gpa);
+        defer out.deinit();
+        try handleInfo(&server, io, &out.writer);
+        var body = out.toArrayList();
+        defer body.deinit(gpa);
+        try testing.expect(std.mem.indexOf(u8, body.items, "bunker://dff1d77f") != null);
+        try testing.expect(std.mem.indexOf(u8, body.items, "relay.example.com") != null);
+    }
 }
 
 test "turning the relay answer off is what /info says next" {

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.10.5",
+    .version = "0.10.6",
     .icons = .{"assets/icon.png"},
     .platforms = .{"macos"},
     .permissions = .{ "view", "command", "clipboard" },

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -30,6 +30,16 @@
       <if test="{has_nostrconnect_error}">
         <text foreground="destructive">{nostrconnect_error}</text>
       </if>
+    </column>
+    <separator/>
+  </if>
+  <!-- Signing out and backing up have nothing to do with having a connection
+       string to hand out, and they used to sit INSIDE the bunker card's `if`.
+       The moment a keyholder stopped publishing a URI it could not be reached
+       on, both of them disappeared with it and there was no way to sign out at
+       all. Two different questions, two blocks. -->
+  <if test="{show_key_actions}">
+    <column gap="6" padding="16">
       <row gap="8">
         <button variant="secondary" on-press="sign_out">Sign out</button>
         <text grow="1" foreground="text_muted" wrap="true">Locks the signer. Your key stays on this Mac and needs its passphrase again.</text>
@@ -76,7 +86,7 @@
   </if>
   <if test="{show_serving}">
     <column gap="6" padding="16">
-      <text foreground="text_muted">Other devices</text>
+      <text foreground="text_muted">Other apps</text>
       <row gap="8" cross="center">
         <text grow="1" wrap="true">{serve_relays_line}</text>
         <button on-press="toggle_relays">{serve_relays_action}</button>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -765,21 +765,27 @@ pub const Model = struct {
 
     pub fn serve_relays_line(self: *const Model) []const u8 {
         return if (self.serve_relays)
-            "Answering your other devices over relays."
+            "Other apps can use this key, over relays."
         else
-            "Signing only for the app that started me.";
+            "This key signs only for the app that started it.";
     }
 
     pub fn serve_relays_action(self: *const Model) []const u8 {
-        return if (self.serve_relays) "Stop" else "Start";
+        // "Turn off" rather than "Stop": nothing is running to stop, and the
+        // change only lands at the next start, which "Stop" reads as denying.
+        return if (self.serve_relays) "Turn off" else "Turn on";
     }
 
     /// Says WHEN, because relay threads are created once with the key, so a
     /// running daemon cannot grow or drop them. A switch that looks like it did
     /// something and did not is worse than one that says so.
+    /// Different in each state, because it used to promise "the link above" when
+    /// the reader was in the state that has no link.
     pub fn serve_relays_hint(self: *const Model) []const u8 {
-        _ = self;
-        return "Takes effect the next time the signer starts. Your other clients connect with the link above.";
+        return if (self.serve_relays)
+            "Other clients connect with the link above. Takes effect the next time this keyholder starts."
+        else
+            "Turn this on to sign in to other Nostr apps from here. Takes effect the next time this keyholder starts.";
     }
 
     fn setPubkey(self: *Model, pk: []const u8) void {
@@ -799,11 +805,16 @@ pub const Model = struct {
     /// not the one showing: an empty one still takes its share of the window,
     /// and on the unlock screen it pushed the heading half way down.
     pub fn show_serving(self: *const Model) bool {
-        return self.show_bunker() or self.show_relays() or self.show_empty();
+        return self.show_bunker() or self.show_key_actions() or self.show_relays() or self.show_empty();
     }
 
     pub fn show_bunker(self: *const Model) bool {
         return self.phase == .connected and self.bunker_len > 0;
+    }
+    /// Signing out and backing up the key: available whenever there is a key in
+    /// hand, whether or not this keyholder answers anybody over relays.
+    pub fn show_key_actions(self: *const Model) bool {
+        return self.phase == .connected;
     }
     /// Copy-button label, confirming briefly after a successful copy.
     pub fn copy_label(self: *const Model) []const u8 {
@@ -1595,7 +1606,14 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             // sign out parked at "Starting the signer…" until the app was
             // restarted. `/lock` keeps the key; `/forget` is the one that
             // removes it.
-            if (!model.managed) return;
+            // This used to refuse whenever the window had not started the
+            // daemon, which meant a dead button in the one place most readers
+            // ever see this window: opened from an app. The press did nothing
+            // and said nothing.
+            //
+            // It is safe now because the app that owns this keyholder starts
+            // another when it ends, and that one comes up locked, which is what
+            // signing out means here.
             model.clearOnboardError();
             model.submitting = false;
             sendLock(model, fx);
@@ -1609,8 +1627,15 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
             model.clearBunker();
             model.clearRelays();
             model.clearSecrets();
-            spawnDaemon(model, fx);
-            attemptConnect(model, fx);
+            // Ours to restart, or somebody else's to. An app that handed its
+            // keyholder over starts the replacement itself; starting a second
+            // one here would leave two processes wanting the same key.
+            if (model.managed) {
+                spawnDaemon(model, fx);
+                attemptConnect(model, fx);
+            } else {
+                std.process.exit(0);
+            }
         },
         .forget_edit => |e| {
             model.forget_buf.apply(e);
@@ -1635,6 +1660,19 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
                 model.setAuth("");
                 model.clearRows();
                 model.clearSecrets();
+                // Ours to replace, or not ours at all.
+                //
+                // Unguarded, this started a keyholder of our own over the top of
+                // the app's, with `--serve-relays`, and `mintDaemonSecret`
+                // replaced the app's bearer secret in this model so this window
+                // could never reach the real one again. It used to fail loudly
+                // because the path was empty; resolving the path correctly is
+                // what would have turned it into a silent second signer with a
+                // public door.
+                //
+                // The app that owns this keyholder starts the replacement, and
+                // that one comes up with no key, which is what deleting it means.
+                if (!model.managed) std.process.exit(0);
                 spawnDaemon(model, fx);
                 attemptConnect(model, fx);
                 return;
@@ -1689,11 +1727,33 @@ pub fn update(model: *Model, msg: Msg, fx: *Effects) void {
     }
 }
 
-const OnboardKind = enum { setup, unlock };
+pub const OnboardKind = enum { setup, unlock };
 
 /// Applies a `/setup` or `/unlock` response. On success the key is loaded and
 /// the daemon is serving, so clear the secrets and switch to the approvals
 /// queue; on failure keep what the user typed and show why.
+/// What this window tells the app that started it, by the only channel it has.
+///
+/// The app watches this window's exit code to learn whether a key was MINTED
+/// here, which is not the same as one being brought: a key made a moment ago
+/// provably has no history, and the app uses that to write a first contact list
+/// without reading one back first. Claiming a mint for an import would let it
+/// publish over a real list; the reverse only loses the name beat.
+///
+/// Nothing ever produced this code before. This window had no exit path at all,
+/// so the app's `created` test was false for every mint and its whole
+/// minted-here branch was dead code.
+const ceremony_created_code: u8 = 9;
+
+pub fn exitCodeForTest(model: *const Model, kind: OnboardKind) u8 {
+    return exitCodeFor(model, kind);
+}
+
+fn exitCodeFor(model: *const Model, kind: OnboardKind) u8 {
+    if (kind != .setup) return 0; // an unlock made no key
+    return if (model.import_mode) 0 else ceremony_created_code;
+}
+
 fn onOnboardResponse(model: *Model, fx: *Effects, r: native_sdk.EffectResponse, kind: OnboardKind) void {
     model.submitting = false;
     if (r.outcome == .ok and r.status == 200) {
@@ -1702,6 +1762,18 @@ fn onOnboardResponse(model: *Model, fx: *Effects, r: native_sdk.EffectResponse, 
         model.clearOnboardError();
         model.version = 0; // a fresh serving session; poll the queue from the start
         model.phase = .connected;
+        // Opened by an app for one thing, and that thing just worked, so this
+        // window is done. It used to sit there afterwards showing a serving
+        // view for a keyholder the reader never asked to administer, and they
+        // had to close it by hand before getting back to what they were doing.
+        //
+        // Exiting IS closing for a window like this, and the app that started
+        // it is already watching for that: it learns the ceremony finished from
+        // the exit and nowhere else.
+        //
+        // Only when an app opened it. Run on its own, this window is the whole
+        // application and quitting after an unlock would be absurd.
+        if (!model.managed) std.process.exit(exitCodeFor(model, kind));
         // Pull /info so we learn the bunker:// URI to show the user; its handler
         // arms the pending-queue poll once it confirms the unlocked state.
         fetchInfo(model, fx);
@@ -1806,7 +1878,11 @@ pub fn chooseDaemonBin(env_bin: ?[]const u8, bundled: ?[]const u8) ?[]const u8 {
 /// Reading stdin is gated on the flag ON PURPOSE. Started from Finder or a
 /// terminal there is nothing on stdin, and a read would block this window
 /// before it drew anything.
-const AttachedTo = struct { address: []const u8, secret: []const u8 };
+pub const AttachedTo = struct { address: []const u8, secret: []const u8 };
+
+pub fn resolveConfigForTest(attached: ?AttachedTo, bin: ?[]const u8, env_addr: ?[]const u8) Resolved {
+    return resolveConfig(attached, bin, env_addr);
+}
 
 var g_attach_addr_buf: [128]u8 = undefined;
 var g_attach_secret_buf: [256]u8 = undefined;
@@ -1852,6 +1928,45 @@ fn bundledDaemonPath(io: std.Io, buf: []u8) ?[]const u8 {
 }
 
 /// Resolves the daemon address, token-file path, and (optional) daemon binary.
+/// What this window decided from what it found, with no IO in it.
+///
+/// Split out because the bug that made it necessary was a control-flow one: an
+/// early return in the attached branch skipped resolving the signer's path, and
+/// nothing could catch that because the whole decision was tangled with reading
+/// argv, stdin and the filesystem. This half is a function of its inputs, so a
+/// test can say what it must decide.
+pub const Resolved = struct {
+    base_url: []const u8,
+    auth: ?[]const u8,
+    /// Where the binary is. Known in BOTH modes: the terminal card names it and
+    /// a restart needs it, neither of which is about who started it.
+    daemon_bin: ?[]const u8,
+    /// Whether this window is the one that starts it. A keyholder handed over
+    /// by an app is not ours to start, stop or replace.
+    managed: bool,
+    port_known: bool,
+};
+
+fn resolveConfig(attached: ?AttachedTo, bin: ?[]const u8, env_addr: ?[]const u8) Resolved {
+    if (attached) |a| return .{
+        .base_url = a.address,
+        .auth = a.secret,
+        .daemon_bin = bin,
+        .managed = false,
+        .port_known = true,
+    };
+    const managed = bin != null;
+    return .{
+        .base_url = env_addr orelse default_address,
+        .auth = null,
+        .daemon_bin = bin,
+        .managed = managed,
+        // In managed mode there is nothing to know yet: the daemon takes a
+        // kernel-chosen port and prints it back.
+        .port_known = !managed,
+    };
+}
+
 /// `SIGNER_APPROVAL_HTTP` defaults to 127.0.0.1:8787; the token-file path
 /// defaults to `$HOME/.zig-nostr-signer.token`. Managed mode is switched on by
 /// a `signer` bundled beside the app, or an overriding `SIGNER_BIN`. The token
@@ -1871,29 +1986,25 @@ fn loadConfig(model: *Model, io: std.Io, environ: *const std.process.Environ.Map
     // The address on argv, the secret on stdin: the same pair the daemon
     // itself takes, and for the same reason. An address is not a secret, and a
     // secret has no business in argv where `ps` prints it.
-    if (attachedAddress(io, raw_args)) |addr| {
-        model.setBaseUrl(addr.address);
-        model.setAuth(addr.secret);
-        model.managed = false;
-        model.port_known = true;
-        return;
-    }
-
-    const address = environ.get("SIGNER_APPROVAL_HTTP") orelse default_address;
-    model.setBaseUrl(address);
-
+    // WHERE the signer is, resolved first and in both modes. (see resolveConfig)
+    //
+    // Two different things used to be tangled in this one field: where the
+    // binary is, which the terminal card names and a restart needs, and whether
+    // this window is the one that starts it. Only the second is `managed`.
+    // Returning early from the attached branch skipped this and cost both: the
+    // card went back to naming an app the reader may not have installed, and
+    // anything needing the path said "check SIGNER_BIN". Reported within the
+    // hour, on the release that fixed the other half.
     var bundled_buf: [1024]u8 = undefined;
     const bundled = bundledDaemonPath(io, &bundled_buf);
-    if (chooseDaemonBin(environ.get("SIGNER_BIN"), bundled)) |bin| {
-        model.setDaemonBin(bin);
-        model.managed = true;
-    }
-    // The address is known in BOTH modes now. Attached mode talks to whatever
-    // the operator pointed us at. In managed mode there is nothing to know
-    // yet: the daemon takes a kernel-chosen port and prints it back, which is
-    // what removes the well-known address anything else could have been
-    // sitting on.
-    model.port_known = !model.managed;
+    const bin = chooseDaemonBin(environ.get("SIGNER_BIN"), bundled);
+
+    const r = resolveConfig(attachedAddress(io, raw_args), bin, environ.get("SIGNER_APPROVAL_HTTP"));
+    model.setBaseUrl(r.base_url);
+    if (r.auth) |secret| model.setAuth(secret);
+    if (r.daemon_bin) |b| model.setDaemonBin(b);
+    model.managed = r.managed;
+    model.port_known = r.port_known;
 }
 
 pub fn main(init: std.process.Init) !void {

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -776,6 +776,80 @@ test "the terminal path is offered beside the paste field, not instead of it" {
     }
 }
 
+test "signing out and backing up do not depend on having a bunker link" {
+    // Both controls used to live INSIDE the bunker card's `if`. The moment a
+    // keyholder stopped publishing a URI it could not be reached on, which is
+    // every keyholder an app starts, the reader lost the only way to sign out
+    // and the only way to back up their key. Reported from a real install: "the
+    // only way is to use delete my key".
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+
+    var model = main.initialModel();
+    model.phase = .connected;
+    // No relays, so no connection string. Exactly what an app's keyholder is.
+    try testing.expect(!model.show_bunker());
+
+    // Asserted on the TREE, not on the predicate. The predicate was right while
+    // the markup still had both controls inside the bunker card's `if`, so a
+    // test of the predicate passes on the broken build. Only rendering catches
+    // where a control actually lives.
+    const tree = try buildTree(arena_state.allocator(), &model);
+    _ = try expectByText(tree.root, .button, "Sign out");
+    _ = try expectByText(tree.root, .button, "Back up your key");
+    // And no link is offered for a keyholder nothing can reach.
+    try testing.expect(findByText(tree.root, .button, "Copy") == null);
+}
+
+test "the exit code says whether a key was made or brought" {
+    // The app that opens this window learns from the exit code whether a key
+    // was MINTED here, and uses that to write a first contact list without
+    // reading one back. Saying "minted" for an import would let it publish over
+    // a real list.
+    var model = main.initialModel();
+
+    model.import_mode = false;
+    try testing.expectEqual(@as(u8, 9), main.exitCodeForTest(&model, .setup));
+
+    model.import_mode = true;
+    try testing.expectEqual(@as(u8, 0), main.exitCodeForTest(&model, .setup));
+
+    // An unlock made no key, whichever screen it came from.
+    model.import_mode = false;
+    try testing.expectEqual(@as(u8, 0), main.exitCodeForTest(&model, .unlock));
+}
+
+test "a handed-over keyholder still tells us where the signer is" {
+    // The regression this exists for: the attached branch returned early and
+    // skipped resolving the binary's path. Two things broke at once, on the
+    // release that fixed the other half. The terminal card went back to naming
+    // an app the reader may not have installed, and everything needing the path
+    // said "check SIGNER_BIN".
+    //
+    // Where the binary IS and whether we START it are different questions. Only
+    // the second is `managed`.
+    const bin = "/Applications/Plaza.app/Contents/MacOS/signer";
+    const handed = main.AttachedTo{ .address = "127.0.0.1:56945", .secret = "0123456789abcdef0123" };
+
+    const attached = main.resolveConfigForTest(handed, bin, null);
+    try testing.expectEqualStrings("127.0.0.1:56945", attached.base_url);
+    try testing.expectEqualStrings(bin, attached.daemon_bin.?);
+    // Handed over, so not ours to start, stop or replace.
+    try testing.expect(!attached.managed);
+    try testing.expect(attached.port_known);
+
+    // On its own it starts one, and still knows the same path.
+    const own = main.resolveConfigForTest(null, bin, null);
+    try testing.expectEqualStrings(bin, own.daemon_bin.?);
+    try testing.expect(own.managed);
+    try testing.expect(!own.port_known);
+
+    // And with no signer anywhere it manages nothing.
+    const none = main.resolveConfigForTest(null, null, null);
+    try testing.expect(none.daemon_bin == null);
+    try testing.expect(!none.managed);
+}
+
 test "the terminal card names the signer this window actually ships with" {
     // This window ships inside Plaza too. Started from there, the signer beside
     // it is Plaza's, and naming Notary's sent a reader to a path that is not on


### PR DESCRIPTION
Six reports from one real install, tested by hand against a packaged bundle before this was opened. They share two causes.

## Sign out and backup had vanished

Both lived **inside** the card that shows the connection link. A keyholder that publishes no link, which is every keyholder an app starts, showed neither. The only key control left was the one that deletes it, which is exactly how it was reported: *"the only way is to use delete my key"*.

They are their own block now.

## Sign out did nothing anyway

It refused whenever this window had not started the daemon, which is the case most readers ever see. Safe to allow now that the app owning the keyholder starts another when it ends, and the replacement comes up locked.

Verified live: daemon exited, window closed itself, `lock ok` in the audit log.

## The dangerous one

Removing the key called `spawnDaemon` with **no ownership check**. With a keyholder handed over by an app it started a second one, with `--serve-relays`, and `mintDaemonSecret` replaced the app's bearer secret in this model so this window could never reach the real keyholder again.

It failed loudly while the daemon's path was empty. Resolving that path correctly, which shipped in v0.10.5, is what would have turned it into a silent second signer with a public door.

## Also

- **A keyholder on no relays offers no connection string.** A `bunker://` URI names the relays to reach a signer on; built from an empty list it names nothing, and it was shown as a link worth copying.
- **The window closes itself** once the app that opened it got what it asked for, and says by its **exit code** whether a key was minted here or brought. Nothing ever produced that code before, so the app's minted-here branch was dead for every mint through this window.
- **Per-state wording** for signing for other apps. It used to promise "the link above" in the state that has no link, and called them devices when there are none.

## On the test

My first test for the sign-out fix asserted on `show_key_actions()`. The probe came back NOT CAUGHT: the predicate was already true while the button was still in the wrong block, so it passed on the broken build. It renders the tree now and asserts the button is really there.

```
39/40 tests passed (1 failed)   <- markup reverted
40/40                            <- with the fix
```