### PR TITLE
Notary ships a Linux build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,81 @@ jobs:
 
       - name: Check formatting
         run: zig fmt --check src
+
+  # Packages the Linux tarball on every pull request, for both architectures.
+  #
+  # release.yml builds these on a tag and uploads them into the release, and a
+  # release is the one artifact nobody gets to re-check. So the script runs
+  # here, where a break is a red X on a pull request rather than a published
+  # release missing half its downloads, and the `ubuntu-24.04-arm` label is
+  # proven here before the release path is allowed to depend on it.
+  linux-package:
+    name: linux-package (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-latest, arch: x86_64 }
+          - { runner: ubuntu-24.04-arm, arch: aarch64 }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read Zig version
+        id: zig-version
+        run: echo "version=$(cat .zigversion)" >> "$GITHUB_OUTPUT"
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ steps.zig-version.outputs.version }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install the Native SDK CLI
+        run: npm install -g @native-sdk/cli@0.9.2
+
+      # gtk4 only. Notary draws on a canvas and declares no web use, so the host
+      # compiles with the WebKitGTK stub and links gtk4 and libdl and nothing
+      # else. Installing WebKit here would hide a regression that made it real.
+      - name: Install the Linux host dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-4-dev
+
+      # The retried fetch: `zig build` dies with "unable to discover remote git
+      # server capabilities: ProtocolError" pulling secp256k1, which this repo
+      # pins by git URL rather than by tarball. Seen on three runners now, and
+      # it failed a release build outright over in Plaza.
+      - name: Fetch the dependency tree
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if (cd daemon && zig build --fetch); then exit 0; fi
+            echo "fetch attempt $attempt failed" >&2
+            sleep $((attempt * 10))
+          done
+          echo "could not fetch dependencies in five attempts" >&2
+          exit 1
+
+      - name: Build the daemon
+        run: cd daemon && zig build -Doptimize=ReleaseFast
+
+      - name: Package
+        run: gui/scripts/package-linux.sh --signer daemon/zig-out/bin/signer --output dist
+
+      # The installer derives the file name from `uname -m`, so a tarball named
+      # for the wrong architecture is a 404 for whoever the runner was not.
+      - name: The tarball is for the architecture this runner actually is
+        run: |
+          got="$(ls dist/notary-*-linux-*.tar.gz | head -1)"
+          case "$got" in
+            *-linux-${{ matrix.arch }}.tar.gz) echo "$got" ;;
+            *) echo "expected a ${{ matrix.arch }} tarball, packaged $got" >&2; exit 1 ;;
+          esac
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: notary-linux-${{ matrix.arch }}
+          path: dist/*.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,108 @@ jobs:
             echo "release exists; replacing its artifact with the one built here"
             gh release upload "$GITHUB_REF_NAME" "$asset" --clobber
           else
+            # A DRAFT. The Linux tarballs are built by another job that takes
+            # minutes longer, and a release published before they arrive is one
+            # whose Linux installer 404s for exactly as long as that takes. The
+            # `publish` job below lifts the draft once every artifact is up.
             gh release create "$GITHUB_REF_NAME" "$asset" \
+              --draft \
               --title "Notary $GITHUB_REF_NAME" \
               --notes-file .github/RELEASE_NOTES.md
           fi
+
+  # The Linux tarball: the window and the daemon it spawns, side by side, the
+  # same two binaries the macOS bundle carries in Contents/MacOS.
+  #
+  # Notary declared Linux support in 0.10.7 and shipped no Linux artifact with
+  # it, so the release page said it ran there and offered a macOS zip.
+  linux-tarball:
+    name: package · publish (${{ matrix.arch }})
+    needs: macos-app
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-latest, arch: x86_64 }
+          - { runner: ubuntu-24.04-arm, arch: aarch64 }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read Zig version
+        id: zig-version
+        run: echo "version=$(cat .zigversion)" >> "$GITHUB_OUTPUT"
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ steps.zig-version.outputs.version }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install the Native SDK CLI
+        run: npm install -g @native-sdk/cli@0.9.2
+
+      # gtk4 only. Notary draws on a canvas and declares no web use, so the host
+      # compiles with the WebKitGTK stub and links gtk4 and libdl and nothing
+      # else. Installing WebKit here would hide a regression that made it real.
+      - name: Install the Linux host dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-4-dev
+
+      # The retried fetch: `zig build` dies with "unable to discover remote git
+      # server capabilities: ProtocolError" pulling secp256k1, which this repo
+      # pins by git URL rather than by tarball. Seen on three runners now, and
+      # it failed a release build outright over in Plaza. Seconds when it works,
+      # and nothing after it needs the network.
+      - name: Fetch the dependency tree
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if (cd daemon && zig build --fetch); then exit 0; fi
+            echo "fetch attempt $attempt failed" >&2
+            sleep $((attempt * 10))
+          done
+          echo "could not fetch dependencies in five attempts" >&2
+          exit 1
+
+      - name: Build the daemon
+        run: cd daemon && zig build -Doptimize=ReleaseFast
+
+      - name: Package
+        run: gui/scripts/package-linux.sh --signer daemon/zig-out/bin/signer --output dist
+
+      # The installer derives the file name from the release tag and `uname -m`,
+      # so a tarball named for the wrong architecture is a 404 for whoever the
+      # runner was not. Checked rather than trusted.
+      - name: The tarball matches the tag and this architecture
+        run: |
+          want="notary-${GITHUB_REF_NAME#v}-linux-${{ matrix.arch }}.tar.gz"
+          [ -f "dist/$want" ] || { echo "expected dist/$want, got: $(ls dist)" >&2; exit 1; }
+          [ -f "dist/$want.sha256" ] || { echo "no published digest beside $want" >&2; exit 1; }
+          echo "$want"
+
+      - name: Upload into the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          want="notary-${GITHUB_REF_NAME#v}-linux-${{ matrix.arch }}.tar.gz"
+          gh release upload "$GITHUB_REF_NAME" "dist/$want" "dist/$want.sha256" --clobber
+
+  # Lifts the draft, once and only once every artifact is up. Until this runs
+  # the release is invisible, so there is no window in which the page offers a
+  # Linux install that is not there yet.
+  publish:
+    needs: [macos-app, linux-tarball]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release edit "$GITHUB_REF_NAME" --draft=false
+          echo "published $GITHUB_REF_NAME with:"
+          gh release view "$GITHUB_REF_NAME" --json assets --jq '.assets[].name'

--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ release is built by CI from a tagged commit
 trust nothing you didn't run? Read the
 [installer](scripts/install-macos.sh) and [build from source](#build).
 
+**Linux (x86_64 and aarch64):**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/zig-nostr/notary/main/scripts/install-linux.sh | bash
+```
+
+GTK 4 is the one runtime dependency, and the installer says so before it
+downloads anything rather than after the window fails to open. It verifies the
+SHA-256, installs into `~/.local` so nothing needs root and nothing lands
+outside your home directory, puts Notary in the launcher, and starts it. Pass
+`--archive <file>` to install a tarball you already have, which needs no
+network. There is nothing to sign or notarise here, and the trust anchor is the
+same: a build you can reproduce.
+
 ## Two components, one product
 
 Notary is split into two processes on purpose, so the secret key stays isolated
@@ -102,7 +116,9 @@ from the user interface:
   screen. `signer import` reads it from the terminal instead, so it never
   touches the window at all.
 
-Packaged together, one download brings up both as a single macOS `.app`.
+Packaged together, so one download brings up both: a single `.app` on macOS, and
+a tarball carrying the two binaries side by side on Linux. The window finds the
+daemon beside its own executable either way.
 
 ## Build
 

--- a/gui/scripts/package-linux.sh
+++ b/gui/scripts/package-linux.sh
@@ -26,6 +26,10 @@ set -euo pipefail
 say() { printf '\033[1m==>\033[0m %s\n' "$1"; }
 die() { printf '\033[1;31merror:\033[0m %s\n' "$1" >&2; exit 1; }
 
+# The caller's directory, captured BEFORE anything cds, because a relative
+# --output or --signer means "relative to where you typed it" and this script
+# moves to gui/ before using either.
+caller_pwd="$PWD"
 gui_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 outdir="$gui_root/dist"
 signer="${SIGNER_BIN:-$gui_root/../daemon/zig-out/bin/signer}"
@@ -40,12 +44,14 @@ done
 [ "$(uname -s)" = "Linux" ] || die "packaging for Linux needs Linux (the gtk4 link does not cross)."
 command -v native >/dev/null 2>&1 || die "the Native SDK CLI is not on PATH (npm install -g @native-sdk/cli)."
 pkg-config --exists gtk4 2>/dev/null || die "gtk4 development files are missing (apt install libgtk-4-dev)."
-[ -x "$signer" ] || die "no signer daemon at '$signer'. Build it: (cd daemon && zig build -Doptimize=ReleaseFast)"
+# Both made absolute against the caller's directory, or they silently become
+# paths relative to gui/ once this cds. --signer failed loudly, after the build
+# had already run. --output failed SILENTLY: the tarball went to gui/dist while
+# CI looked in dist/, and the only symptom was a later step finding no file.
+case "$signer" in /*) ;; *) signer="$caller_pwd/$signer" ;; esac
+case "$outdir" in /*) ;; *) outdir="$caller_pwd/$outdir" ;; esac
 
-# Resolved BEFORE the cd, or a relative --signer silently becomes a path
-# relative to gui/ and the copy fails after the build has already run. The
-# check above passed for exactly that reason: it ran in the caller's directory.
-signer="$(cd "$(dirname "$signer")" && pwd)/$(basename "$signer")"
+[ -x "$signer" ] || die "no signer daemon at '$signer'. Build it: (cd daemon && zig build -Doptimize=ReleaseFast)"
 
 cd "$gui_root"
 version="$(sed -n 's/^ *\.version = "\(.*\)",$/\1/p' app.zon | head -1)"

--- a/gui/scripts/package-linux.sh
+++ b/gui/scripts/package-linux.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+# Packages Notary for Linux: the window, the daemon it supervises, and the
+# desktop entry that puts it in the launcher, in one tarball.
+#
+#   gui/scripts/package-linux.sh --signer <path> [--output dist]
+#
+# RUN THIS ON LINUX. Not a preference: the toolkit's Linux host links gtk4, and
+# a Mac has no Linux copy of it, so a cross build from macOS compiles every Zig
+# module and then dies at the link.
+#
+# The tarball carries two executables side by side in bin/:
+#
+#   notary   the window
+#   signer   the daemon it spawns, which is where the key lives
+#
+# so one download brings up both. At launch the window finds the `signer`
+# sitting beside it (bundledDaemonPath in src/main.zig), exactly as it finds it
+# in Contents/MacOS on macOS. No SIGNER_BIN, no second download.
+#
+# There is nothing to sign and nothing to notarise here. A Linux tarball is
+# bytes in a directory, and the trust anchor is the same as it is on macOS: a
+# build you can reproduce from source.
+set -euo pipefail
+
+say() { printf '\033[1m==>\033[0m %s\n' "$1"; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$1" >&2; exit 1; }
+
+gui_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+outdir="$gui_root/dist"
+signer="${SIGNER_BIN:-$gui_root/../daemon/zig-out/bin/signer}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --output) outdir="${2:?--output needs a path}"; shift 2 ;;
+    --signer) signer="${2:?--signer needs a path}"; shift 2 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ "$(uname -s)" = "Linux" ] || die "packaging for Linux needs Linux (the gtk4 link does not cross)."
+command -v native >/dev/null 2>&1 || die "the Native SDK CLI is not on PATH (npm install -g @native-sdk/cli)."
+pkg-config --exists gtk4 2>/dev/null || die "gtk4 development files are missing (apt install libgtk-4-dev)."
+[ -x "$signer" ] || die "no signer daemon at '$signer'. Build it: (cd daemon && zig build -Doptimize=ReleaseFast)"
+
+# Resolved BEFORE the cd, or a relative --signer silently becomes a path
+# relative to gui/ and the copy fails after the build has already run. The
+# check above passed for exactly that reason: it ran in the caller's directory.
+signer="$(cd "$(dirname "$signer")" && pwd)/$(basename "$signer")"
+
+cd "$gui_root"
+version="$(sed -n 's/^ *\.version = "\(.*\)",$/\1/p' app.zon | head -1)"
+[ -n "$version" ] || die "could not read the version from app.zon"
+arch="$(uname -m)"
+stage="$outdir/notary-$version-linux-$arch"
+
+# Cleared first: `native package` does not build, it carries whatever is already
+# sitting in zig-out. On a developer's machine that is routinely the last thing
+# they were debugging, and the specific hazard is `-Dautomation=true`, which
+# embeds a server that drives the UI through the real input path in an app that
+# holds somebody's key.
+say "Clearing zig-out so nothing stale or instrumented can be picked up..."
+rm -rf zig-out "$stage" "$outdir/notary-$version-linux-$arch.tar.gz"
+
+say "Building (ReleaseFast, no automation)..."
+native build .
+
+# `grep -c ... || true`, not `grep -q`: under `set -o pipefail` a matching
+# `grep -q` exits early, `strings` dies of SIGPIPE, and the pipeline reports
+# THAT rather than the match, so the check waves an instrumented binary
+# straight through.
+hits="$(strings zig-out/bin/notary | grep -c "native-sdk-automation" || true)"
+[ "$hits" = "0" ] || die "the built binary carries the automation server ($hits marker(s)). Refusing to package it."
+
+say "Packaging..."
+native package --target linux --output "$stage"
+
+say "Injecting the daemon beside the window..."
+cp "$signer" "$stage/bin/signer"
+chmod +x "$stage/bin/"*
+
+# Both assertions, both directions, for the reason the macOS script gives: the
+# window degrades SILENTLY when the daemon is missing beside it, so a release is
+# the wrong place to find that out; and anything else that wandered into
+# zig-out/bin would otherwise ride along.
+for required in notary signer; do
+  [ -x "$stage/bin/$required" ] || die "$required is missing from the package."
+done
+for bin in "$stage/bin/"*; do
+  case "$(basename "$bin")" in
+    notary | signer) ;;
+    *) die "$(basename "$bin") is in the package and is not a binary Notary runs. If it belongs, name it here; if it does not, stop installing it in build.zig." ;;
+  esac
+done
+
+# What the packager wrote, checked rather than assumed.
+desktop="$stage/share/applications/notary.desktop"
+[ -f "$desktop" ] || die "the packager wrote no desktop entry, so Notary would not appear in the launcher."
+
+say "Compressing..."
+tar -C "$outdir" -czf "$outdir/notary-$version-linux-$arch.tar.gz" "notary-$version-linux-$arch"
+( cd "$outdir" && sha256sum "notary-$version-linux-$arch.tar.gz" > "notary-$version-linux-$arch.tar.gz.sha256" )
+
+say "Built $outdir/notary-$version-linux-$arch.tar.gz"
+say "Carries: $(cd "$stage/bin" && echo *)"

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+#
+# Notary - one-line Linux installer.
+#
+#   curl -fsSL https://raw.githubusercontent.com/zig-nostr/notary/main/scripts/install-linux.sh | bash
+#
+# Downloads the latest release for this architecture, verifies its SHA-256,
+# installs into ~/.local (no root, nothing outside your home), puts Notary in
+# the launcher, and starts it.
+#
+# One download brings up both halves: the window, and the `signer` daemon it
+# spawns, which is where your key actually lives. They install side by side
+# because the window finds the daemon beside its own executable.
+#
+# Notary needs GTK 4 at runtime and nothing else: the toolkit's Linux host links
+# gtk4 and libdl, and the WebKit layer is compiled out because Notary draws on a
+# canvas rather than in a browser.
+#
+# Notary is not signed or notarised anywhere, on purpose. It holds your key, so
+# the trust anchor is a build you can reproduce, not a signature you cannot
+# inspect. Read this script, and build from source
+# (https://github.com/zig-nostr/notary#build) if you would rather.
+#
+set -euo pipefail
+
+# Script scope, not `main`'s. The EXIT trap runs after `main` returns, and a
+# `local` is gone by then: under `set -u` the cleanup then dies on its own
+# variable, which is a confusing failure at the end of a successful install.
+workdir=""
+cleanup() { [ -n "$workdir" ] && rm -rf "$workdir"; }
+trap cleanup EXIT
+
+say() { printf '\033[1m==>\033[0m %s\n' "$1"; }
+warn() { printf '\033[1;33mnote:\033[0m %s\n' "$1"; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$1" >&2; exit 1; }
+
+# All work happens inside main(), invoked on the very last line, so bash runs
+# nothing until the whole script has been read. A truncated `curl | bash` (a
+# connection dropped mid-stream) then does nothing at all rather than half of
+# an install.
+main() {
+  local repo="zig-nostr/notary"
+  # A tarball already on disk, instead of the latest published release. For
+  # installing without a network, and for trying a build before it is a release,
+  # which is how this script was first tested at all.
+  local archive=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --archive) archive="${2:?--archive needs a path}"; shift 2 ;;
+      *) die "unknown argument: $1" ;;
+    esac
+  done
+
+  # Only what the chosen path actually uses. `curl` belongs to the download,
+  # and demanding it for `--archive` refuses an offline install for a tool that
+  # install would never call.
+  for tool in sha256sum tar; do
+    command -v "$tool" >/dev/null 2>&1 || die "$tool is required and is not on PATH."
+  done
+
+  # GTK 4 is the one runtime dependency, and finding out it is missing when the
+  # window fails to open is worse than being told now. Checked by loader rather
+  # than by package name, because the package is called libgtk-4-1 on Debian and
+  # Ubuntu, gtk4 on Fedora and Arch, and something else again elsewhere.
+  #
+  # `grep -c ... || true`, NOT `grep -q`. Under `set -o pipefail` a matching
+  # `grep -q` exits at once, `ldconfig` dies of SIGPIPE, and the pipeline reports
+  # THAT rather than the match, so the guard fires on a machine that has GTK. It
+  # fires on one that does not either, because grep exits 1 there, which makes it
+  # a check that can never pass. `package-linux.sh` carries a comment about this
+  # exact trap and I wrote it here anyway.
+  if command -v ldconfig >/dev/null 2>&1; then
+    local gtk
+    gtk="$(ldconfig -p 2>/dev/null | grep -c "libgtk-4\.so" || true)"
+    [ "$gtk" != "0" ] || die "GTK 4 is missing. Install it first: apt install libgtk-4-1, dnf install gtk4, or pacman -S gtk4."
+  fi
+
+  local arch
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64 | aarch64) ;;
+    *) die "no build for $arch. Notary publishes x86_64 and aarch64; build from source for anything else." ;;
+  esac
+
+  local tmp
+  tmp="$(mktemp -d)"
+  workdir="$tmp"
+
+  local tag asset
+  if [ -n "$archive" ]; then
+    [ -f "$archive" ] || die "$archive does not exist."
+    asset="$(basename "$archive")"
+    tag="local"
+    say "Installing from $archive"
+    cp "$archive" "$tmp/$asset"
+    installFrom "$tmp" "$asset" "$tag"
+    return
+  fi
+
+  command -v curl >/dev/null 2>&1 || die "curl is required to download a release (or pass --archive <file>)."
+
+  say "Looking up the latest release..."
+  local api resp code json url
+  api="https://api.github.com/repos/$repo/releases/latest"
+  # Not `curl -f`: -f collapses every HTTP answer into one exit code, so a rate
+  # limit and a network failure become the same unhelpful message. The status
+  # comes back on its own line instead.
+  resp="$(curl -sSL -w '\n%{http_code}' "$api")" || die "could not reach GitHub. Check your connection and try again."
+  code="$(printf '%s' "$resp" | tail -1)"
+  json="$(printf '%s' "$resp" | sed '$d')"
+  case "$code" in
+    200) ;;
+    403) die "GitHub rate-limited this machine. Wait a few minutes, or download the release by hand." ;;
+    404) die "no published release found for $repo." ;;
+    *) die "GitHub answered $code." ;;
+  esac
+
+  tag="$(printf '%s' "$json" | grep -o '"tag_name":[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"([^"]+)".*/\1/' || true)"
+  [ -n "$tag" ] || die "could not read the release tag."
+  asset="notary-${tag#v}-linux-$arch.tar.gz"
+  url="https://github.com/$repo/releases/download/$tag/$asset"
+
+  say "Downloading $asset..."
+  curl -fSL --progress-bar -o "$tmp/$asset" "$url" || die "download failed. There may be no $arch build for $tag."
+
+  # The digest is published beside the tarball rather than read out of the API
+  # body, so a release whose notes were edited cannot change what this compares
+  # against.
+  if curl -fsSL -o "$tmp/$asset.sha256" "$url.sha256" 2>/dev/null; then
+    local want got
+    want="$(awk '{print $1}' "$tmp/$asset.sha256")"
+    got="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+    [ "$want" = "$got" ] || die "the download does not match its published SHA-256. Not installing it."
+    say "SHA-256 verified."
+  else
+    warn "no published SHA-256 for this release, so the download could not be verified."
+  fi
+
+  installFrom "$tmp" "$asset" "$tag"
+}
+
+# Unpacks an archive and installs it. Shared by the download path and by
+# `--archive`, so a local install and a released one are the same install.
+installFrom() {
+  local tmp="$1" asset="$2" tag="$3"
+  say "Unpacking..."
+  tar -C "$tmp" -xzf "$tmp/$asset"
+  local src
+  src="$(find "$tmp" -maxdepth 1 -type d -name 'notary-*-linux-*' | head -1)"
+  [ -n "$src" ] || die "the archive did not contain what was expected."
+  for required in notary signer; do
+    [ -x "$src/bin/$required" ] || die "$required is missing from the archive."
+  done
+
+  # ~/.local, so nothing needs root and nothing lands outside the home
+  # directory. This is where the XDG spec puts a single user's own programs, and
+  # it is what makes uninstalling "delete three paths".
+  local prefix="$HOME/.local"
+  say "Installing into $prefix..."
+  mkdir -p "$prefix/bin" "$prefix/share/applications" "$prefix/share/icons/hicolor"
+
+  # The window finds `signer` as a SIBLING of its own executable, so both go in
+  # one directory or the daemon that holds the key is silently missing.
+  install -m 0755 "$src/bin/notary" "$src/bin/signer" "$prefix/bin/"
+
+  # The icons ship as app-icon.png, which is what the toolkit's packager names
+  # every app's icon. Installed under that name they would collide with every
+  # other app built the same way, so they are renamed on the way in and the
+  # desktop entry is pointed at the new name below.
+  local size_dir
+  while IFS= read -r size_dir; do
+    local size
+    size="$(basename "$(dirname "$size_dir")")"
+    mkdir -p "$prefix/share/icons/hicolor/$size/apps"
+    install -m 0644 "$size_dir/app-icon.png" "$prefix/share/icons/hicolor/$size/apps/notary.png"
+  done < <(find "$src/share/icons/hicolor" -type d -name apps 2>/dev/null)
+
+  # Exec must be absolute. The entry ships with a bare executable name, which
+  # only resolves if ~/.local/bin is on PATH, and the desktop environment that
+  # launches a link handler does not necessarily have the PATH a shell does.
+  # The packager writes the executable QUOTED (`Exec="notary"`), so the
+  # replacement has to swallow the quotes rather than the name alone: matching
+  # `.*notary` leaves the closing quote stranded and the entry is malformed.
+  # The result is quoted too, because a home directory may contain a space.
+  sed -E -e "s|^Exec=\"?[^\" ]*\"?|Exec=\"$prefix/bin/notary\"|" \
+         -e "s|^Icon=app-icon$|Icon=notary|" \
+      "$src/share/applications/notary.desktop" > "$prefix/share/applications/notary.desktop"
+  chmod 0644 "$prefix/share/applications/notary.desktop"
+
+  # Best effort: a desktop environment that indexes on its own will find these
+  # anyway, and a machine with neither tool is not broken.
+  command -v update-desktop-database >/dev/null 2>&1 &&
+    update-desktop-database "$prefix/share/applications" 2>/dev/null || true
+  command -v gtk-update-icon-cache >/dev/null 2>&1 &&
+    gtk-update-icon-cache -f -t "$prefix/share/icons/hicolor" 2>/dev/null || true
+  case ":$PATH:" in
+    *":$prefix/bin:"*) ;;
+    *) warn "$prefix/bin is not on your PATH. Add it to run 'notary' from a terminal; the desktop entry works either way." ;;
+  esac
+
+  say "Installed Notary $tag."
+  say "Starting it..."
+  "$prefix/bin/notary" >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+}
+
+main "$@"


### PR DESCRIPTION
0.10.7 declared Linux support and shipped no Linux artifact with it. The release page says it runs there and offers a macOS zip, which is the gap this closes.

**The tarball** carries the window and the daemon side by side in `bin/`, which is the same arrangement `Contents/MacOS` has and for the same reason: the window finds `signer` beside its own executable, so one download brings up both and the key still only ever lives in the daemon child.

**`gui/scripts/package-linux.sh`** mirrors the macOS script's guarantees rather than inventing new ones. It clears `zig-out` first, because `native package` does not build and would otherwise carry whatever was last left there, and the specific hazard is `-Dautomation=true`, which embeds a server that drives the UI through the real input path in an app holding somebody's key. It then refuses a binary carrying the automation marker, and asserts both binaries are present and that nothing else rode along.

**`scripts/install-linux.sh`** is Plaza's, which has been driven end to end on a real desktop, minus the URL-scheme handling Notary does not declare.

**The release stops publishing before it is finished.** The Linux jobs take minutes longer than the macOS one, so a release created up front is one whose Linux installer 404s for exactly that long. Plaza's v0.18.0 was live with macOS only for eight minutes this morning, which is how this was noticed. `macos-app` creates a **draft** now, and a `publish` job lifts it once every artifact is up.

**Verified**, not assumed: packaged on Linux in a container, then installed the tarball on a real Ubuntu desktop. Both binaries land in `~/.local/bin`, the desktop entry gets an absolute quoted `Exec` and the renamed icon, and the window comes up. Two things I found doing it rather than by reading: `--signer` had to be resolved to an absolute path before the script's `cd`, or a relative one silently broke after the build had already run; and the naive port of Plaza's installer left a `x-scheme-handler/notary` check for a scheme Notary does not declare.

**Not in here.** No version bump, so merging this publishes nothing. Cutting 0.10.8 is the next PR.