### PR TITLE
Notary builds and runs on Linux

### DIFF
--- a/gui/app.zon
+++ b/gui/app.zon
@@ -5,7 +5,7 @@
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
     .version = "0.10.6",
     .icons = .{"assets/icon.png"},
-    .platforms = .{"macos"},
+    .platforms = .{ "macos", "linux" },
     .permissions = .{ "view", "command", "clipboard" },
     .capabilities = .{ "native_views", "gpu_surfaces" },
     .shell = .{

--- a/gui/src/app.native
+++ b/gui/src/app.native
@@ -42,7 +42,7 @@
     <column gap="6" padding="16">
       <row gap="8">
         <button variant="secondary" on-press="sign_out">Sign out</button>
-        <text grow="1" foreground="text_muted" wrap="true">Locks the signer. Your key stays on this Mac and needs its passphrase again.</text>
+        <text grow="1" foreground="text_muted" wrap="true">Locks the signer. Your key stays on this computer and needs its passphrase again.</text>
       </row>
       <separator/>
       <if test="{backup_closed}">
@@ -185,7 +185,7 @@
         <button variant="destructive" on-press="reveal_forget">Use another key</button>
       </if>
       <if test="{forget_open}">
-        <text foreground="text_muted" wrap="true">Signing in as somebody else removes this key from this Mac. It is the only copy here, so make sure you have its nsec written down first. Type "delete my key" to confirm.</text>
+        <text foreground="text_muted" wrap="true">Signing in as somebody else removes this key from this computer. It is the only copy here, so make sure you have its nsec written down first. Type "delete my key" to confirm.</text>
         <row><text-field text="{forget_confirm}" placeholder="delete my key" on-input="forget_edit" grow="1"/></row>
         <row gap="8">
           <button grow="1" on-press="cancel_forget">Cancel</button>

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -456,10 +456,17 @@ pub const Model = struct {
     /// place it cannot.
     pub fn mintDaemonSecret(self: *Model) void {
         var raw: [24]u8 = undefined;
-        // The OS CSPRNG, reached directly because this runs in a Model method
-        // that has no `io` to hand. macOS guarantees `arc4random_buf` never
-        // fails and needs no seeding.
-        std.c.arc4random_buf(&raw, raw.len);
+        // The OS CSPRNG through `io`, which this reaches by way of a module
+        // global because a Model method has none to hand.
+        //
+        // It used to call `std.c.arc4random_buf` directly, which is a macOS
+        // guarantee and not a portable one: Zig declares that symbol as `void`
+        // on musl and on glibc below 2.36, so the call is a COMPILE error, not a
+        // link error, on Ubuntu 22.04, Debian 11, RHEL 9 and every static build.
+        // `std.crypto.random` and `std.posix.getrandom` are both gone in 0.16,
+        // so this is the remaining way to ask.
+        const io = g_io orelse return;
+        io.randomSecure(&raw) catch return;
         const hexed = std.fmt.bufPrint(&self.daemon_secret_buf, "{x}\n", .{raw}) catch return;
         self.daemon_secret_len = hexed.len;
         self.setAuth(hexed[0 .. hexed.len - 1]); // the header wants it without the newline
@@ -1884,6 +1891,14 @@ pub fn resolveConfigForTest(attached: ?AttachedTo, bin: ?[]const u8, env_addr: ?
     return resolveConfig(attached, bin, env_addr);
 }
 
+/// The process `Io`, for the one place that needs the OS CSPRNG from inside a
+/// Model method. Set once at startup, and by the test that mints a secret.
+var g_io: ?std.Io = null;
+
+pub fn setIoForTest(io: std.Io) void {
+    g_io = io;
+}
+
 var g_attach_addr_buf: [128]u8 = undefined;
 var g_attach_secret_buf: [256]u8 = undefined;
 
@@ -2018,6 +2033,7 @@ pub fn main(init: std.process.Init) !void {
     });
     defer app_state.destroy();
     app_state.model = initialModel();
+    g_io = init.io;
     loadConfig(&app_state.model, init.io, init.environ_map, init.minimal.args);
 
     try runner.runWithOptions(app_state.app(), .{

--- a/gui/src/main.zig
+++ b/gui/src/main.zig
@@ -156,7 +156,7 @@ pub const Row = struct {
     /// The requesting client's pubkey, hex.
     client_buf: [64]u8 = [_]u8{0} ** 64,
     client_len: u8 = 0,
-    /// Whether `client_buf` holds a name an app on this Mac chose for itself,
+    /// Whether `client_buf` holds a name an app on this computer chose for itself,
     /// rather than the pubkey of whoever signed a request over a relay.
     ///
     /// The two are not the same kind of fact and the row must not read as
@@ -218,7 +218,7 @@ pub const Row = struct {
     /// word, and eight characters of each end is what makes it comparable at
     /// all, since nobody reads sixty-four.
     ///
-    /// A request from an app on this Mac carries a name the app chose. Any
+    /// A request from an app on this computer carries a name the app chose. Any
     /// program running as this user can read the daemon's token and claim any
     /// name, so "from Plaza" would state something nobody checked, on the one
     /// row in this application where a person is being asked to check
@@ -227,7 +227,7 @@ pub const Row = struct {
         const c = self.client();
         if (c.len == 0) return "unknown client";
         if (self.local)
-            return std.fmt.allocPrint(arena, "an app on this Mac calling itself \"{s}\"", .{c}) catch c;
+            return std.fmt.allocPrint(arena, "an app on this computer calling itself \"{s}\"", .{c}) catch c;
         if (c.len < 20) return c;
         return std.fmt.allocPrint(arena, "from {s}…{s}", .{ c[0..8], c[c.len - 8 ..] }) catch c;
     }

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -93,6 +93,11 @@ test "the secret is minted fresh and never leaves this process except down the p
     // (`ps -Eww` printed one), and could always read a 0600 token file, because
     // file permissions separate USERS and not apps. A pipe to a child has no
     // name and no path, so there is nothing to open.
+    // The mint reaches the OS CSPRNG through `io`, so the test provides one.
+    var threaded = std.Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    main.setIoForTest(threaded.io());
+
     var a = Model{};
     var b = Model{};
     a.mintDaemonSecret();

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -310,7 +310,7 @@ test "an approval row says who is asking and what would be signed" {
         \\"local":true,"client":"plaza","preview":"gm"}]}
     );
     const here_tree = try buildTree(arena_state.allocator(), &here);
-    _ = try expectByText(here_tree.root, .text, "an app on this Mac calling itself \"plaza\"");
+    _ = try expectByText(here_tree.root, .text, "an app on this computer calling itself \"plaza\"");
 
     // And it must not be dressed up as proof of who is asking.
     try testing.expect(findByText(here_tree.root, .text, "from plaza") == null);

--- a/gui/src/tests.zig
+++ b/gui/src/tests.zig
@@ -298,7 +298,7 @@ test "an approval row says who is asking and what would be signed" {
     const old_tree = try buildTree(arena_state.allocator(), &old);
     _ = try expectByText(old_tree.root, .text, "unknown client");
 
-    // An app on this Mac gets the other sentence. It named itself, and any
+    // An app on this computer gets the other sentence. It named itself, and any
     // program running as this user could have named itself the same, so the
     // row says what happened rather than asserting an identity: this is the
     // one screen in the application whose whole job is to be read carefully
@@ -688,7 +688,7 @@ test "a refused nostrconnect link says which thing went wrong" {
 test "the destructive key removal is inert until the phrase matches exactly" {
     var m = main.Model{};
     // Disabled by default, so the press that removes somebody's only copy of an
-    // identity on this Mac cannot be a mis-click.
+    // identity on this computer cannot be a mis-click.
     try testing.expect(m.forget_disabled());
 
     m.forget_buf.set("yes");


### PR DESCRIPTION
Notary builds and runs on Linux, and stops telling a Linux reader their key is on a Mac.

## The compile error

`mintDaemonSecret` called `std.c.arc4random_buf`. That is a macOS guarantee, not a portable one: Zig declares the symbol as `void` where it is not present, so calling it is a COMPILE error rather than a link error. I checked the targets rather than assuming, by building the call on its own for each:

```
x86_64-linux-musl      → error: type 'void' not a function
x86_64-linux-gnu.2.35  → error: type 'void' not a function
x86_64-linux-gnu.2.36  → compiles
```

That covers Ubuntu 22.04, Debian 11, RHEL 9 and every static build. It goes through `io.randomSecure` instead, reached by way of a module global because a `Model` method has no `io` to hand, and `std.crypto.random` and `std.posix.getrandom` are both gone in 0.16.

The failure mode if that global were ever unset is worth stating, since this is the credential the local channel rests on: the mint would return early and leave the secret empty, and the daemon refuses to start on an empty secret (`fail("no secret arrived on stdin")`), so it is a visible startup failure rather than an open channel. The global is assigned in `main` before `loadConfig` and before the runner, and the only caller is `spawnDaemon`, which runs as an effect long after that.

## The copy

The manifest named only macOS, and four strings told the reader their key was on "this Mac". They say "this computer" now, including the one on the screen whose whole job is to be read carefully before somebody allows a signature under their name.

## Not required by Plaza's Linux work

Plaza's Linux branch does not need this. I assumed it did and tested instead of trusting that: `native build` does not enforce the manifest's platform list, `ubuntu-latest` is glibc 2.39 where the symbol is declared, and Plaza's `linux-package` job passes against the pinned `v0.10.6`. So this is correctness for everyone whose distro is older, and for anyone building statically, rather than a blocker for anything.

No release. The version stays 0.10.6 and the release notes still describe it.

## Checked

Every CI gate run locally first: `zig build`, `zig build test` and `zig fmt --check .` in `daemon`, and `native check`, `native test`, `native build` and `zig fmt --check src` in `gui`, plus the release-notes and manifest-version match.
