### PR TITLE
Notary is 0.10.7

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
 
+### What's new in v0.10.7
+
+**Notary runs on Linux.** The download on this page is still the macOS app. What changed is that the same window and the same keyholder now build and run on Linux, which is what lets Plaza's Linux build carry a keyholder of its own instead of asking you to bring one.
+
+**Fixed: it would not build at all on distributions with older system libraries.** The daemon secret was minted through a function macOS guarantees and Linux does not, and on musl and on glibc below 2.36 that is a compile error rather than a warning. Ubuntu 22.04, Debian 11, RHEL 9 and every static build could not compile it. It asks the operating system for randomness through a portable route now.
+
+**"This Mac" now reads "this computer"** everywhere it appears, including the sentence you read before allowing a signature under your name.
+
 ### What's new in v0.10.6
 
 **Fixed: signing out and backing up your key had disappeared.** Both controls lived inside the card that shows the connection link, so a keyholder that publishes no link, which is every keyholder an app starts, showed neither. The only key control left was the one that deletes it. They are their own section now: whether you have a link to hand out and whether you can sign out are different questions.

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.10.6",
+    .version = "0.10.7",
     .icons = .{"assets/icon.png"},
     .platforms = .{ "macos", "linux" },
     .permissions = .{ "view", "command", "clipboard" },


### PR DESCRIPTION
Cuts the release that carries the Linux work.

**What is in it**

The window and the keyholder build and run on Linux. That is what lets Plaza's Linux build ship a keyholder of its own rather than asking a reader to bring one. The download on the release page is still the macOS app: `release.yml` has one job and it is `macos-app`.

The portability fix that made it buildable there at all. `std.c.arc4random_buf` is a macOS guarantee, and Zig declares that symbol as `void` where it is absent, so calling it is a compile error rather than a link error on musl and on glibc below 2.36. Ubuntu 22.04, Debian 11, RHEL 9 and every static build could not compile Notary before this.

And the copy that no longer tells a Linux reader their key is on a Mac.

**Why this goes first**

Plaza pins a Notary tag and builds it from source. Its `release.yml` currently pins `NOTARY_REF: v0.10.6`, whose `gui/app.zon` still declares `.platforms = .{"macos"}`. So Plaza's own Linux release needs a Notary release to point at, and this is it. Once this publishes, `notary-bump.yml` over in Plaza opens the pin PR on its next hourly run.

**Mechanically**

This bumps `gui/app.zon`, which is the path `tag.yml` watches, so the tag is cut from this commit rather than from whatever `main` happens to be a second later. That is the failure #87 exists to prevent.

**Checked**

Every CI gate locally first: `zig build`, `zig build test` and `zig fmt --check .` in `daemon`; `native check`, `native test`, `native build` and `zig fmt --check src` in `gui`; and the release-notes gate against the new version.