### PR TITLE
Notary pins nostr 0.13.1

### DIFF
--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.12.2.tar.gz",
-            .hash = "nostr-0.12.2-CMyPzbCNCADKsHa5sjfrIuubspCP-af9WeBAply59UIO",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.13.1.tar.gz",
+            .hash = "nostr-0.13.1-CMyPzfWDCAC71_28V6l6QF7nZVbL3zDUbOaiGHF_F3Yr",
         },
     },
     .paths = .{

--- a/daemon/src/approval_http.zig
+++ b/daemon/src/approval_http.zig
@@ -2359,8 +2359,15 @@ test "Allow once actually lets one request through, and only one" {
 
 test "a one-shot answer covers only the question it answered" {
     var broker: Broker = .{};
-    const plaza = nostr.signer_ipc.clientId("plaza");
-    const other = nostr.signer_ipc.clientId("something-else");
+    // Two distinct client ids. `signer_ipc.clientId` built these until nostr
+    // 0.13.0 removed it along with the header a local client used to introduce
+    // itself with; production names the one caller it has with the
+    // `local_client` literal above, so a test that needs two makes its own.
+    // Only their distinctness matters here.
+    const plaza: [32]u8 = local_client;
+    var other: [32]u8 = local_client;
+
+    other[31] +%= 1;
 
     var info = Pending{ .local = true, .kind = 1, .method_id = .sign_event, .client_id = plaza };
     try testing.expectEqual(Broker.Knock.filed, broker.knock(info));


### PR DESCRIPTION
Two versions forward, not one. The daemon was still on 0.12.2 while Plaza was on 0.13.0, so this catches up and takes the tarball fetch change at the same time.

**Why it matters here.** 0.13.1 fetches its own dependencies as HTTPS tarballs rather than over the git protocol. That is where every `ProtocolError` in this repo's CI came from: the failure happens while resolving the *library's* dependency tree, not this one's, so nothing done here could have fixed it.

**One dead test, from the 0.13.0 removal.** `signer_ipc.clientId` went away along with the header a local client used to introduce itself with. Production had already moved to its own `local_client` literal; one test had not. It only ever needed two client ids that differ, so it derives them from that literal.

Worth noting how that survived: plain `zig build` passes with a broken test block, because Zig never analyses it in a non-test build. Only the test step catches this, which is why a stale pin can look fine right up until you move it.

Verified from a **cold cache**, with `.zig-cache` deleted so the whole tree was re-fetched.

**The retried `zig build --fetch` steps stay**, for the same reason as Plaza's bump: taking out the safety net in the same commit that removes its reason means finding out the hard way if the reason is not fully gone. They come out in their own PR.