### PR TITLE
Drop the fetch retries; their cause is gone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,20 +148,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-4-dev
 
-      # The retried fetch: `zig build` dies with "unable to discover remote git
-      # server capabilities: ProtocolError" pulling secp256k1, which this repo
-      # pins by git URL rather than by tarball. Seen on three runners now, and
-      # it failed a release build outright over in Plaza.
-      - name: Fetch the dependency tree
-        run: |
-          for attempt in 1 2 3 4 5; do
-            if (cd daemon && zig build --fetch); then exit 0; fi
-            echo "fetch attempt $attempt failed" >&2
-            sleep $((attempt * 10))
-          done
-          echo "could not fetch dependencies in five attempts" >&2
-          exit 1
-
       - name: Build the daemon
         run: cd daemon && zig build -Doptimize=ReleaseFast -Dcpu=baseline
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,21 +135,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-4-dev
 
-      # The retried fetch: `zig build` dies with "unable to discover remote git
-      # server capabilities: ProtocolError" pulling secp256k1, which this repo
-      # pins by git URL rather than by tarball. Seen on three runners now, and
-      # it failed a release build outright over in Plaza. Seconds when it works,
-      # and nothing after it needs the network.
-      - name: Fetch the dependency tree
-        run: |
-          for attempt in 1 2 3 4 5; do
-            if (cd daemon && zig build --fetch); then exit 0; fi
-            echo "fetch attempt $attempt failed" >&2
-            sleep $((attempt * 10))
-          done
-          echo "could not fetch dependencies in five attempts" >&2
-          exit 1
-
       - name: Build the daemon
         run: cd daemon && zig build -Doptimize=ReleaseFast -Dcpu=baseline
 


### PR DESCRIPTION
Two retry loops, added this afternoon when `zig build` kept dying with `unable to discover remote git server capabilities: ProtocolError` pulling `secp256k1`. They treated the symptom.

nostr 0.13.1 fetches its own dependencies as HTTPS tarballs rather than over the git protocol, and this repo pins it as of #93, so the git path that kept failing is not walked at all any more.

**A pure removal.** 29 lines out, nothing added. No source touched, no version moved, no binary changed, and no release needed: these live only in workflow files.

**Its own PR on purpose**, so this PR's CI is the test. Every job now fetches exactly once, on both architectures and on macOS, with nothing papering over a failure. If the tarball change did not fully fix it, this is where it shows, and this is a one-click revert.