### PR TITLE
The library says when a relay has gone quiet

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 **Notary**: a native NIP-46 remote signer for Nostr. macOS (Apple Silicon), **ad-hoc signed (not notarized)**, and Linux (x86_64 and aarch64).
 
+### What's new in v0.10.9
+
+**Housekeeping, and one leak.** When a relay connection has gone quiet and what to do about it now comes from the `nostr` library rather than a copy kept here: the same three numbers and the same decision existed in Notary and in Plaza, written down in neither, so a correction to one would silently not reach the other.
+
+The library release that carries it also fixes a leak on Notary's own reconnect path: freeing a relay connection freed everything except the connection object itself, so every reconnect left one behind for the life of the daemon.
+
+Nothing you can see changed. Everything in v0.10.8 below is in this release too.
+
 ### What's new in v0.10.8
 
 **There is a Linux download now.** 0.10.7 said Notary ran on Linux and offered only a macOS app, which was true and useless. This release carries a tarball for x86_64 and aarch64:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ While pre-1.0, minor versions add capability and patch versions are fixes.
 
 ## [Unreleased]
 
+## [0.10.9] - 2026-09-07
+
+### Changed
+
+- When a relay connection has gone quiet, and what to do about it, comes from
+  the `nostr` library (`nostr.liveness`) rather than from a copy kept here. The
+  same three numbers and the same decision existed in this daemon and in the
+  client built on the same library, and were written down in neither, so a
+  correction to one would silently not reach the other. The table of
+  connections and the thread that ticks stay here: what "give up" means differs
+  between a signer and a client.
+
+- Pins `nostr` 0.14.1, which fixes a leak on this daemon's own reconnect path:
+  `Relay.deinit` freed everything a dial allocated except the `Relay` itself, so
+  every reconnect leaked one.
+
 ## [0.10.1] - 2026-08-28
 
 ### Changed

--- a/daemon/build.zig.zon
+++ b/daemon/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .nostr = .{
-            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.13.1.tar.gz",
-            .hash = "nostr-0.13.1-CMyPzfWDCAC71_28V6l6QF7nZVbL3zDUbOaiGHF_F3Yr",
+            .url = "https://github.com/zig-nostr/nostr/archive/refs/tags/v0.14.1.tar.gz",
+            .hash = "nostr-0.14.1-CMyPzSLDCABUv81rExu84jizBXMixUg9gKteve9P_t0h",
         },
     },
     .paths = .{

--- a/daemon/src/relay_keeper.zig
+++ b/daemon/src/relay_keeper.zig
@@ -13,10 +13,10 @@
 //! waiting. So one more thread watches all of them. It sends the keepalive, and
 //! it is the one still able to act when no answer comes.
 //!
-//! The numbers are Amethyst's, from their survey of 122 relays: idle timeouts
-//! cluster around 60, 120, 240, 300 and 600 seconds, and a ping only reliably
-//! holds a connection open when its interval is at most about half the shortest
-//! tier. Ninety seconds is three missed answers.
+//! When it pings and when it gives up is `nostr.liveness`, which is where those
+//! numbers belong: they were the same numbers here and in the client built on
+//! this library, written down in neither. They are Amethyst's, from their
+//! survey of 122 relays.
 //!
 //! **Answering the relay's pings is not a substitute for sending our own.** A
 //! relay's idle timer counts what it RECEIVES from us, so the pong the library
@@ -33,36 +33,6 @@
 
 const std = @import("std");
 const nostr = @import("nostr");
-
-/// Silence after which the keeper asks the relay whether it is still there.
-pub const ping_after_ms: i64 = 30_000;
-/// Silence after which it stops asking and cuts the connection.
-pub const dead_after_ms: i64 = 90_000;
-/// How often the keeper looks. Short enough that ninety seconds means ninety,
-/// long enough to cost nothing.
-pub const tick_ms: u64 = 5_000;
-
-/// What to do about one connection, given how long it has been silent and how
-/// long since it was last pinged. Both null mean "no measurement".
-///
-/// A pure function, so the policy can be asserted without a socket, a thread or
-/// a clock. Everything interesting about this file is in here.
-pub const Action = enum { leave_it, ping, give_up };
-
-pub fn action(idle_ms: ?i64, since_ping_ms: ?i64) Action {
-    // Nothing has ever arrived on this connection. That is the window between
-    // the handshake and the relay's first word, not a stall, and reading a
-    // missing measurement as an infinite one would cut off every relay that
-    // took a moment to answer.
-    const idle = idle_ms orelse return .leave_it;
-    if (idle >= dead_after_ms) return .give_up;
-    if (idle < ping_after_ms) return .leave_it;
-    // Silent past the interval. Ping, but only once per interval: at a five
-    // second tick a socket that has stopped answering would otherwise collect a
-    // dozen more pings on its way to being declared dead.
-    const since = since_ping_ms orelse return .ping;
-    return if (since >= ping_after_ms) .ping else .leave_it;
-}
 
 /// The live connections, one slot per relay.
 ///
@@ -122,7 +92,7 @@ pub fn run(gpa: std.mem.Allocator, table: *Table, quiet_status: u8, dead_status:
     const io = threaded.io();
 
     while (true) {
-        io.sleep(std.Io.Duration.fromMilliseconds(tick_ms), .awake) catch {};
+        io.sleep(std.Io.Duration.fromMilliseconds(nostr.liveness.tick_ms), .awake) catch {};
         const now = std.Io.Timestamp.now(io, .awake).toMilliseconds();
         for (0..table.live.len) |i| {
             table.acquire();
@@ -130,7 +100,7 @@ pub fn run(gpa: std.mem.Allocator, table: *Table, quiet_status: u8, dead_status:
             const relay = table.live[i] orelse continue;
             const idle = relay.idleMs(io);
             const since: ?i64 = if (table.pinged_ms[i] == 0) null else now - table.pinged_ms[i];
-            switch (action(idle, since)) {
+            switch (nostr.liveness.action(idle, since)) {
                 .leave_it => {},
                 .ping => {
                     // A failed write is not a verdict on its own; the silence
@@ -152,43 +122,6 @@ pub fn run(gpa: std.mem.Allocator, table: *Table, quiet_status: u8, dead_status:
             }
         }
     }
-}
-
-test "a connection that has never spoken is not a stalled one" {
-    // The window between the handshake and the relay's first word. Reading a
-    // missing measurement as an infinite one would cut off every relay that
-    // took a moment to answer, which on a slow network is all of them.
-    try std.testing.expectEqual(Action.leave_it, action(null, null));
-    try std.testing.expectEqual(Action.leave_it, action(null, 999_999));
-}
-
-test "a talking relay is left alone" {
-    try std.testing.expectEqual(Action.leave_it, action(0, null));
-    try std.testing.expectEqual(Action.leave_it, action(ping_after_ms - 1, null));
-}
-
-test "a relay that has gone quiet is asked whether it is still there" {
-    try std.testing.expectEqual(Action.ping, action(ping_after_ms, null));
-}
-
-test "a quiet relay is asked once per interval, not once per look" {
-    const idle = ping_after_ms + 5_000;
-    try std.testing.expectEqual(Action.leave_it, action(idle, 5_000));
-    try std.testing.expectEqual(Action.ping, action(idle, ping_after_ms));
-}
-
-test "a relay that answers none of three pings is given up on" {
-    try std.testing.expectEqual(Action.give_up, action(dead_after_ms, 0));
-    // The deadline wins over the ping interval: a socket this far gone is not
-    // asked again, it is closed.
-    try std.testing.expectEqual(Action.give_up, action(dead_after_ms + 60_000, dead_after_ms));
-}
-
-test "the deadline is a multiple of the interval, so silence is answered before it is fatal" {
-    // Not decoration. If the deadline were under the interval the keeper would
-    // declare a relay dead without ever having asked it anything, and every
-    // quiet connection would be recycled on a timer.
-    try std.testing.expect(dead_after_ms >= ping_after_ms * 2);
 }
 
 test "a slot past the end of the table is ignored rather than trusted" {

--- a/gui/app.zon
+++ b/gui/app.zon
@@ -3,7 +3,7 @@
     .name = "notary",
     .display_name = "Notary",
     .description = "Notary: approve or deny Nostr signing requests; your key stays in the signer daemon.",
-    .version = "0.10.8",
+    .version = "0.10.9",
     .icons = .{"assets/icon.png"},
     .platforms = .{ "macos", "linux" },
     .permissions = .{ "view", "command", "clipboard" },


### PR DESCRIPTION
The ping interval, the deadline and the decision between them existed twice: in this daemon and in the client built on the same library, the same three numbers and the same function, written down in neither. A correction to one would silently not reach the other.

They are in `nostr.liveness` now, tested there. What stays here is what this daemon does with the decision: the table of live connections, the thread that ticks, and the statuses it publishes. What "give up" means is not the same for a signer as for a client, and that difference is the part worth keeping local.

Pins `nostr` 0.14.1 along the way, which fixes a leak on this daemon's own reconnect path: `Relay.deinit` freed everything a dial allocated except the `Relay` itself, so every reconnect leaked one for the life of the process.

73 tests to 67: the six that assert the policy moved with it.

Notary is 0.10.9.
