### PR TITLE
Say which systems the Linux build actually runs on

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ trust nothing you didn't run? Read the
 curl -fsSL https://raw.githubusercontent.com/zig-nostr/notary/main/scripts/install-linux.sh | bash
 ```
 
+A reasonably recent distribution: **Ubuntu 23.10+, Debian 13+, or Fedora 39+**.
+The toolkit's Linux host declares a GTK floor of 4.10 and the binaries are built
+against glibc 2.38, which land on the same generation, so Ubuntu 22.04 and
+Debian 12 are too old. The installer checks that before downloading anything,
+because "it will not start" is not something to discover after trusting an app
+with your key.
+
 GTK 4 is the one runtime dependency, and the installer says so before it
 downloads anything rather than after the window fails to open. It verifies the
 SHA-256, installs into `~/.local` so nothing needs root and nothing lands

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -16,6 +16,13 @@
 # gtk4 and libdl, and the WebKit layer is compiled out because Notary draws on a
 # canvas rather than in a browser.
 #
+# It does need a RECENT distribution, though. The toolkit's Linux host declares a
+# GTK floor of 4.10 (its own source: "This host's GTK floor is 4.10"), and the
+# release binaries are built on Ubuntu 24.04, so they want glibc 2.38 or newer.
+# Both land on the same generation: Ubuntu 23.10+, Debian 13+, Fedora 39+.
+# Ubuntu 22.04 and Debian 12 cannot run this, and are checked for below rather
+# than left to fail with a loader error after a successful-looking install.
+#
 # Notary is not signed or notarised anywhere, on purpose. It holds your key, so
 # the trust anchor is a build you can reproduce, not a signature you cannot
 # inspect. Read this script, and build from source
@@ -73,6 +80,30 @@ main() {
     local gtk
     gtk="$(ldconfig -p 2>/dev/null | grep -c "libgtk-4\.so" || true)"
     [ "$gtk" != "0" ] || die "GTK 4 is missing. Install it first: apt install libgtk-4-1, dnf install gtk4, or pacman -S gtk4."
+  fi
+
+  # The distribution floor, checked BEFORE downloading anything or writing files.
+  # Without this an Ubuntu 22.04 user gets a clean install, a verified digest, a
+  # cheerful "Installed Notary", and then `version GLIBC_2.38 not found` the
+  # first time they open it. For an app that holds a key, "it will not start"
+  # should never be something you discover after trusting it with one.
+  #
+  # glibc is the proxy for both floors. The real constraints are glibc 2.38 (the
+  # binaries are built on Ubuntu 24.04) and GTK 4.10 (the toolkit's own declared
+  # floor), and every distribution that has one has the other, so one check
+  # answers both and needs no -dev package to run.
+  local glibc
+  glibc="$(ldd --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+$' || true)"
+  if [ -n "$glibc" ]; then
+    local major minor
+    major="${glibc%%.*}"
+    minor="${glibc##*.}"
+    if [ "$major" -lt 2 ] || { [ "$major" -eq 2 ] && [ "$minor" -lt 38 ]; }; then
+      die "this build needs glibc 2.38 or newer and GTK 4.10 or newer; you have glibc $glibc.
+       That means Ubuntu 23.10+, Debian 13+, or Fedora 39+. Ubuntu 22.04 and
+       Debian 12 are too old for it. Building from source on your own system
+       works if its GTK is 4.10 or newer: https://github.com/zig-nostr/notary#build"
+    fi
   fi
 
   local arch


### PR DESCRIPTION
Same floor Plaza just documented, and the same silence.

The release binaries need **glibc 2.38** and the toolkit's Linux host declares a **GTK floor of 4.10**, stated in its own source: *"This host's GTK floor is 4.10 (the GtkFileDialog family below)"*. Ubuntu 22.04 and Debian 12 cannot run them. I confirmed it by running the published Plaza tarball, which is built the same way, in each: 22.04 stops at `GLIBC_2.36 not found`, Debian 12 at `GLIBC_2.38 not found`.

The installer's header claimed GTK 4 was needed "and nothing else". So a 22.04 user would get a clean install, a verified SHA-256, a cheerful "Installed Notary", and then a loader error the first time they opened it.

That matters more here than in Plaza. **For an app that holds a key, "it will not start" is not something to discover after trusting it with one.** So the floor is checked before anything is downloaded or written, and the refusal names distributions rather than a version number nobody can act on.

glibc is the proxy for both constraints, since every distribution recent enough for one has the other, and reading it needs no `-dev` package. Probed in containers: refuses on Ubuntu 22.04 (2.35) and Debian 12 (2.36), passes on 24.04 (2.39) and falls through to the normal path.

**Not widening it**: compiling the toolkit's `gtk_host.c` against GTK 4.6 fails on `GtkFileDialog` and `GtkAlertDialog`, 4.10 types used without version guards. That is upstream's floor, and working around it would mean a third fork patch.