### PR TITLE
Notary is 0.10.8

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,4 +1,16 @@
-**Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**.
+**Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**, and Linux (x86_64 and aarch64).
+
+### What's new in v0.10.8
+
+**There is a Linux download now.** 0.10.7 said Notary ran on Linux and offered only a macOS app, which was true and useless. This release carries a tarball for x86_64 and aarch64:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/zig-nostr/notary/main/scripts/install-linux.sh | bash
+```
+
+GTK 4 is the one runtime dependency, and the installer says so before it downloads anything rather than after the window fails to open. It verifies the SHA-256, installs into `~/.local` so nothing needs root and nothing lands outside your home directory, puts Notary in the launcher, and starts it. Pass `--archive <file>` to install a tarball you already have.
+
+One download still brings up both halves: the window, and the `signer` daemon it spawns, which is where your key actually lives. They install side by side because the window finds the daemon beside its own executable, exactly as it does inside the `.app` on macOS.
 
 ### What's new in v0.10.7
 

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.10.7",
+    .version = "0.10.8",
     .icons = .{"assets/icon.png"},
     .platforms = .{ "macos", "linux" },
     .permissions = .{ "view", "command", "clipboard" },


### PR DESCRIPTION
Cuts the release that actually carries a Linux download.

0.10.7 declared Linux support and shipped only a macOS app. True and useless: the release page said it ran there and offered nothing to run.

**What is in it.** A tarball for x86_64 and aarch64, behind the same kind of one-line installer macOS has. One download still brings up both halves, because the window finds `signer` beside its own executable exactly as it does inside `Contents/MacOS`.

**Built for a baseline CPU**, so it starts on a machine that is not the one that compiled it. Plaza learned that the hard way this afternoon: its v0.18.0 aarch64 tarball died with `Illegal instruction` on Apple Silicon and those assets were deleted. Notary gets the fix before its first Linux artifact rather than after.

**The release will not publish half-finished.** `macos-app` creates a draft, the Linux jobs upload into it, and a `publish` job lifts the draft once every asset is up. Plaza's v0.18.0 was live with macOS only for eight minutes because it published up front, which is how this was noticed.

**On the notes.** They describe the Linux download and nothing else. The baseline-CPU change fixed a defect no Notary user could ever have hit, since no Linux artifact was published before this one, and telling people about a bug they never had is noise.

**Checked** locally first: `zig build`, `zig build test`, `zig fmt --check .` in `daemon`; `native check`, `native test`, `zig fmt --check src` in `gui`; and the release-notes gate against the new version. The window was also driven on a real Ubuntu desktop, where it renders its first-run screen correctly.