### PR TITLE
CI cuts the tag, from the commit that bumped the version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  # How the Tag workflow asks for a build: a tag it pushed with the default
+  # token cannot start this one on its own. Run against the tag ref, so
+  # `github.ref_name` reads exactly as a tag push would give it.
+  workflow_dispatch:
 
 permissions:
   contents: write # create the release and upload the .app

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,60 @@
+name: Tag
+
+# Cuts the release tag from the commit that bumped the version, and nothing
+# else.
+#
+# This exists because I tagged by hand and got it wrong: a wait pulled `main` a
+# second before a squash-merge landed, so `git tag` named the previous commit.
+# The tag said v0.10.6 and pointed at v0.10.5's tree.
+#
+# The release build below refused it, which is what its version check is for.
+# What that check could not protect was PLAZA, which had already built against
+# the same tag and shipped a release carrying the previous window. A tag here is
+# a build input over there, so one that is right by name and wrong by content is
+# not a local mistake.
+#
+# The fix is not a better wait. No local checkout is involved: the tag is created
+# on ${{ github.sha }}, which IS the commit that carried the bump.
+on:
+  push:
+    branches: [main]
+    paths: ["gui/app.zon"]
+
+permissions:
+  contents: write # create the tag
+  actions: write # and start the release build for it
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # so an existing tag can be seen
+
+      - name: Tag the version this commit declares
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(sed -n 's/.*\.version = "\([^"]*\)".*/\1/p' gui/app.zon | head -1)"
+          [ -n "$version" ] || { echo "no version found in gui/app.zon" >&2; exit 1; }
+          tag="v$version"
+
+          # Idempotent: this fires on every push touching gui/app.zon, and most
+          # of those do not move the version.
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            echo "$tag already exists; nothing to do"
+            exit 0
+          fi
+
+          git config user.name "sepehr-safari"
+          git config user.email "safari.sepehr@gmail.com"
+          # On this exact commit, named explicitly. The whole point.
+          git tag -a "$tag" -m "Notary $tag" "$GITHUB_SHA"
+          git push origin "$tag"
+          echo "tagged $tag at $GITHUB_SHA"
+
+          # A tag pushed with the default token starts no other workflow, so the
+          # release is asked for by name, against the tag ref.
+          gh workflow run release.yml --ref "$tag"
+          echo "asked release.yml to build $tag"


### PR DESCRIPTION
I tagged v0.10.6 by hand and got it wrong. A wait pulled `main` a second before the squash-merge landed, so `git tag` named the previous commit: the tag said **v0.10.6** and pointed at **v0.10.5's tree**.

The release build refused it, which is what its version check is for:

```
tag v0.10.6 says 0.10.6, gui/app.zon says 0.10.5
```

What that check could not protect was **Plaza**, which had already built against the same tag eleven minutes earlier and shipped a release carrying the previous window. Everything tested by hand that afternoon was missing from it, and the shipped binary proves it:

```
"Other devices" (old): 1
"Other apps"    (new): 0
```

A tag here is a **build input over there**. One that is right by name and wrong by content is not a local mistake.

## The fix

No local checkout is involved any more. The tag is created on `${{ github.sha }}`, which *is* the commit carrying the bump, so there is nothing to be stale about. Pushing a version bump to `main` is the whole of cutting a release.

`release.yml` gains `workflow_dispatch`, because a tag pushed with the default token starts no other workflow. The tag job asks for the build by name against the tag ref, so `github.ref_name` reads exactly as a tag push would give it.

Plaza gets the same change in zig-nostr/plaza#329, plus a workflow that watches for a new Notary release and opens its own bump PR, so a keyholder fix no longer depends on me remembering to cut the second release.