### PR TITLE
Linux release binaries are built for a baseline CPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           exit 1
 
       - name: Build the daemon
-        run: cd daemon && zig build -Doptimize=ReleaseFast
+        run: cd daemon && zig build -Doptimize=ReleaseFast -Dcpu=baseline
 
       - name: Package
         run: gui/scripts/package-linux.sh --signer daemon/zig-out/bin/signer --output dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           exit 1
 
       - name: Build the daemon
-        run: cd daemon && zig build -Doptimize=ReleaseFast
+        run: cd daemon && zig build -Doptimize=ReleaseFast -Dcpu=baseline
 
       - name: Package
         run: gui/scripts/package-linux.sh --signer daemon/zig-out/bin/signer --output dist

--- a/gui/scripts/package-linux.sh
+++ b/gui/scripts/package-linux.sh
@@ -67,8 +67,14 @@ stage="$outdir/notary-$version-linux-$arch"
 say "Clearing zig-out so nothing stale or instrumented can be picked up..."
 rm -rf zig-out "$stage" "$outdir/notary-$version-linux-$arch.tar.gz"
 
-say "Building (ReleaseFast, no automation)..."
-native build .
+# `-Dcpu=baseline`, and this is not optional for a release. Zig defaults to the
+# BUILD machine's CPU, so a binary built on a CI runner carries whatever that
+# runner's processor happened to support. Plaza's v0.18.0 aarch64 tarball was
+# built that way and died with SIGILL, immediately and with no output, on Apple
+# Silicon under UTM. Every Linux VM on an Apple machine is that target, and the
+# daemon in this tarball holds somebody's key, so it had better start.
+say "Building (ReleaseFast, baseline CPU, no automation)..."
+native build . -Dcpu=baseline
 
 # `grep -c ... || true`, not `grep -q`: under `set -o pipefail` a matching
 # `grep -q` exits early, `strings` dies of SIGPIPE, and the pipeline reports


### PR DESCRIPTION
The defect Plaza just shipped and pulled, fixed here before the first Linux artifact rather than after.

Zig targets the **build machine's** CPU by default, so a binary built on `ubuntu-24.04-arm` carries whatever that Neoverse-class runner supported. Plaza's v0.18.0 aarch64 tarball did exactly that and died with `Illegal instruction`, exit 132, no output, on Apple Silicon under UTM. Those assets have been deleted from that release.

Notary has not published a Linux artifact yet, so this lands first. Both binaries in the tarball are covered: the window through `gui/scripts/package-linux.sh`, and the daemon through the two workflows that build it. The daemon matters more, because it is where the key lives and a keyholder that will not start is a keyholder you cannot sign with.

**macOS packaging is deliberately untouched.** It is the same class of hazard, a runner moving to newer Apple Silicon would produce binaries that fault on older Macs, but it has never misbehaved and changing it belongs in its own decision rather than riding along with a Linux fix. Worth deciding separately.

**Verified** in Plaza, with the artifact that matters: the aarch64 tarball built by CI on the ARM runner, installed on an Apple Silicon VM, running. A locally built binary proves nothing here, since my machine is the same architecture as the VM.